### PR TITLE
[bcr-wdc-quote-service] fix openapi definitions

### DIFF
--- a/crates/bcr-wdc-quote-service/src/admin.rs
+++ b/crates/bcr-wdc-quote-service/src/admin.rs
@@ -17,7 +17,7 @@ use crate::TStamp;
         ("since" = Option<chrono::NaiveDateTime>, Query, description = "only quote requests younger than `since`")
     ),
     responses (
-        (status = 200, description = "Successful response", body = web_quotes::ListReply, content_type = "application/json"),
+        (status = 200, description = "Successful response", body = ListReply, content_type = "application/json"),
     )
 )]
 pub async fn list_pending_quotes<KeysHndlr, Wlt, QuotesRepo>(
@@ -106,7 +106,7 @@ fn convert_into_list_params(params: web_quotes::ListParam) -> (ListFilters, Opti
         ("since" = Option<chrono::DateTime<chrono::Utc>>, Query, description = "quotes younger than `since`")
     ),
     responses (
-        (status = 200, description = "Successful response", body = web_quotes::ListReplyLight, content_type = "application/json"),
+        (status = 200, description = "Successful response", body = ListReplyLight, content_type = "application/json"),
     )
 )]
 pub async fn list_quotes<KeysHndlr, Wlt, QuotesRepo>(
@@ -169,7 +169,7 @@ fn convert_to_info_reply(quote: quotes::Quote) -> web_quotes::InfoReply {
         ("id" = String, Path, description = "The quote id")
     ),
     responses (
-        (status = 200, description = "Successful response", body = web_quotes::InfoReply, content_type = "application/json"),
+        (status = 200, description = "Successful response", body = InfoReply, content_type = "application/json"),
         (status = 404, description = "Quote id not  found"),
     )
 )]
@@ -195,9 +195,9 @@ where
     params(
         ("id" = String, Path, description = "The quote id")
     ),
-    request_body(content = web_quotes::UpdateQuoteRequest, content_type = "application/json"),
+    request_body(content = UpdateQuoteRequest, content_type = "application/json"),
     responses (
-        (status = 200, description = "Successful response", body = web_quotes::UpdateQuoteResponse, content_type = "application/json"),
+        (status = 200, description = "Successful response", body = UpdateQuoteResponse, content_type = "application/json"),
     )
 )]
 pub async fn admin_update_quote<KeysHndlr, Wlt, QuotesRepo>(

--- a/crates/bcr-wdc-quote-service/src/lib.rs
+++ b/crates/bcr-wdc-quote-service/src/lib.rs
@@ -4,7 +4,10 @@ use axum::extract::FromRef;
 use axum::routing::{get, post};
 use axum::Router;
 use cashu::nuts::nut00 as cdk00;
+use cashu::nuts::nut02 as cdk02;
+use cashu::nuts::nut11 as cdk11;
 use cashu::nuts::nut12 as cdk12;
+use cashu::nuts::nut14 as cdk14;
 use utoipa::OpenApi;
 // ----- local modules
 mod admin;
@@ -87,24 +90,29 @@ pub fn credit_routes(ctrl: AppController) -> Router {
 #[derive(utoipa::OpenApi)]
 #[openapi(
     components(schemas(
-        //bcr_ebill_core::contact::IdentityPublicData,
         bcr_wdc_webapi::quotes::BillInfo,
-        bcr_wdc_webapi::quotes::IdentityPublicData,
         bcr_wdc_webapi::quotes::ContactType,
-        bcr_wdc_webapi::quotes::PostalAddress,
         bcr_wdc_webapi::quotes::EnquireReply,
         bcr_wdc_webapi::quotes::EnquireRequest,
+        bcr_wdc_webapi::quotes::IdentityPublicData,
         bcr_wdc_webapi::quotes::InfoReply,
+        bcr_wdc_webapi::quotes::LightInfo,
         bcr_wdc_webapi::quotes::ListReply,
+        bcr_wdc_webapi::quotes::ListReplyLight,
+        bcr_wdc_webapi::quotes::PostalAddress,
         bcr_wdc_webapi::quotes::ResolveOffer,
+        bcr_wdc_webapi::quotes::StatusReply,
+        bcr_wdc_webapi::quotes::StatusReplyDiscriminants,
         bcr_wdc_webapi::quotes::UpdateQuoteRequest,
         bcr_wdc_webapi::quotes::UpdateQuoteResponse,
-        bcr_wdc_webapi::quotes::StatusReply,
         cashu::Amount,
         cdk00::BlindSignature,
         cdk00::BlindedMessage,
         cdk00::Witness,
+        cdk02::Id,
+        cdk11::P2PKWitness,
         cdk12::BlindSignatureDleq,
+        cdk14::HTLCWitness,
     ),),
     paths(
         crate::web::enquire_quote,

--- a/crates/bcr-wdc-quote-service/src/web.rs
+++ b/crates/bcr-wdc-quote-service/src/web.rs
@@ -14,9 +14,9 @@ use crate::{
 #[utoipa::path(
     post,
     path = "/v1/mint/credit/quote",
-    request_body(content = web_quotes::EnquireRequest, content_type = "application/json"),
+    request_body(content = EnquireRequest, content_type = "application/json"),
     responses (
-        (status = 200, description = "Quote request admitted", body = web_quotes::EnquireReply, content_type = "application/json"),
+        (status = 200, description = "Quote request admitted", body = EnquireReply, content_type = "application/json"),
         (status = 404, description = "Quote request not accepted"),
     )
 )]
@@ -74,7 +74,7 @@ fn convert_to_enquire_reply(quote: quotes::Quote) -> web_quotes::StatusReply {
         ("id" = Uuid, Path, description = "The quote id")
     ),
     responses (
-        (status = 200, description = "Successful response", body = web_quotes::StatusReply, content_type = "application/json"),
+        (status = 200, description = "Successful response", body = StatusReply, content_type = "application/json"),
         (status = 404, description = "Quote id not  found"),
     )
 )]
