### PR TITLE
Peanut/credit keys swap

### DIFF
--- a/src/credit/error.rs
+++ b/src/credit/error.rs
@@ -3,7 +3,9 @@
 use thiserror::Error;
 // ----- local modules
 // ----- local imports
-use super::{keys, quotes};
+use super::quotes;
+use crate::credit::keys::Error as CreditKeysError;
+use crate::keys::Error as KeysError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
@@ -11,7 +13,9 @@ pub enum Error {
     #[error("Quote error {0}")]
     Quote(#[from] quotes::Error),
     #[error("Key error {0}")]
-    Key(#[from] keys::Error),
+    CreditKeys(#[from] CreditKeysError),
+    #[error("Keys error {0}")]
+    Keys(#[from] KeysError),
 
     #[error("unknown quote id {0}")]
     UnknownQuoteID(uuid::Uuid),

--- a/src/credit/keys.rs
+++ b/src/credit/keys.rs
@@ -709,14 +709,12 @@ mod tests {
         maturing_repo
             .expect_info()
             .with(eq(maturity_kid))
-            .returning(move |_| {
-                Ok(None)
-            });
+            .returning(move |_| Ok(None));
         let debit_kid = testkeys::generate_random_keysetid();
         debit_repo
             .expect_replacing_id()
             .with(eq(in_kid))
-            .returning(move |_| {Ok(Some(debit_kid))});
+            .returning(move |_| Ok(Some(debit_kid)));
 
         let swap_repo = SwapRepository {
             endorsed_keys: quote_repo,

--- a/src/credit/mod.rs
+++ b/src/credit/mod.rs
@@ -10,6 +10,7 @@ pub mod persistence;
 pub mod quotes;
 pub mod web;
 // ----- local imports
+use crate::keys::{sign_with_keys, Result as KeyResult};
 use crate::utils;
 use error::{Error, Result};
 use keys::generate_keyset_id_from_bill;
@@ -97,10 +98,10 @@ impl Controller {
 
         let signatures = selected_blinds
             .iter()
-            .map(|blind| keys::sign_with_keys(&keyset, blind))
+            .map(|blind| sign_with_keys(&keyset, blind))
             .collect::<Vec<_>>()
             .into_iter()
-            .collect::<keys::Result<Vec<_>>>()?;
+            .collect::<KeyResult<Vec<_>>>()?;
         let expiration = ttl.unwrap_or(utils::calculate_default_expiration_date_for_quote(now));
         quote.accept(signatures, expiration)?;
         self.quotes.update_if_pending(quote);

--- a/src/credit/persistence.rs
+++ b/src/credit/persistence.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 // ----- extra library imports
+use anyhow::Result as AnyResult;
 use cdk::nuts::nut02 as cdk02;
 use uuid::Uuid;
 // ----- local modules
@@ -74,14 +75,10 @@ pub struct InMemoryKeysRepository {
 }
 
 impl keys::CreateRepository for InMemoryKeysRepository {
-    fn info(&self, id: &KeysetID) -> Option<cdk::mint::MintKeySetInfo> {
-        self.keys.read().unwrap().get(id).map(|k| k.0.clone())
+    fn info(&self, id: &KeysetID) -> AnyResult<Option<cdk::mint::MintKeySetInfo>> {
+        Ok(self.keys.read().unwrap().get(id).map(|k| k.0.clone()))
     }
-    fn store(
-        &self,
-        keyset: cdk02::MintKeySet,
-        info: cdk::mint::MintKeySetInfo,
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn store(&self, keyset: cdk02::MintKeySet, info: cdk::mint::MintKeySetInfo) -> AnyResult<()> {
         self.keys
             .write()
             .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-
 use wildcat::credit;
 
 #[tokio::main]
@@ -11,7 +10,12 @@ async fn main() {
     let quote_repo = credit::persistence::InMemoryQuoteRepository::default();
     let quote_keys_repo = credit::persistence::InMemoryKeysRepository::default();
     let maturing_keys_repo = credit::persistence::InMemoryKeysRepository::default();
-    let ctrl = credit::Controller::new(&[0u8; 32], quote_repo.clone(), quote_keys_repo, maturing_keys_repo);
+    let ctrl = credit::Controller::new(
+        &[0u8; 32],
+        quote_repo.clone(),
+        quote_keys_repo,
+        maturing_keys_repo,
+    );
 
     let credit_route = credit::web::routes(ctrl.clone());
     let admin_route = credit::admin::routes(ctrl.clone());

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -47,7 +47,7 @@ pub trait KeysRepository {
     fn load(&self, id: KeysetID) -> AnyResult<Option<MintKeySet>>;
     fn info(&self, id: KeysetID) -> AnyResult<Option<MintKeySetInfo>>;
     // in case keyset id is inactive, returns the proper replacement for it
-    fn replacing_keysetid(&self, id: KeysetID) -> AnyResult<Option<KeysetID>>;
+    fn replacing_id(&self, id: KeysetID) -> AnyResult<Option<KeysetID>>;
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -132,7 +132,7 @@ where
         for i in inputs {
             let o = self
                 .keys
-                .replacing_keysetid(i.keyset_id.into())
+                .replacing_id(i.keyset_id.into())
                 .map_err(Error::KeysetRepository)?
                 .ok_or(Error::UnknownKeyset(i.keyset_id.into()))?;
             ids.push(o);
@@ -306,9 +306,14 @@ mod tests {
         keyrepo
             .expect_load()
             .with(eq(kid))
-            .returning(move|_| Ok(Some(ex_keys.clone())));
-        keyrepo.expect_replacing_keysetid().returning(move|_| Ok(Some(kid)));
-        proofrepo.expect_spend().with(eq(inputs.clone())).returning(|_| Ok(()));
+            .returning(move |_| Ok(Some(ex_keys.clone())));
+        keyrepo
+            .expect_replacing_id()
+            .returning(move |_| Ok(Some(kid)));
+        proofrepo
+            .expect_spend()
+            .with(eq(inputs.clone()))
+            .returning(|_| Ok(()));
         let swaps = Service {
             keys: keyrepo,
             proofs: proofrepo,
@@ -339,9 +344,14 @@ mod tests {
         keyrepo
             .expect_load()
             .with(eq(kid))
-            .returning(move|_| Ok(Some(ex_keys.clone())));
-        keyrepo.expect_replacing_keysetid().returning(move|_| Ok(Some(kid)));
-        proofrepo.expect_spend().with(eq(inputs.clone())).returning(|_| Ok(()));
+            .returning(move |_| Ok(Some(ex_keys.clone())));
+        keyrepo
+            .expect_replacing_id()
+            .returning(move |_| Ok(Some(kid)));
+        proofrepo
+            .expect_spend()
+            .with(eq(inputs.clone()))
+            .returning(|_| Ok(()));
         let swaps = Service {
             keys: keyrepo,
             proofs: proofrepo,

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -102,7 +102,7 @@ where
         outputs: &[BlindedMessage],
     ) -> Result<Vec<BlindSignature>> {
         if inputs.is_empty() {
-            return Err(Error::ZeroAmount)
+            return Err(Error::ZeroAmount);
         }
         // first step: zero-cost verifications
         let no_zero_amount = outputs.iter().all(|output| output.amount != Amount::ZERO);
@@ -247,7 +247,7 @@ mod tests {
         keyrepo
             .expect_load()
             .with(eq(kid))
-            .returning(move|_| Ok(Some(keys.clone())));
+            .returning(move |_| Ok(Some(keys.clone())));
         let swaps = Service {
             keys: keyrepo,
             proofs: proofrepo,
@@ -276,7 +276,7 @@ mod tests {
         keyrepo
             .expect_load()
             .with(eq(kid))
-            .returning(move|_| Ok(Some(keys.clone())));
+            .returning(move |_| Ok(Some(keys.clone())));
         let swaps = Service {
             keys: keyrepo,
             proofs: proofrepo,
@@ -292,10 +292,11 @@ mod tests {
     fn test_swap_split_tokens_ok() {
         let keys = keys::generate_keyset();
         let inputs = utils::generate_proofs(&keys, vec![Amount::from(8)].as_slice());
-        let outputs: Vec<_> = utils::generate_blinds(&keys, vec![Amount::from(4), Amount::from(4)].as_slice())
-            .into_iter()
-            .map(|a| a.0)
-            .collect();
+        let outputs: Vec<_> =
+            utils::generate_blinds(&keys, vec![Amount::from(4), Amount::from(4)].as_slice())
+                .into_iter()
+                .map(|a| a.0)
+                .collect();
         let mut keyrepo = MockKeysRepository::new();
         let mut proofrepo = MockProofRepository::new();
         proofrepo
@@ -322,14 +323,17 @@ mod tests {
         let r = swaps.swap(&inputs, &outputs);
         assert!(r.is_ok());
         let bs = r.unwrap();
-        assert!(utils::verify_signatures_data(&keys, outputs.into_iter().zip(bs.into_iter())));
-
+        assert!(utils::verify_signatures_data(
+            &keys,
+            outputs.into_iter().zip(bs.into_iter())
+        ));
     }
 
     #[test]
     fn test_swap_merge_tokens_ok() {
         let keys = keys::generate_keyset();
-        let inputs = utils::generate_proofs(&keys, vec![Amount::from(4), Amount::from(4)].as_slice());
+        let inputs =
+            utils::generate_proofs(&keys, vec![Amount::from(4), Amount::from(4)].as_slice());
         let outputs: Vec<_> = utils::generate_blinds(&keys, vec![Amount::from(8)].as_slice())
             .into_iter()
             .map(|a| a.0)
@@ -360,8 +364,9 @@ mod tests {
         let r = swaps.swap(&inputs, &outputs);
         assert!(r.is_ok());
         let bs = r.unwrap();
-        assert!(utils::verify_signatures_data(&keys, outputs.into_iter().zip(bs.into_iter())));
-
+        assert!(utils::verify_signatures_data(
+            &keys,
+            outputs.into_iter().zip(bs.into_iter())
+        ));
     }
-
 }


### PR DESCRIPTION
- move sign_with_keys to top-level keys module

from crate::credit::keys
to crate::keys



- refactor Repository to return AnyResult

for better error handling



- implement keys manager system for credit

in the credit side of wildcat, the keys repository for the swap service juggles
with three keys types:
- quote keys: keysets generated based on billID/endorserID
- maturity keys: keysets for circulating credit eCash
- debit keys: keysets for circulating debit eCash

the credit::keys::SwapRepository implements the logic that manages
tokens from these 3 different types of keys, and hides such complexity
to the swap service, presenting itself a simple swap::KeysRepository