### PR TITLE
[docker] Add platform amd64 for cdk_mint in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,7 @@ services:
 
   cdk_mint:
     image: thesimplekid/cdk-mintd:0.9
+    platform: linux/amd64
     volumes:
       - ./docker/cdk-mintd/config.toml:/root/.cdk-mintd/config.toml
     restart: unless-stopped


### PR DESCRIPTION
### **User description**
Add linux/amd64 to let Docker Desktop on Mac ARM know that it needs to use virtualization for cdk_mint which doesn't have native images available due to the custom build with nix.

Let me know if I'm breaking any conventions.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Specify `linux/amd64` platform for `cdk_mint` service in Docker Compose

- Improves compatibility for Mac ARM users running Docker Desktop


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add linux/amd64 platform to cdk_mint service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Added <code>platform: linux/amd64</code> to <code>cdk_mint</code> service<br> <li> Ensures correct architecture is used for custom Nix build<br> <li> Facilitates Docker Desktop usage on Mac ARM devices


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/129/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>