### PR TITLE
[bcr-wdc-swap-service] improve storage operation for proofs 

### DIFF
--- a/crates/bcr-wdc-ebpp/src/onchain.rs
+++ b/crates/bcr-wdc-ebpp/src/onchain.rs
@@ -596,8 +596,6 @@ mod tests {
             "03e416ffcdde3d5b83a1940fda7aec1179ed3382d080da9c2672c02115a37ad45e";
         let (descr, keymap) =
             Descriptor::parse_descriptor(secp256k1::global::SECP256K1, descriptor).unwrap();
-        dbg!(&descr);
-        dbg!(&keymap);
 
         let tmp_dir = tempfile::tempdir().unwrap();
         let network = btc::Network::Testnet;

--- a/crates/bcr-wdc-swap-client/tests/swap.rs
+++ b/crates/bcr-wdc-swap-client/tests/swap.rs
@@ -46,10 +46,16 @@ async fn swap_p2pk() {
     let keys_entry = keys_test::generate_keyset();
     let kid = keys_entry.0.id;
 
+    let condition = MintCondition {
+        target: Amount::ZERO,
+        pub_key: keys_test::publics()[0],
+        is_minted: true,
+    };
+
     keys_service
         .keys
         .keys
-        .store(keys_entry.clone())
+        .store(keys_entry.clone(), condition)
         .expect("store");
 
     let p2pk_secret = cashu::SecretKey::generate();

--- a/crates/bcr-wdc-swap-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-swap-service/src/persistence/surreal.rs
@@ -86,9 +86,7 @@ impl ProofRepository for ProofDB {
 
 fn proof_to_record_id(main_table: &str, proof: &cdk00::Proof) -> RecordId {
     let table = main_table.to_string() + &proof.keyset_id.to_string();
-    let rid = RecordId::from_table_key(table, proof.secret.to_string());
-    dbg!(&rid);
-    rid
+    RecordId::from_table_key(table, proof.secret.to_string())
 }
 
 #[cfg(test)]
@@ -142,7 +140,6 @@ mod tests {
 
         let res = db.insert(&proofs).await;
         assert!(res.is_err());
-        dbg!(&res);
         assert!(matches!(res.unwrap_err(), Error::ProofsAlreadySpent));
     }
 

--- a/crates/bcr-wdc-swap-service/src/service.rs
+++ b/crates/bcr-wdc-swap-service/src/service.rs
@@ -208,7 +208,6 @@ mod tests {
         };
 
         let r = swaps.swap(&inputs, &outputs).await;
-        dbg!(&r);
         assert!(r.is_err());
         let e = r.unwrap_err();
         assert!(matches!(e, Error::UnknownKeyset(_)));

--- a/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
@@ -214,7 +214,6 @@ impl DBRepository {
             .bind(("table", self.proofs.clone()))
             .await?
             .take(0)?;
-        dbg!(&balances);
         let mut ret_val = Vec::with_capacity(balances.len());
         for balance in balances {
             let DBEntryBalance { keyset_id, amount } = balance;


### PR DESCRIPTION
- proofs stored in a per-keyset table
- proof decomposed and stored as a combination of {c, secret}