### PR TITLE
Add basic E-Bill API endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,4 @@ tracing-subscriber = {version = "0.3"}
 utoipa = {version = "5"}
 utoipa-swagger-ui = {version = "9"}
 uuid = {version = "1"}
+url = {version = "2.5.4"}

--- a/crates/bcr-wdc-ebill-service/Cargo.toml
+++ b/crates/bcr-wdc-ebill-service/Cargo.toml
@@ -15,6 +15,9 @@ thiserror.workspace = true
 tokio = {workspace = true, features = ["signal", "time"]}
 tracing = {workspace = true, features = ["log"]}
 tracing-log = {workspace = true}
+bitcoin = {workspace = true, features = ["serde"]}
 tracing-subscriber = {workspace = true, features = ["serde"]}
+url = {workspace = true, features = ["serde"]}
+bip39 = {workspace = true, features = ["serde"]}
 rustls = "0.23"
 serde_repr = "0.1"

--- a/crates/bcr-wdc-ebill-service/Cargo.toml
+++ b/crates/bcr-wdc-ebill-service/Cargo.toml
@@ -2,16 +2,19 @@
 name = "bcr-wdc-ebill-service"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 axum = {workspace = true, features = ["macros"]}
 bcr-ebill-api = {git = "https://github.com/BitcreditProtocol/E-Bill.git", branch = "406-anonymous-mode"} #temp until it's merged and released
 bcr-ebill-transport = {git = "https://github.com/BitcreditProtocol/E-Bill.git", branch = "406-anonymous-mode"} #temp until it's merged and released
 config.workspace = true
-rustls = "0.23"
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tokio = {workspace = true, features = ["signal", "time"]}
 tracing = {workspace = true, features = ["log"]}
 tracing-log = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["serde"]}
+rustls = "0.23"
+serde_repr = "0.1"

