### PR TITLE
chore(build): cargo fmt

### DIFF
--- a/crates/bcr-wdc-key-service/src/lib.rs
+++ b/crates/bcr-wdc-key-service/src/lib.rs
@@ -38,7 +38,7 @@ pub struct AppController {
 
 impl AppController {
     pub async fn new(seed: &[u8], cfg: AppConfig) -> Self {
-      let AppConfig { keys, quotekeys } = cfg;
+        let AppConfig { keys, quotekeys } = cfg;
 
         let keys_repo = ProdKeysRepository::new(keys)
             .await

--- a/crates/bcr-wdc-key-service/src/main.rs
+++ b/crates/bcr-wdc-key-service/src/main.rs
@@ -30,7 +30,6 @@ async fn main() {
         .await
         .expect("Failed to bind to address");
 
-
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_signal())
         .await
@@ -38,25 +37,25 @@ async fn main() {
 }
 
 async fn shutdown_signal() {
-  let ctrl_c = async {
-    signal::ctrl_c()
-          .await
-          .expect("failed to install Ctrl+C handler");
-  };
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
 
-  #[cfg(unix)]
-  let terminate = async {
-      signal::unix::signal(signal::unix::SignalKind::terminate())
-          .expect("failed to install signal handler")
-          .recv()
-          .await;
-  };
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
 
-  #[cfg(not(unix))]
-  let terminate = std::future::pending::<()>();
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
 
-  tokio::select! {
-      _ = ctrl_c => {},
-      _ = terminate => {},
-  }
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }

--- a/crates/bcr-wdc-quote-service/src/main.rs
+++ b/crates/bcr-wdc-quote-service/src/main.rs
@@ -35,25 +35,25 @@ async fn main() {
 }
 
 async fn shutdown_signal() {
-  let ctrl_c = async {
-    signal::ctrl_c()
-          .await
-          .expect("failed to install Ctrl+C handler");
-  };
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
 
-  #[cfg(unix)]
-  let terminate = async {
-      signal::unix::signal(signal::unix::SignalKind::terminate())
-          .expect("failed to install signal handler")
-          .recv()
-          .await;
-  };
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
 
-  #[cfg(not(unix))]
-  let terminate = std::future::pending::<()>();
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
 
-  tokio::select! {
-      _ = ctrl_c => {},
-      _ = terminate => {},
-  }
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }

--- a/crates/bcr-wdc-swap-service/src/lib.rs
+++ b/crates/bcr-wdc-swap-service/src/lib.rs
@@ -30,7 +30,10 @@ pub struct AppController {
 
 impl AppController {
     pub async fn new(cfg: AppConfig) -> Self {
-        let AppConfig { proof_db, keys_client } = cfg;
+        let AppConfig {
+            proof_db,
+            keys_client,
+        } = cfg;
 
         let keys_repo = ProdKeysService::new(keys_client)
             .await

--- a/crates/bcr-wdc-swap-service/src/main.rs
+++ b/crates/bcr-wdc-swap-service/src/main.rs
@@ -35,26 +35,25 @@ async fn main() {
 }
 
 async fn shutdown_signal() {
-  let ctrl_c = async {
-    signal::ctrl_c()
-          .await
-          .expect("failed to install Ctrl+C handler");
-  };
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
 
-  #[cfg(unix)]
-  let terminate = async {
-      signal::unix::signal(signal::unix::SignalKind::terminate())
-          .expect("failed to install signal handler")
-          .recv()
-          .await;
-  };
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
 
-  #[cfg(not(unix))]
-  let terminate = std::future::pending::<()>();
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
 
-  tokio::select! {
-      _ = ctrl_c => {},
-      _ = terminate => {},
-  }
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }
-

--- a/crates/bcr-wdc-treasury-service/src/main.rs
+++ b/crates/bcr-wdc-treasury-service/src/main.rs
@@ -1,5 +1,5 @@
-use tokio::signal;
 use std::str::FromStr;
+use tokio::signal;
 
 #[derive(Debug, serde::Deserialize)]
 struct MainConfig {
@@ -41,25 +41,25 @@ async fn main() {
 }
 
 async fn shutdown_signal() {
-  let ctrl_c = async {
-    signal::ctrl_c()
-          .await
-          .expect("failed to install Ctrl+C handler");
-  };
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
 
-  #[cfg(unix)]
-  let terminate = async {
-      signal::unix::signal(signal::unix::SignalKind::terminate())
-          .expect("failed to install signal handler")
-          .recv()
-          .await;
-  };
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
 
-  #[cfg(not(unix))]
-  let terminate = std::future::pending::<()>();
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
 
-  tokio::select! {
-      _ = ctrl_c => {},
-      _ = terminate => {},
-  }
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Reformatted code across multiple files for consistency.

- Improved indentation and alignment in struct and function definitions.

- Standardized `shutdown_signal` function formatting across services.

- Minor import reordering for better readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Reformatted `AppController::new` function for consistency</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/lib.rs

<li>Adjusted indentation in <code>AppController::new</code> function.<br> <li> Improved readability of struct unpacking.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/90/files#diff-3f8809d40f9e828f899b297d0eed35852796e26fa96f3c629ac0f4a6dc079589">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Standardized `shutdown_signal` function formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/main.rs

<li>Reformatted <code>shutdown_signal</code> function for better readability.<br> <li> Removed unnecessary blank line.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/90/files#diff-7ba54acb93cc4589ba66b78ffda6d81df6b37c6425ef914204c83fa374faeaec">+21/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Standardized `shutdown_signal` function formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/main.rs

<li>Reformatted <code>shutdown_signal</code> function for better readability.<br> <li> Improved indentation consistency.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/90/files#diff-2315d2c5dd613d7bc2bbdcea2b1512baa28f4bb7d62d0de18e1b50a1cc2a2ffa">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Improved struct unpacking formatting in `AppController::new`</code></dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/lib.rs

<li>Reformatted struct unpacking in <code>AppController::new</code>.<br> <li> Improved alignment for better readability.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/90/files#diff-d6043a0bd0e59231f714995c9050c95248343410c6e4944cd2d027c37ded0b06">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Standardized `shutdown_signal` function formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/main.rs

<li>Reformatted <code>shutdown_signal</code> function for better readability.<br> <li> Improved indentation consistency.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/90/files#diff-1740914fe229f4c6fd2faa6312452b6f9d3b4b6af729c5d9f8a921b0afff6858">+21/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Standardized `shutdown_signal` function and reordered imports</code></dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/main.rs

<li>Reformatted <code>shutdown_signal</code> function for better readability.<br> <li> Reordered imports for better organization.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/90/files#diff-ce3b84223bbd3d0908da85d994cb4a235eb6f85bed167479654f1f30c2b4268e">+19/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>