### PR TITLE
[bcr-wdc-keys] add verify_with_keys

### DIFF
--- a/crates/bcr-wdc-keys/src/lib.rs
+++ b/crates/bcr-wdc-keys/src/lib.rs
@@ -128,6 +128,7 @@ pub mod test_utils {
     use bitcoin::bip32::DerivationPath;
     use cashu::mint as cdk_mint;
     use cashu::nuts::nut01 as cdk01;
+    use cashu::secret as cdk_secret;
     use once_cell::sync::Lazy;
 
     static SECPCTX: Lazy<bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>> =
@@ -161,6 +162,21 @@ pub mod test_utils {
             max_order: 10,
         };
         (info, set)
+    }
+
+    pub fn generate_blind(
+        keyset: &cdk02::MintKeySet,
+        amount: &cdk_Amount,
+    ) -> (cdk00::BlindedMessage, cdk_secret::Secret, cdk01::SecretKey) {
+            let _keypair = keyset.keys.get(amount).expect("keys for amount");
+            let secret = cdk_secret::Secret::new(rand::random::<u64>().to_string());
+            let (b_, r) =
+                cdk_dhke::blind_message(secret.as_bytes(), None).expect("cdk_dhke::blind_message");
+            (
+                cdk00::BlindedMessage::new(*amount, keyset.id, b_),
+                secret,
+                r,
+            )
     }
 
     pub const RANDOMS: [&str; 6] = [

--- a/crates/bcr-wdc-quote-service/src/error.rs
+++ b/crates/bcr-wdc-quote-service/src/error.rs
@@ -48,9 +48,7 @@ impl axum::response::IntoResponse for Error {
                 StatusCode::NOT_FOUND,
                 format!("No key for amount {}", amount),
             ),
-            Error::Keys(_) => {
-                (StatusCode::BAD_REQUEST, String::new())
-            }
+            Error::Keys(_) => (StatusCode::BAD_REQUEST, String::new()),
 
             Error::KeysRepository(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::QuotesRepository(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),

--- a/crates/bcr-wdc-quote-service/src/error.rs
+++ b/crates/bcr-wdc-quote-service/src/error.rs
@@ -44,16 +44,12 @@ impl axum::response::IntoResponse for Error {
 
             Error::Chrono(_) => (StatusCode::BAD_REQUEST, String::from("Malformed datetime")),
 
-            Error::Keys(KeysError::TStamp(tstamp)) => (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid timestamp: {}", tstamp),
-            ),
             Error::Keys(KeysError::NoKeyForAmount(amount)) => (
                 StatusCode::NOT_FOUND,
                 format!("No key for amount {}", amount),
             ),
-            Error::Keys(KeysError::CdkDHKE(_)) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, String::new())
+            Error::Keys(_) => {
+                (StatusCode::BAD_REQUEST, String::new())
             }
 
             Error::KeysRepository(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),

--- a/crates/bcr-wdc-swap-service/src/utils.rs
+++ b/crates/bcr-wdc-swap-service/src/utils.rs
@@ -1,11 +1,11 @@
 // ----- standard library imports
 // ----- extra library imports
+use bcr_wdc_keys::test_utils::generate_blind;
 use cashu::Amount as cdk_Amount;
 use cashu::dhke as cdk_dhke;
 use cashu::nuts::nut00 as cdk00;
 use cashu::nuts::nut01 as cdk01;
 use cashu::nuts::nut02 as cdk02;
-use bcr_wdc_keys::test_utils::generate_blind;
 use cashu::secret as cdk_secret;
 // ----- local imports
 

--- a/crates/bcr-wdc-swap-service/src/utils.rs
+++ b/crates/bcr-wdc-swap-service/src/utils.rs
@@ -5,6 +5,7 @@ use cashu::dhke as cdk_dhke;
 use cashu::nuts::nut00 as cdk00;
 use cashu::nuts::nut01 as cdk01;
 use cashu::nuts::nut02 as cdk02;
+use bcr_wdc_keys::test_utils::generate_blind;
 use cashu::secret as cdk_secret;
 // ----- local imports
 
@@ -28,15 +29,7 @@ pub fn generate_blinds(
 ) -> Vec<(cdk00::BlindedMessage, cdk_secret::Secret, cdk01::SecretKey)> {
     let mut blinds: Vec<(cdk00::BlindedMessage, cdk_secret::Secret, cdk01::SecretKey)> = Vec::new();
     for amount in amounts {
-        let _keypair = keyset.keys.get(amount).expect("keys for amount");
-        let secret = cdk_secret::Secret::new(rand::random::<u64>().to_string());
-        let (b_, r) =
-            cdk_dhke::blind_message(secret.as_bytes(), None).expect("cdk_dhke::blind_message");
-        blinds.push((
-            cdk00::BlindedMessage::new(*amount, keyset.id, b_),
-            secret,
-            r,
-        ));
+        blinds.push(generate_blind(keyset, amount));
     }
     blinds
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `verify_with_keys` function for proof verification.

- Introduced `generate_blind` utility in `test_utils`.

- Simplified error handling in `bcr-wdc-quote-service`.

- Added a test for signing and verifying messages.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Added proof verification and utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-keys/src/lib.rs

<li>Added <code>verify_with_keys</code> function for proof verification.<br> <li> Introduced <code>generate_blind</code> utility in <code>test_utils</code>.<br> <li> Added a test for signing and verifying messages.<br> <li> Enhanced error handling with new error variants.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/65/files#diff-765ea20e9f4249876119a4c21df57d8f4293028c192002048c5cd5d89d5f7551">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Refactored `generate_blinds` to use utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/utils.rs

<li>Replaced inline <code>generate_blinds</code> logic with <code>generate_blind</code> utility.<br> <li> Improved code reuse by leveraging <code>test_utils</code>.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/65/files#diff-38a491290e2d3b9856dd081afcd993fa9e588fb3c97fb5ffaece0aa32d9e51a6">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Simplified error handling for `Keys` errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/error.rs

<li>Simplified error handling for <code>Keys</code> errors.<br> <li> Removed specific error handling for <code>TStamp</code>.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/65/files#diff-ba4223300771963ac9bac2c3a6d4859b9e260cff57010253b4ef8f8d51f641ef">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>