@@ -99,7 +99,7 @@ where
     params(
         ("id" = Uuid, Path, description = "The quote id")
     ),
-    request_body(content = web_quotes::ResolveOffer, content_type = "application/json"),
+    request_body(content = ResolveOffer, content_type = "application/json"),
     responses (
         (status = 200, description = "Successful response"),
         (status = 404, description = "Quote not found"),


### PR DESCRIPTION
### **User description**
we are a bit stuck in terms of completely fixing openapi auto-generated definitions

- cashu@0.7 has an issue in its definition of keyset ID structure
- The fix I pushes has been merged and landed in 0.8
- moving cashu and cdk libraries  to 0.8 would force us to move to more recent utoipa and utoipa-swagger-ui which has an issue with zip library. We are waiting for zip maintainers to yank their latest released version

I hope the zip issue will be fixed soon


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed OpenAPI definitions by updating response and request body references.

- Updated `cashu` library dependencies to include new modules.

- Enhanced OpenAPI schema components with additional entities.

- Improved consistency in API path definitions and response types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Fix OpenAPI response and request body references in admin module</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/admin.rs

<li>Updated response body references to remove <code>web_quotes</code> prefix.<br> <li> Adjusted request body references for consistency.<br> <li> Improved API path definitions for admin-related endpoints.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/99/files#diff-0ac7a81b04baaf01768d8526f8dceb0754d20adf93d53808f189a4b810752acb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Fix OpenAPI references and improve mint-related endpoints</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/web.rs

<li>Updated request and response body references to remove <code>web_quotes</code> <br>prefix.<br> <li> Improved API path definitions for mint-related endpoints.<br> <li> Enhanced consistency in response type definitions.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/99/files#diff-1bd0e6958ea77d8d30de256aa68ee557a88bc615c71586889a98edca3ea18e30">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update dependencies and enhance OpenAPI schema components</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/lib.rs

<li>Added new <code>cashu</code> library modules (<code>nut02</code>, <code>nut11</code>, <code>nut14</code>).<br> <li> Enhanced OpenAPI schema components with additional entities.<br> <li> Improved modularity by including more comprehensive schema <br>definitions.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/99/files#diff-165657972ffc04299a11d483cafb1e6a8590ee69e9f7a7170b74a4d93b04b628">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>