### PR TITLE
[bcr-wdc-quote-service] refactor QuotesRepository trait

### DIFF
--- a/crates/bcr-wdc-quote-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-quote-service/src/persistence/inmemory.rs
@@ -45,7 +45,11 @@ impl Repository for QuotesIDMap {
         Ok(self.quotes.read().unwrap().get(&id).cloned())
     }
 
-    async fn update_status_if_pending(&self, qid: uuid::Uuid, new: quotes::QuoteStatus) -> AnyResult<()> {
+    async fn update_status_if_pending(
+        &self,
+        qid: uuid::Uuid,
+        new: quotes::QuoteStatus,
+    ) -> AnyResult<()> {
         let mut m = self.quotes.write().unwrap();
         let result = m.get_mut(&qid);
         if let Some(old) = result {
@@ -56,7 +60,11 @@ impl Repository for QuotesIDMap {
         Ok(())
     }
 
-    async fn update_status_if_offered(&self, qid: uuid::Uuid, new: quotes::QuoteStatus) -> AnyResult<()> {
+    async fn update_status_if_offered(
+        &self,
+        qid: uuid::Uuid,
+        new: quotes::QuoteStatus,
+    ) -> AnyResult<()> {
         let mut m = self.quotes.write().unwrap();
         let result = m.get_mut(&qid);
         if let Some(old) = result {

--- a/crates/bcr-wdc-quote-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-quote-service/src/persistence/inmemory.rs
@@ -45,29 +45,23 @@ impl Repository for QuotesIDMap {
         Ok(self.quotes.read().unwrap().get(&id).cloned())
     }
 
-    async fn update_if_pending(&self, new: quotes::Quote) -> AnyResult<()> {
-        let id = new.id;
+    async fn update_status_if_pending(&self, qid: uuid::Uuid, new: quotes::QuoteStatus) -> AnyResult<()> {
         let mut m = self.quotes.write().unwrap();
-        let result = m.remove(&id);
+        let result = m.get_mut(&qid);
         if let Some(old) = result {
             if matches!(old.status, quotes::QuoteStatus::Pending { .. }) {
-                m.insert(id, new);
-            } else {
-                m.insert(id, old);
+                old.status = new;
             }
         }
         Ok(())
     }
 
-    async fn update_if_offered(&self, new: quotes::Quote) -> AnyResult<()> {
-        let id = new.id;
+    async fn update_status_if_offered(&self, qid: uuid::Uuid, new: quotes::QuoteStatus) -> AnyResult<()> {
         let mut m = self.quotes.write().unwrap();
-        let result = m.remove(&id);
+        let result = m.get_mut(&qid);
         if let Some(old) = result {
             if matches!(old.status, quotes::QuoteStatus::Offered { .. }) {
-                m.insert(id, new);
-            } else {
-                m.insert(id, old);
+                old.status = new;
             }
         }
         Ok(())

--- a/crates/bcr-wdc-quote-service/src/quotes.rs
+++ b/crates/bcr-wdc-quote-service/src/quotes.rs
@@ -53,8 +53,9 @@ impl From<BillInfo> for bcr_wdc_webapi::quotes::BillInfo {
     }
 }
 
-#[derive(Debug, Clone, strum::EnumDiscriminants)]
-#[strum_discriminants(derive(serde::Serialize))]
+#[derive(Debug, Clone, strum::EnumDiscriminants, serde::Serialize, serde::Deserialize)]
+#[strum_discriminants(derive(serde::Serialize, serde::Deserialize))]
+#[serde(tag = "status")]
 pub enum QuoteStatus {
     Pending { public_key: cdk01::PublicKey },
     Denied,


### PR DESCRIPTION
the trait provides two methods:
- update_if_pending
- update_if_offered

we refactor them and narrow the scope of the update action to:
- update_status_if_pending
- update_status_if_offered

Only the status of the quote can be updated, not the information about
the ebill

We also refactor the persistence::surreal struct to something much
simpler