### PR TITLE
chore: add cdk mint to docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,3 +84,25 @@ services:
       test: [ "CMD", "/surreal", "is-ready" ]
       interval: 5s
       retries: 5
+
+  cdk_mint:
+    image: thesimplekid/cdk-mintd:v0.7.4@sha256:9da05978f0e18a11ff08a2f6494d87bc2efdc1d70f733278f0c5dd4f74db1579
+    restart: unless-stopped
+    environment:
+      - CDK_MINTD_URL=https://example.com
+      - CDK_MINTD_LN_BACKEND=fakewallet
+      - CDK_MINTD_LISTEN_HOST=0.0.0.0
+      - CDK_MINTD_LISTEN_PORT=8085
+      - CDK_MINTD_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+      - CDK_MINTD_DATABASE=redb
+      - CDK_MINTD_CACHE_BACKEND=memory
+    command: ["cdk-mintd"]
+    ports:
+      - "8085:8085"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://127.0.0.1:8085/v1/info || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 60s
+      start_interval: 3s


### PR DESCRIPTION
In preparation of the bff-wallet crate:
Add a cdk mint to the docker compose setup.
This mint currently uses `fakewallet` and does not connect to a real lightning node.