--- a/crates/bcr-wdc-ebill-service/src/bill.rs
+++ b/crates/bcr-wdc-ebill-service/src/bill.rs
@@ -1,0 +1,435 @@
+// ----- standard library imports
+// ----- extra library imports
+use bcr_ebill_api::{
+    data::{
+        bill::{
+            BillAcceptanceStatus, BillCombinedBitcoinKey, BillCurrentWaitingState, BillData,
+            BillParticipants, BillPaymentStatus, BillRecourseStatus, BillSellStatus, BillStatus,
+            BillWaitingForPaymentState, BillWaitingForRecourseState, BillWaitingForSellState,
+            BitcreditBillResult,
+        },
+        contact::{BillAnonParticipant, BillIdentParticipant, BillParticipant},
+        notification::{Notification, NotificationType},
+    },
+    util::date::DateTimeUtc,
+};
+use serde::{Deserialize, Serialize};
+// ----- local imports
+use crate::{
+    contact::ContactTypeWeb,
+    identity::{FileWeb, PostalAddressWeb},
+};
+// ----- end imports
+
+#[derive(Debug, Serialize)]
+pub struct BillsResponse<T: Serialize> {
+    pub bills: Vec<T>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BitcreditBillWeb {
+    pub id: String,
+    pub participants: BillParticipantsWeb,
+    pub data: BillDataWeb,
+    pub status: BillStatusWeb,
+    pub current_waiting_state: Option<BillCurrentWaitingStateWeb>,
+}
+
+impl From<BitcreditBillResult> for BitcreditBillWeb {
+    fn from(val: BitcreditBillResult) -> Self {
+        BitcreditBillWeb {
+            id: val.id,
+            participants: val.participants.into(),
+            data: val.data.into(),
+            status: val.status.into(),
+            current_waiting_state: val.current_waiting_state.map(|cws| cws.into()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub enum BillCurrentWaitingStateWeb {
+    Sell(BillWaitingForSellStateWeb),
+    Payment(BillWaitingForPaymentStateWeb),
+    Recourse(BillWaitingForRecourseStateWeb),
+}
+
+impl From<BillCurrentWaitingState> for BillCurrentWaitingStateWeb {
+    fn from(val: BillCurrentWaitingState) -> Self {
+        match val {
+            BillCurrentWaitingState::Sell(state) => BillCurrentWaitingStateWeb::Sell(state.into()),
+            BillCurrentWaitingState::Payment(state) => {
+                BillCurrentWaitingStateWeb::Payment(state.into())
+            }
+            BillCurrentWaitingState::Recourse(state) => {
+                BillCurrentWaitingStateWeb::Recourse(state.into())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillWaitingForSellStateWeb {
+    pub time_of_request: u64,
+    pub buyer: BillParticipantWeb,
+    pub seller: BillParticipantWeb,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub mempool_link_for_address_to_pay: String,
+}
+
+impl From<BillWaitingForSellState> for BillWaitingForSellStateWeb {
+    fn from(val: BillWaitingForSellState) -> Self {
+        BillWaitingForSellStateWeb {
+            time_of_request: val.time_of_request,
+            buyer: val.buyer.into(),
+            seller: val.seller.into(),
+            currency: val.currency,
+            sum: val.sum,
+            link_to_pay: val.link_to_pay,
+            address_to_pay: val.address_to_pay,
+            mempool_link_for_address_to_pay: val.mempool_link_for_address_to_pay,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillWaitingForPaymentStateWeb {
+    pub time_of_request: u64,
+    pub payer: BillIdentParticipantWeb,
+    pub payee: BillParticipantWeb,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub mempool_link_for_address_to_pay: String,
+}
+
+impl From<BillWaitingForPaymentState> for BillWaitingForPaymentStateWeb {
+    fn from(val: BillWaitingForPaymentState) -> Self {
+        BillWaitingForPaymentStateWeb {
+            time_of_request: val.time_of_request,
+            payer: val.payer.into(),
+            payee: val.payee.into(),
+            currency: val.currency,
+            sum: val.sum,
+            link_to_pay: val.link_to_pay,
+            address_to_pay: val.address_to_pay,
+            mempool_link_for_address_to_pay: val.mempool_link_for_address_to_pay,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillWaitingForRecourseStateWeb {
+    pub time_of_request: u64,
+    pub recourser: BillIdentParticipantWeb,
+    pub recoursee: BillIdentParticipantWeb,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub mempool_link_for_address_to_pay: String,
+}
+
+impl From<BillWaitingForRecourseState> for BillWaitingForRecourseStateWeb {
+    fn from(val: BillWaitingForRecourseState) -> Self {
+        BillWaitingForRecourseStateWeb {
+            time_of_request: val.time_of_request,
+            recourser: val.recourser.into(),
+            recoursee: val.recoursee.into(),
+            currency: val.currency,
+            sum: val.sum,
+            link_to_pay: val.link_to_pay,
+            address_to_pay: val.address_to_pay,
+            mempool_link_for_address_to_pay: val.mempool_link_for_address_to_pay,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillStatusWeb {
+    pub acceptance: BillAcceptanceStatusWeb,
+    pub payment: BillPaymentStatusWeb,
+    pub sell: BillSellStatusWeb,
+    pub recourse: BillRecourseStatusWeb,
+    pub redeemed_funds_available: bool,
+    pub has_requested_funds: bool,
+}
+
+impl From<BillStatus> for BillStatusWeb {
+    fn from(val: BillStatus) -> Self {
+        BillStatusWeb {
+            acceptance: val.acceptance.into(),
+            payment: val.payment.into(),
+            sell: val.sell.into(),
+            recourse: val.recourse.into(),
+            redeemed_funds_available: val.redeemed_funds_available,
+            has_requested_funds: val.has_requested_funds,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillAcceptanceStatusWeb {
+    pub time_of_request_to_accept: Option<u64>,
+    pub requested_to_accept: bool,
+    pub accepted: bool,
+    pub request_to_accept_timed_out: bool,
+    pub rejected_to_accept: bool,
+}
+
+impl From<BillAcceptanceStatus> for BillAcceptanceStatusWeb {
+    fn from(val: BillAcceptanceStatus) -> Self {
+        BillAcceptanceStatusWeb {
+            time_of_request_to_accept: val.time_of_request_to_accept,
+            requested_to_accept: val.requested_to_accept,
+            accepted: val.accepted,
+            request_to_accept_timed_out: val.request_to_accept_timed_out,
+            rejected_to_accept: val.rejected_to_accept,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillPaymentStatusWeb {
+    pub time_of_request_to_pay: Option<u64>,
+    pub requested_to_pay: bool,
+    pub paid: bool,
+    pub request_to_pay_timed_out: bool,
+    pub rejected_to_pay: bool,
+}
+
+impl From<BillPaymentStatus> for BillPaymentStatusWeb {
+    fn from(val: BillPaymentStatus) -> Self {
+        BillPaymentStatusWeb {
+            time_of_request_to_pay: val.time_of_request_to_pay,
+            requested_to_pay: val.requested_to_pay,
+            paid: val.paid,
+            request_to_pay_timed_out: val.request_to_pay_timed_out,
+            rejected_to_pay: val.rejected_to_pay,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillSellStatusWeb {
+    pub time_of_last_offer_to_sell: Option<u64>,
+    pub sold: bool,
+    pub offered_to_sell: bool,
+    pub offer_to_sell_timed_out: bool,
+    pub rejected_offer_to_sell: bool,
+}
+
+impl From<BillSellStatus> for BillSellStatusWeb {
+    fn from(val: BillSellStatus) -> Self {
+        BillSellStatusWeb {
+            time_of_last_offer_to_sell: val.time_of_last_offer_to_sell,
+            sold: val.sold,
+            offered_to_sell: val.offered_to_sell,
+            offer_to_sell_timed_out: val.offer_to_sell_timed_out,
+            rejected_offer_to_sell: val.rejected_offer_to_sell,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillRecourseStatusWeb {
+    pub time_of_last_request_to_recourse: Option<u64>,
+    pub recoursed: bool,
+    pub requested_to_recourse: bool,
+    pub request_to_recourse_timed_out: bool,
+    pub rejected_request_to_recourse: bool,
+}
+
+impl From<BillRecourseStatus> for BillRecourseStatusWeb {
+    fn from(val: BillRecourseStatus) -> Self {
+        BillRecourseStatusWeb {
+            time_of_last_request_to_recourse: val.time_of_last_request_to_recourse,
+            recoursed: val.recoursed,
+            requested_to_recourse: val.requested_to_recourse,
+            request_to_recourse_timed_out: val.request_to_recourse_timed_out,
+            rejected_request_to_recourse: val.rejected_request_to_recourse,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillDataWeb {
+    pub language: String,
+    pub time_of_drawing: u64,
+    pub issue_date: String,
+    pub time_of_maturity: u64,
+    pub maturity_date: String,
+    pub country_of_issuing: String,
+    pub city_of_issuing: String,
+    pub country_of_payment: String,
+    pub city_of_payment: String,
+    pub currency: String,
+    pub sum: String,
+    pub files: Vec<FileWeb>,
+    pub active_notification: Option<NotificationWeb>,
+}
+
+impl From<BillData> for BillDataWeb {
+    fn from(val: BillData) -> Self {
+        BillDataWeb {
+            language: val.language,
+            time_of_drawing: val.time_of_drawing,
+            issue_date: val.issue_date,
+            time_of_maturity: val.time_of_maturity,
+            maturity_date: val.maturity_date,
+            country_of_issuing: val.country_of_issuing,
+            city_of_issuing: val.city_of_issuing,
+            country_of_payment: val.country_of_payment,
+            city_of_payment: val.city_of_payment,
+            currency: val.currency,
+            sum: val.sum,
+            files: val.files.into_iter().map(|f| f.into()).collect(),
+            active_notification: val.active_notification.map(|an| an.into()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillParticipantsWeb {
+    pub drawee: BillIdentParticipantWeb,
+    pub drawer: BillIdentParticipantWeb,
+    pub payee: BillParticipantWeb,
+    pub endorsee: Option<BillParticipantWeb>,
+    pub endorsements_count: u64,
+    pub all_participant_node_ids: Vec<String>,
+}
+
+impl From<BillParticipants> for BillParticipantsWeb {
+    fn from(val: BillParticipants) -> Self {
+        BillParticipantsWeb {
+            drawee: val.drawee.into(),
+            drawer: val.drawer.into(),
+            payee: val.payee.into(),
+            endorsee: val.endorsee.map(|e| e.into()),
+            endorsements_count: val.endorsements_count,
+            all_participant_node_ids: val.all_participant_node_ids,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub enum BillParticipantWeb {
+    Anon(BillAnonParticipantWeb),
+    Ident(BillIdentParticipantWeb),
+}
+
+impl From<BillParticipant> for BillParticipantWeb {
+    fn from(val: BillParticipant) -> Self {
+        match val {
+            BillParticipant::Ident(data) => BillParticipantWeb::Ident(data.into()),
+            BillParticipant::Anon(data) => BillParticipantWeb::Anon(data.into()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct BillAnonParticipantWeb {
+    pub node_id: String,
+    pub email: Option<String>,
+    pub nostr_relays: Vec<String>,
+}
+
+impl From<BillAnonParticipant> for BillAnonParticipantWeb {
+    fn from(val: BillAnonParticipant) -> Self {
+        BillAnonParticipantWeb {
+            node_id: val.node_id,
+            email: val.email,
+            nostr_relays: val.nostr_relays,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillIdentParticipantWeb {
+    #[serde(rename = "type")]
+    pub t: ContactTypeWeb,
+    pub node_id: String,
+    pub name: String,
+    #[serde(flatten)]
+    pub postal_address: PostalAddressWeb,
+    pub email: Option<String>,
+    pub nostr_relays: Vec<String>,
+}
+
+impl From<BillIdentParticipant> for BillIdentParticipantWeb {
+    fn from(val: BillIdentParticipant) -> Self {
+        BillIdentParticipantWeb {
+            t: val.t.into(),
+            name: val.name,
+            node_id: val.node_id,
+            postal_address: val.postal_address.into(),
+            email: val.email,
+            nostr_relays: val.nostr_relays,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationWeb {
+    pub id: String,
+    pub node_id: Option<String>,
+    pub notification_type: NotificationTypeWeb,
+    pub reference_id: Option<String>,
+    pub description: String,
+    pub datetime: DateTimeUtc,
+    pub active: bool,
+    pub payload: Option<serde_json::Value>,
+}
+
+impl From<Notification> for NotificationWeb {
+    fn from(val: Notification) -> Self {
+        NotificationWeb {
+            id: val.id,
+            node_id: val.node_id,
+            notification_type: val.notification_type.into(),
+            reference_id: val.reference_id,
+            description: val.description,
+            datetime: val.datetime,
+            active: val.active,
+            payload: val.payload,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum NotificationTypeWeb {
+    General,
+    Bill,
+}
+
+impl From<NotificationType> for NotificationTypeWeb {
+    fn from(val: NotificationType) -> Self {
+        match val {
+            NotificationType::Bill => NotificationTypeWeb::Bill,
+            NotificationType::General => NotificationTypeWeb::General,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RequestToPayBitcreditBillPayload {
+    pub bill_id: String,
+    pub currency: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BillCombinedBitcoinKeyWeb {
+    pub private_key: String,
+}
+
+impl From<BillCombinedBitcoinKey> for BillCombinedBitcoinKeyWeb {
+    fn from(val: BillCombinedBitcoinKey) -> Self {
+        BillCombinedBitcoinKeyWeb {
+            private_key: val.private_key,
+        }
+    }
+}

--- a/crates/bcr-wdc-ebill-service/src/contact.rs
+++ b/crates/bcr-wdc-ebill-service/src/contact.rs
@@ -1,0 +1,97 @@
+use bcr_ebill_api::data::contact::{Contact, ContactType};
+// ----- standard library imports
+// ----- extra library imports
+use serde::{Deserialize, Serialize};
+// ----- local modules
+use crate::identity::{FileWeb, PostalAddressWeb};
+// ----- end imports
+
+#[repr(u8)]
+#[derive(
+    Debug, Copy, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq,
+)]
+pub enum ContactTypeWeb {
+    Person = 0,
+    Company = 1,
+    Anon = 2,
+}
+
+impl TryFrom<u64> for ContactTypeWeb {
+    type Error = bcr_ebill_api::service::Error;
+
+    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
+        Ok(ContactType::try_from(value)
+            .map_err(Self::Error::Validation)?
+            .into())
+    }
+}
+
+impl From<ContactType> for ContactTypeWeb {
+    fn from(val: ContactType) -> Self {
+        match val {
+            ContactType::Person => ContactTypeWeb::Person,
+            ContactType::Company => ContactTypeWeb::Company,
+            ContactType::Anon => ContactTypeWeb::Anon,
+        }
+    }
+}
+
+impl From<ContactTypeWeb> for ContactType {
+    fn from(value: ContactTypeWeb) -> Self {
+        match value {
+            ContactTypeWeb::Person => ContactType::Person,
+            ContactTypeWeb::Company => ContactType::Company,
+            ContactTypeWeb::Anon => ContactType::Anon,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NewContactPayload {
+    pub t: u64,
+    pub node_id: String,
+    pub name: String,
+    pub email: Option<String>,
+    pub postal_address: Option<PostalAddressWeb>,
+    pub date_of_birth_or_registration: Option<String>,
+    pub country_of_birth_or_registration: Option<String>,
+    pub city_of_birth_or_registration: Option<String>,
+    pub identification_number: Option<String>,
+    pub avatar_file_upload_id: Option<String>,
+    pub proof_document_file_upload_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContactWeb {
+    pub t: ContactTypeWeb,
+    pub node_id: String,
+    pub name: String,
+    pub email: Option<String>,
+    pub postal_address: Option<PostalAddressWeb>,
+    pub date_of_birth_or_registration: Option<String>,
+    pub country_of_birth_or_registration: Option<String>,
+    pub city_of_birth_or_registration: Option<String>,
+    pub identification_number: Option<String>,
+    pub avatar_file: Option<FileWeb>,
+    pub proof_document_file: Option<FileWeb>,
+    pub nostr_relays: Vec<String>,
+}
+
+impl From<Contact> for ContactWeb {
+    fn from(val: Contact) -> Self {
+        ContactWeb {
+            t: val.t.into(),
+            node_id: val.node_id,
+            name: val.name,
+            email: val.email,
+            postal_address: val.postal_address.map(|pa| pa.into()),
+            date_of_birth_or_registration: val.date_of_birth_or_registration,
+            country_of_birth_or_registration: val.country_of_birth_or_registration,
+            city_of_birth_or_registration: val.city_of_birth_or_registration,
+            identification_number: val.identification_number,
+            avatar_file: val.avatar_file.map(|f| f.into()),
+            proof_document_file: val.proof_document_file.map(|f| f.into()),
+            nostr_relays: val.nostr_relays,
+        }
+    }
+}

--- a/crates/bcr-wdc-ebill-service/src/error.rs
+++ b/crates/bcr-wdc-ebill-service/src/error.rs
@@ -26,6 +26,22 @@ pub enum Error {
     /// all errors originating from validation
     #[error("Validation error: {0}")]
     Validation(#[from] bcr_ebill_api::util::ValidationError),
+
+    /// all errors originating from invalid URLs
+    #[error("Invalid URL")]
+    InvalidUrl,
+
+    /// all errors originating from invalid bitcoin keys
+    #[error("Invalid bitcoin key")]
+    InvalidBitcoinKey,
+
+    /// all errors originating from creating an identity, if an identity already exists
+    #[error("Identity already exists")]
+    IdentityAlreadyExists,
+
+    /// all errors originating from invalid mnemonics
+    #[error("Invalid Mnemonic")]
+    InvalidMnemonic,
 }
 
 impl axum::response::IntoResponse for Error {
@@ -36,6 +52,22 @@ impl axum::response::IntoResponse for Error {
             Error::BillService(e) => BillServiceError(e).into_response(),
             Error::NotificationService(e) => ServiceError(e.into()).into_response(),
             Error::Validation(e) => ValidationError(e).into_response(),
+            Error::InvalidUrl => {
+                (StatusCode::BAD_REQUEST, String::from("invalid URL")).into_response()
+            }
+            Error::InvalidBitcoinKey => {
+                (StatusCode::BAD_REQUEST, String::from("invalid Bitcoin Key")).into_response()
+            }
+            Error::InvalidMnemonic => (
+                StatusCode::BAD_REQUEST,
+                String::from("invalid bip39 mnemonic"),
+            )
+                .into_response(),
+            Error::IdentityAlreadyExists => (
+                StatusCode::BAD_REQUEST,
+                String::from("Identity already exists"),
+            )
+                .into_response(),
         };
 
         response.into_response()

--- a/crates/bcr-wdc-ebill-service/src/identity.rs
+++ b/crates/bcr-wdc-ebill-service/src/identity.rs
@@ -1,0 +1,188 @@
+// ----- standard library imports
+// ----- extra library imports
+use bcr_ebill_api::{
+    data::{
+        identity::{Identity, IdentityType},
+        File, OptionalPostalAddress, PostalAddress,
+    },
+    util::BcrKeys,
+};
+use serde::{Deserialize, Serialize};
+// ----- end imports
+
+#[repr(u8)]
+#[derive(
+    Debug, Copy, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq,
+)]
+pub enum IdentityTypeWeb {
+    Ident = 0,
+    Anon = 1,
+}
+
+impl TryFrom<u64> for IdentityTypeWeb {
+    type Error = bcr_ebill_api::service::Error;
+
+    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
+        Ok(IdentityType::try_from(value)
+            .map_err(Self::Error::Validation)?
+            .into())
+    }
+}
+
+impl From<IdentityType> for IdentityTypeWeb {
+    fn from(val: IdentityType) -> Self {
+        match val {
+            IdentityType::Ident => IdentityTypeWeb::Ident,
+            IdentityType::Anon => IdentityTypeWeb::Anon,
+        }
+    }
+}
+
+impl From<IdentityTypeWeb> for IdentityType {
+    fn from(value: IdentityTypeWeb) -> Self {
+        match value {
+            IdentityTypeWeb::Ident => IdentityType::Ident,
+            IdentityTypeWeb::Anon => IdentityType::Anon,
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SeedPhrase {
+    pub seed_phrase: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IdentityWeb {
+    pub node_id: String,
+    pub name: String,
+    pub email: Option<String>,
+    pub bitcoin_public_key: String,
+    pub npub: String,
+    pub postal_address: OptionalPostalAddressWeb,
+    pub date_of_birth: Option<String>,
+    pub country_of_birth: Option<String>,
+    pub city_of_birth: Option<String>,
+    pub identification_number: Option<String>,
+    pub profile_picture_file: Option<FileWeb>,
+    pub identity_document_file: Option<FileWeb>,
+    pub nostr_relays: Vec<String>,
+}
+
+impl IdentityWeb {
+    pub fn from(identity: Identity, keys: BcrKeys) -> Self {
+        Self {
+            node_id: identity.node_id.clone(),
+            name: identity.name,
+            email: identity.email,
+            bitcoin_public_key: identity.node_id.clone(),
+            npub: keys.get_nostr_npub(),
+            postal_address: identity.postal_address.into(),
+            date_of_birth: identity.date_of_birth,
+            country_of_birth: identity.country_of_birth,
+            city_of_birth: identity.city_of_birth,
+            identification_number: identity.identification_number,
+            profile_picture_file: identity.profile_picture_file.map(|f| f.into()),
+            identity_document_file: identity.identity_document_file.map(|f| f.into()),
+            nostr_relays: identity.nostr_relays,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NewIdentityPayload {
+    pub t: u64,
+    pub name: String,
+    pub email: Option<String>,
+    pub postal_address: OptionalPostalAddressWeb,
+    pub date_of_birth: Option<String>,
+    pub country_of_birth: Option<String>,
+    pub city_of_birth: Option<String>,
+    pub identification_number: Option<String>,
+    pub profile_picture_file_upload_id: Option<String>,
+    pub identity_document_file_upload_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostalAddressWeb {
+    pub country: String,
+    pub city: String,
+    pub zip: Option<String>,
+    pub address: String,
+}
+
+impl From<PostalAddress> for PostalAddressWeb {
+    fn from(val: PostalAddress) -> Self {
+        PostalAddressWeb {
+            country: val.country,
+            city: val.city,
+            zip: val.zip,
+            address: val.address,
+        }
+    }
+}
+
+impl From<PostalAddressWeb> for PostalAddress {
+    fn from(value: PostalAddressWeb) -> Self {
+        Self {
+            country: value.country,
+            city: value.city,
+            zip: value.zip,
+            address: value.address,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptionalPostalAddressWeb {
+    pub country: Option<String>,
+    pub city: Option<String>,
+    pub zip: Option<String>,
+    pub address: Option<String>,
+}
+
+impl OptionalPostalAddressWeb {
+    pub fn is_none(&self) -> bool {
+        self.country.is_none()
+            && self.city.is_none()
+            && self.zip.is_none()
+            && self.address.is_none()
+    }
+}
+
+impl From<OptionalPostalAddress> for OptionalPostalAddressWeb {
+    fn from(value: OptionalPostalAddress) -> Self {
+        Self {
+            country: value.country,
+            city: value.city,
+            zip: value.zip,
+            address: value.address,
+        }
+    }
+}
+
+impl From<OptionalPostalAddressWeb> for OptionalPostalAddress {
+    fn from(value: OptionalPostalAddressWeb) -> Self {
+        Self {
+            country: value.country,
+            city: value.city,
+            zip: value.zip,
+            address: value.address,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileWeb {
+    pub name: String,
+    pub hash: String,
+}
+
+impl From<File> for FileWeb {
+    fn from(val: File) -> Self {
+        FileWeb {
+            name: val.name,
+            hash: val.hash,
+        }
+    }
+}

--- a/crates/bcr-wdc-ebill-service/src/lib.rs
+++ b/crates/bcr-wdc-ebill-service/src/lib.rs
@@ -125,7 +125,7 @@ pub fn routes(ctrl: AppController) -> Router {
         .route("/identity/detail", get(web::get_identity))
         .route("/identity/create", post(web::create_identity))
         .route("/identity/seed/backup", get(web::get_seed_phrase))
-        .route("/identity/seed/restore", put(web::recover_from_seed_phrase))
+        .route("/identity/seed/recover", put(web::recover_from_seed_phrase))
         .route("/contact/create", post(web::create_contact))
         .route("/bill/list", get(web::get_bills))
         .route("/bill/detail/{bill_id}", get(web::get_bill_detail))

--- a/crates/bcr-wdc-ebill-service/src/lib.rs
+++ b/crates/bcr-wdc-ebill-service/src/lib.rs
@@ -1,7 +1,11 @@
 // ----- standard library imports
 use std::sync::Arc;
 // ----- extra library imports
-use axum::{extract::FromRef, routing::get, Router};
+use axum::{
+    extract::FromRef,
+    routing::{get, post, put},
+    Router,
+};
 use bcr_ebill_api::{
     external::bitcoin::BitcoinClient,
     service::{
@@ -15,7 +19,10 @@ use bcr_ebill_api::{
 };
 use bcr_ebill_transport::{NotificationServiceApi, PushApi, PushService};
 // ----- local modules
+mod bill;
+mod contact;
 mod error;
+mod identity;
 mod web;
 // ----- end imports
 
@@ -115,6 +122,18 @@ impl AppController {
 
 pub fn routes(ctrl: AppController) -> Router {
     Router::new()
-        .route("/test", get(web::test))
+        .route("/identity/detail", get(web::get_identity))
+        .route("/identity/create", post(web::create_identity))
+        .route("/identity/seed/backup", get(web::get_seed_phrase))
+        .route("/identity/seed/restore", put(web::recover_from_seed_phrase))
+        .route("/contact/create", post(web::create_contact))
+        .route("/bill/list", get(web::get_bills))
+        .route("/bill/detail/{bill_id}", get(web::get_bill_detail))
+        .route(
+            "/bill/attachment/{bill_id}/{file_name}",
+            get(web::get_bill_attachment),
+        )
+        .route("/bill/request_to_pay", put(web::request_to_pay_bill))
+        .route("/bill/bitcoin_key/{bill_id}", get(web::bill_bitcoin_key))
         .with_state(ctrl)
 }

--- a/crates/bcr-wdc-ebill-service/src/web.rs
+++ b/crates/bcr-wdc-ebill-service/src/web.rs
@@ -1,24 +1,215 @@
 // ----- standard library imports
 // ----- extra library imports
-use axum::{extract::State, Json};
-use tracing::{error, info};
+use axum::{
+    extract::{Path, State},
+    http::{header, HeaderMap, HeaderValue},
+    response::IntoResponse,
+    Json,
+};
+use bcr_ebill_api::{
+    data::{
+        bill::BillAction,
+        contact::{BillIdentParticipant, BillParticipant, ContactType},
+        identity::{IdentityType, IdentityWithAll},
+        OptionalPostalAddress, PostalAddress,
+    },
+    util::{self, file::detect_content_type_for_bytes, ValidationError},
+};
 // ----- local imports
-use crate::{error::Result, AppController};
+use crate::{
+    bill::{
+        BillCombinedBitcoinKeyWeb, BillsResponse, BitcreditBillWeb,
+        RequestToPayBitcreditBillPayload,
+    },
+    contact::{ContactTypeWeb, ContactWeb, NewContactPayload},
+    error::Result,
+    identity::{IdentityTypeWeb, IdentityWeb, NewIdentityPayload, SeedPhrase},
+    AppController,
+};
 // ----- end imports
 
 #[derive(Debug, Clone, serde::Serialize)]
-pub struct TestResponse {
-    ok: bool,
+pub struct SuccessResponse {
+    pub success: bool,
 }
 
-pub async fn test(State(ctrl): State<AppController>) -> Result<Json<TestResponse>> {
-    match ctrl.identity_service.identity_exists().await {
-        true => {
-            info!("Identity exists");
-        }
-        false => {
-            error!("No Identity found");
-        }
+impl SuccessResponse {
+    pub fn new() -> Self {
+        Self { success: true }
+    }
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn get_seed_phrase(State(ctrl): State<AppController>) -> Result<Json<SeedPhrase>> {
+    tracing::debug!("Received get seed phrase request");
+    let seed_phrase = ctrl.identity_service.get_seedphrase().await?;
+    Ok(Json(SeedPhrase { seed_phrase }))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl, payload))]
+pub async fn recover_from_seed_phrase(
+    State(ctrl): State<AppController>,
+    Json(payload): Json<SeedPhrase>,
+) -> Result<Json<SuccessResponse>> {
+    tracing::debug!("Received restore from seed phrase request");
+    ctrl.identity_service
+        .recover_from_seedphrase(&payload.seed_phrase)
+        .await?;
+    Ok(Json(SuccessResponse::new()))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn get_identity(State(ctrl): State<AppController>) -> Result<Json<IdentityWeb>> {
+    tracing::debug!("Received get identity request");
+    let my_identity = if !ctrl.identity_service.identity_exists().await {
+        return Err(bcr_ebill_api::service::Error::NotFound.into());
+    } else {
+        let full_identity = ctrl.identity_service.get_full_identity().await?;
+        IdentityWeb::from(full_identity.identity, full_identity.key_pair)
     };
-    Ok(Json(TestResponse { ok: true }))
+    Ok(Json(my_identity))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl, payload))]
+pub async fn create_identity(
+    State(ctrl): State<AppController>,
+    Json(payload): Json<NewIdentityPayload>,
+) -> Result<Json<SuccessResponse>> {
+    tracing::debug!("Received create identity request");
+    let current_timestamp = util::date::now().timestamp() as u64;
+    ctrl.identity_service
+        .create_identity(
+            IdentityType::from(IdentityTypeWeb::try_from(payload.t)?),
+            payload.name,
+            payload.email,
+            OptionalPostalAddress::from(payload.postal_address),
+            payload.date_of_birth,
+            payload.country_of_birth,
+            payload.city_of_birth,
+            payload.identification_number,
+            payload.profile_picture_file_upload_id,
+            payload.identity_document_file_upload_id,
+            current_timestamp,
+        )
+        .await?;
+    Ok(Json(SuccessResponse::new()))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn get_bills(
+    State(ctrl): State<AppController>,
+) -> Result<Json<BillsResponse<BitcreditBillWeb>>> {
+    tracing::debug!("Received get bills request");
+    let identity = ctrl.identity_service.get_identity().await?;
+    let bills = ctrl.bill_service.get_bills(&identity.node_id).await?;
+    Ok(Json(BillsResponse {
+        bills: bills.into_iter().map(|b| b.into()).collect(),
+    }))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn get_bill_detail(
+    State(ctrl): State<AppController>,
+    Path(bill_id): Path<String>,
+) -> Result<Json<BitcreditBillWeb>> {
+    tracing::debug!("Received get bill detail request");
+    let current_timestamp = util::date::now().timestamp() as u64;
+    let identity = ctrl.identity_service.get_identity().await?;
+    let bill_detail = ctrl
+        .bill_service
+        .get_detail(&bill_id, &identity, &identity.node_id, current_timestamp)
+        .await?;
+    Ok(Json(bill_detail.into()))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn get_bill_attachment(
+    State(ctrl): State<AppController>,
+    Path(bill_id): Path<String>,
+    Path(file_name): Path<String>,
+) -> Result<impl IntoResponse> {
+    tracing::debug!("Received get bill attachment request");
+    let keys = ctrl.bill_service.get_bill_keys(&bill_id).await?;
+    let file_bytes = ctrl
+        .bill_service
+        .open_and_decrypt_attached_file(&bill_id, &file_name, &keys.private_key)
+        .await
+        .map_err(|_| bcr_ebill_api::service::Error::NotFound)?;
+
+    let content_type = detect_content_type_for_bytes(&file_bytes).ok_or(
+        bcr_ebill_api::service::Error::Validation(ValidationError::InvalidContentType),
+    )?;
+    let parsed_content_type: HeaderValue = content_type.parse().map_err(|_| {
+        bcr_ebill_api::service::Error::Validation(ValidationError::InvalidContentType)
+    })?;
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, parsed_content_type);
+
+    Ok((headers, file_bytes))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn request_to_pay_bill(
+    State(ctrl): State<AppController>,
+    Json(request_to_pay_bill_payload): Json<RequestToPayBitcreditBillPayload>,
+) -> Result<Json<SuccessResponse>> {
+    tracing::debug!("Received request to pay bill request");
+    let current_timestamp = util::date::now().timestamp() as u64;
+    let IdentityWithAll { identity, key_pair } = ctrl.identity_service.get_full_identity().await?;
+
+    ctrl.bill_service
+        .execute_bill_action(
+            &request_to_pay_bill_payload.bill_id,
+            BillAction::RequestToPay(request_to_pay_bill_payload.currency.clone()),
+            &BillParticipant::Ident(BillIdentParticipant::new(identity)?),
+            &key_pair,
+            current_timestamp,
+        )
+        .await?;
+
+    Ok(Json(SuccessResponse::new()))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn bill_bitcoin_key(
+    State(ctrl): State<AppController>,
+    Path(bill_id): Path<String>,
+) -> Result<Json<BillCombinedBitcoinKeyWeb>> {
+    tracing::debug!("Received get bill bitcoin private key request");
+    let IdentityWithAll { identity, key_pair } = ctrl.identity_service.get_full_identity().await?;
+    let combined_key = ctrl
+        .bill_service
+        .get_combined_bitcoin_key_for_bill(
+            &bill_id,
+            &BillParticipant::Ident(BillIdentParticipant::new(identity)?),
+            &key_pair,
+        )
+        .await?;
+    Ok(Json(combined_key.into()))
+}
+
+// TODO: remove this, once we don't need to manually add contacts anymore for nostr transport to work
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn create_contact(
+    State(ctrl): State<AppController>,
+    Json(payload): Json<NewContactPayload>,
+) -> Result<Json<ContactWeb>> {
+    tracing::debug!("Received create contact request");
+    let contact = ctrl
+        .contact_service
+        .add_contact(
+            &payload.node_id,
+            ContactType::from(ContactTypeWeb::try_from(payload.t)?),
+            payload.name,
+            payload.email,
+            payload.postal_address.map(PostalAddress::from),
+            payload.date_of_birth_or_registration,
+            payload.country_of_birth_or_registration,
+            payload.city_of_birth_or_registration,
+            payload.identification_number,
+            payload.avatar_file_upload_id,
+            payload.proof_document_file_upload_id,
+        )
+        .await?;
+    Ok(Json(contact.into()))
 }

--- a/docker/ebill-service/config.toml
+++ b/docker/ebill-service/config.toml
@@ -9,7 +9,7 @@ database = "ebill"
 [appcfg]
 bitcoin_network = "testnet"
 nostr_relays = ["wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app"]
-esplora_base_url = "https://blockstream.info"
+esplora_base_url = "https://esplora.minibill.tech"
 data_dir = "./"
 job_runner_initial_delay_seconds = 1
 job_runner_check_interval_seconds = 600


### PR DESCRIPTION
Implements the basic API needed for Wildcat. I added the full data models - we can reduce them, once we know exactly what we need.
I didn't add any unit tests, since all the calls are basically just calls into the E-Bill API, which is thoroughly tested.

* Add license to the crate
* Switch to our own block explorer
* Add endpoints and data models for
  * backup seed phrase
  * restore from seed phrase
  * create identity (necessary once, to fill out the restored identity)
  * create contact (necessary for now, since we can only receive blocks from known contacts - this will change in the future
  * get bill detail
  * get bill list
  * get private bitcoin key for bil
  * get attachment files for bill
  * request to pay bill
* Instrument the endpoints
* Added these endpoints to the `Wildcat E-Bill Light Client Web API` postman collection

Next steps:

* Create `bcr-wdc-ebill-client` so other parts of wildcat can interact with the ebill service