### PR TITLE
refactor data models to webapi, implement ebill client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ members = [
     "crates/bcr-wdc-wallet-aggregator",
     "crates/bcr-wdc-ebpp",
     "crates/bcr-wdc-ebill-service",
-    "crates/bcr-wdc-e2e-tests"
+    "crates/bcr-wdc-ebill-client",
+    "crates/bcr-wdc-e2e-tests",
 ]
 
 [workspace.dependencies]
@@ -21,13 +22,16 @@ async-trait = {version = "0.1"}
 axum = {version = "0.8"}
 axum-test = {version = "17"}
 bcr-ebill-core = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.0"}
-bcr-wdc-key-client = { path = "./crates/bcr-wdc-key-client"}
-bcr-wdc-key-service = { path = "./crates/bcr-wdc-key-service"}
-bcr-wdc-swap-client = { path = "./crates/bcr-wdc-swap-client"}
-bcr-wdc-swap-service = { path = "./crates/bcr-wdc-swap-service"}
-bcr-wdc-treasury-client = { path = "./crates/bcr-wdc-treasury-client"}
+bcr-ebill-api = {git = "https://github.com/BitcreditProtocol/E-Bill.git", branch = "406-anonymous-mode"} #temp until it's merged and released
+bcr-wdc-key-client = {path = "./crates/bcr-wdc-key-client"}
+bcr-wdc-key-service = {path = "./crates/bcr-wdc-key-service"}
+bcr-wdc-swap-client = {path = "./crates/bcr-wdc-swap-client"}
+bcr-wdc-swap-service = {path = "./crates/bcr-wdc-swap-service"}
+bcr-wdc-treasury-client = {path = "./crates/bcr-wdc-treasury-client"}
 bcr-wdc-utils = {path = "./crates/bcr-wdc-utils"}
 bcr-wdc-webapi = {path = "./crates/bcr-wdc-webapi"}
+bcr-wdc-ebill-service = {path = "./crates/bcr-wdc-ebill-service"}
+bcr-wdc-ebill-client = {path = "./crates/bcr-wdc-ebill-client"}
 bdk_wallet = {version = "1.1"}
 bip39 = {version = "2"}
 bitcoin = {version = "0.32"}
@@ -43,11 +47,12 @@ futures = {version = "0.3"}
 itertools = {version = "0.14"}
 mockall = {version = "0.13"}
 rand = {version = "0.8"}
-reqwest = { version = "0.12"}
+reqwest = {version = "0.12"}
 rust_decimal = {version = "1"}
 secp256k1 = {version = "0.29"}
 serde = {version = "1"}
 serde_json = {version = "1"}
+serde_repr = {version= "0.1"}
 strum = {version = "0"}
 surrealdb = {version = "2.2"}
 thiserror = {version = "2"}

--- a/crates/bcr-wdc-ebill-client/Cargo.toml
+++ b/crates/bcr-wdc-ebill-client/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bcr-wdc-ebill-client"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+reqwest = {workspace = true, features = ["json"]}
+thiserror.workspace = true
+bcr-wdc-webapi.workspace = true

--- a/crates/bcr-wdc-ebill-client/src/lib.rs
+++ b/crates/bcr-wdc-ebill-client/src/lib.rs
@@ -118,7 +118,7 @@ impl EbillClient {
     pub async fn get_bill(&self, bill_id: &str) -> Result<BitcreditBill> {
         let url = self
             .base
-            .join(&format!("/bill/detail/{}", bill_id))
+            .join(&format!("/bill/detail/{bill_id}"))
             .expect("bill detail relative path");
         let res = self.cl.get(url).send().await?;
         if res.status() == reqwest::StatusCode::NOT_FOUND {
@@ -136,14 +136,11 @@ impl EbillClient {
     ) -> Result<(String, Vec<u8>)> {
         let url = self
             .base
-            .join(&format!("/bill/attachment/{}/{}", bill_id, file_name))
+            .join(&format!("/bill/attachment/{bill_id}/{file_name}"))
             .expect("bill attachment relative path");
         let res = self.cl.get(url).send().await?;
         if res.status() == reqwest::StatusCode::NOT_FOUND {
-            return Err(Error::ResourceNotFound(format!(
-                "{} - {}",
-                bill_id, file_name
-            )));
+            return Err(Error::ResourceNotFound(format!("{bill_id} - {file_name}",)));
         }
         let content_type: String = match res.headers().get(header::CONTENT_TYPE).map(|h| h.to_str())
         {
@@ -160,7 +157,7 @@ impl EbillClient {
     ) -> Result<BillCombinedBitcoinKey> {
         let url = self
             .base
-            .join(&format!("/bill/bitcoin_key/{}", bill_id))
+            .join(&format!("/bill/bitcoin_key/{bill_id}"))
             .expect("bill bitcoin key relative path");
         let res = self.cl.get(url).send().await?;
         if res.status() == reqwest::StatusCode::NOT_FOUND {

--- a/crates/bcr-wdc-ebill-service/Cargo.toml
+++ b/crates/bcr-wdc-ebill-service/Cargo.toml
@@ -6,8 +6,9 @@ license = "MIT"
 
 [dependencies]
 axum = {workspace = true, features = ["macros"]}
-bcr-ebill-api = {git = "https://github.com/BitcreditProtocol/E-Bill.git", branch = "406-anonymous-mode"} #temp until it's merged and released
+bcr-ebill-api = {workspace = true} 
 bcr-ebill-transport = {git = "https://github.com/BitcreditProtocol/E-Bill.git", branch = "406-anonymous-mode"} #temp until it's merged and released
+bcr-wdc-webapi.workspace = true
 config.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -19,5 +20,5 @@ bitcoin = {workspace = true, features = ["serde"]}
 tracing-subscriber = {workspace = true, features = ["serde"]}
 url = {workspace = true, features = ["serde"]}
 bip39 = {workspace = true, features = ["serde"]}
+serde_repr.workspace = true 
 rustls = "0.23"
-serde_repr = "0.1"

--- a/crates/bcr-wdc-ebill-service/src/error.rs
+++ b/crates/bcr-wdc-ebill-service/src/error.rs
@@ -27,14 +27,6 @@ pub enum Error {
     #[error("Validation error: {0}")]
     Validation(#[from] bcr_ebill_api::util::ValidationError),
 
-    /// all errors originating from invalid URLs
-    #[error("Invalid URL")]
-    InvalidUrl,
-
-    /// all errors originating from invalid bitcoin keys
-    #[error("Invalid bitcoin key")]
-    InvalidBitcoinKey,
-
     /// all errors originating from creating an identity, if an identity already exists
     #[error("Identity already exists")]
     IdentityAlreadyExists,
@@ -42,6 +34,10 @@ pub enum Error {
     /// all errors originating from invalid mnemonics
     #[error("Invalid Mnemonic")]
     InvalidMnemonic,
+
+    /// all errors originating from identity conversion
+    #[error("Invalid identity")]
+    IdentityConversion,
 }
 
 impl axum::response::IntoResponse for Error {
@@ -52,12 +48,11 @@ impl axum::response::IntoResponse for Error {
             Error::BillService(e) => BillServiceError(e).into_response(),
             Error::NotificationService(e) => ServiceError(e.into()).into_response(),
             Error::Validation(e) => ValidationError(e).into_response(),
-            Error::InvalidUrl => {
-                (StatusCode::BAD_REQUEST, String::from("invalid URL")).into_response()
-            }
-            Error::InvalidBitcoinKey => {
-                (StatusCode::BAD_REQUEST, String::from("invalid Bitcoin Key")).into_response()
-            }
+            Error::IdentityConversion => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                String::from("invalid identity"),
+            )
+                .into_response(),
             Error::InvalidMnemonic => (
                 StatusCode::BAD_REQUEST,
                 String::from("invalid bip39 mnemonic"),

--- a/crates/bcr-wdc-ebill-service/src/lib.rs
+++ b/crates/bcr-wdc-ebill-service/src/lib.rs
@@ -19,10 +19,7 @@ use bcr_ebill_api::{
 };
 use bcr_ebill_transport::{NotificationServiceApi, PushApi, PushService};
 // ----- local modules
-mod bill;
-mod contact;
 mod error;
-mod identity;
 mod web;
 // ----- end imports
 

--- a/crates/bcr-wdc-webapi/Cargo.toml
+++ b/crates/bcr-wdc-webapi/Cargo.toml
@@ -17,6 +17,7 @@ required-features = ["test-utils"]
 [dependencies]
 bcr-ebill-core.workspace = true
 bcr-wdc-utils = {workspace = true, features = ["test-utils"] }
+bcr-ebill-api.workspace = true
 bdk_wallet = {workspace = true}
 bitcoin.workspace = true
 borsh = {workspace = true, features = ["derive"]}
@@ -28,6 +29,11 @@ serde.workspace = true
 strum = {workspace = true, features = ["derive"]}
 utoipa = {workspace = true, features = ["chrono", "uuid", "decimal"]}
 uuid = {workspace = true, features = ["serde"]}
+bip39 = {workspace = true, features = ["serde"]}
+serde_json.workspace = true
+serde_repr.workspace = true 
+url = {workspace = true, features = ["serde"]}
+thiserror.workspace = true
 
 [features]
 default = []

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -1,43 +1,34 @@
 // ----- standard library imports
 // ----- extra library imports
 use bcr_ebill_api::{
-    data::{
-        bill::{
-            BillAcceptanceStatus, BillCombinedBitcoinKey, BillCurrentWaitingState, BillData,
-            BillParticipants, BillPaymentStatus, BillRecourseStatus, BillSellStatus, BillStatus,
-            BillWaitingForPaymentState, BillWaitingForRecourseState, BillWaitingForSellState,
-            BitcreditBillResult,
-        },
-        contact::{BillAnonParticipant, BillIdentParticipant, BillParticipant},
-        notification::{Notification, NotificationType},
-    },
+    data::{bill, contact, notification},
     util::date::DateTimeUtc,
 };
 use serde::{Deserialize, Serialize};
 // ----- local imports
 use crate::{
-    contact::ContactTypeWeb,
-    identity::{FileWeb, PostalAddressWeb},
+    contact::ContactType,
+    identity::{File, PostalAddress},
 };
 // ----- end imports
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BillsResponse<T: Serialize> {
     pub bills: Vec<T>,
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BitcreditBillWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BitcreditBill {
     pub id: String,
-    pub participants: BillParticipantsWeb,
-    pub data: BillDataWeb,
-    pub status: BillStatusWeb,
-    pub current_waiting_state: Option<BillCurrentWaitingStateWeb>,
+    pub participants: BillParticipants,
+    pub data: BillData,
+    pub status: BillStatus,
+    pub current_waiting_state: Option<BillCurrentWaitingState>,
 }
 
-impl From<BitcreditBillResult> for BitcreditBillWeb {
-    fn from(val: BitcreditBillResult) -> Self {
-        BitcreditBillWeb {
+impl From<bill::BitcreditBillResult> for BitcreditBill {
+    fn from(val: bill::BitcreditBillResult) -> Self {
+        BitcreditBill {
             id: val.id,
             participants: val.participants.into(),
             data: val.data.into(),
@@ -47,32 +38,34 @@ impl From<BitcreditBillResult> for BitcreditBillWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub enum BillCurrentWaitingStateWeb {
-    Sell(BillWaitingForSellStateWeb),
-    Payment(BillWaitingForPaymentStateWeb),
-    Recourse(BillWaitingForRecourseStateWeb),
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum BillCurrentWaitingState {
+    Sell(BillWaitingForSellState),
+    Payment(BillWaitingForPaymentState),
+    Recourse(BillWaitingForRecourseState),
 }
 
-impl From<BillCurrentWaitingState> for BillCurrentWaitingStateWeb {
-    fn from(val: BillCurrentWaitingState) -> Self {
+impl From<bill::BillCurrentWaitingState> for BillCurrentWaitingState {
+    fn from(val: bill::BillCurrentWaitingState) -> Self {
         match val {
-            BillCurrentWaitingState::Sell(state) => BillCurrentWaitingStateWeb::Sell(state.into()),
-            BillCurrentWaitingState::Payment(state) => {
-                BillCurrentWaitingStateWeb::Payment(state.into())
+            bill::BillCurrentWaitingState::Sell(state) => {
+                BillCurrentWaitingState::Sell(state.into())
             }
-            BillCurrentWaitingState::Recourse(state) => {
-                BillCurrentWaitingStateWeb::Recourse(state.into())
+            bill::BillCurrentWaitingState::Payment(state) => {
+                BillCurrentWaitingState::Payment(state.into())
+            }
+            bill::BillCurrentWaitingState::Recourse(state) => {
+                BillCurrentWaitingState::Recourse(state.into())
             }
         }
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillWaitingForSellStateWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillWaitingForSellState {
     pub time_of_request: u64,
-    pub buyer: BillParticipantWeb,
-    pub seller: BillParticipantWeb,
+    pub buyer: BillParticipant,
+    pub seller: BillParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -80,9 +73,9 @@ pub struct BillWaitingForSellStateWeb {
     pub mempool_link_for_address_to_pay: String,
 }
 
-impl From<BillWaitingForSellState> for BillWaitingForSellStateWeb {
-    fn from(val: BillWaitingForSellState) -> Self {
-        BillWaitingForSellStateWeb {
+impl From<bill::BillWaitingForSellState> for BillWaitingForSellState {
+    fn from(val: bill::BillWaitingForSellState) -> Self {
+        BillWaitingForSellState {
             time_of_request: val.time_of_request,
             buyer: val.buyer.into(),
             seller: val.seller.into(),
@@ -95,11 +88,11 @@ impl From<BillWaitingForSellState> for BillWaitingForSellStateWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillWaitingForPaymentStateWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillWaitingForPaymentState {
     pub time_of_request: u64,
-    pub payer: BillIdentParticipantWeb,
-    pub payee: BillParticipantWeb,
+    pub payer: BillIdentParticipant,
+    pub payee: BillParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -107,9 +100,9 @@ pub struct BillWaitingForPaymentStateWeb {
     pub mempool_link_for_address_to_pay: String,
 }
 
-impl From<BillWaitingForPaymentState> for BillWaitingForPaymentStateWeb {
-    fn from(val: BillWaitingForPaymentState) -> Self {
-        BillWaitingForPaymentStateWeb {
+impl From<bill::BillWaitingForPaymentState> for BillWaitingForPaymentState {
+    fn from(val: bill::BillWaitingForPaymentState) -> Self {
+        BillWaitingForPaymentState {
             time_of_request: val.time_of_request,
             payer: val.payer.into(),
             payee: val.payee.into(),
@@ -122,11 +115,11 @@ impl From<BillWaitingForPaymentState> for BillWaitingForPaymentStateWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillWaitingForRecourseStateWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillWaitingForRecourseState {
     pub time_of_request: u64,
-    pub recourser: BillIdentParticipantWeb,
-    pub recoursee: BillIdentParticipantWeb,
+    pub recourser: BillIdentParticipant,
+    pub recoursee: BillIdentParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -134,9 +127,9 @@ pub struct BillWaitingForRecourseStateWeb {
     pub mempool_link_for_address_to_pay: String,
 }
 
-impl From<BillWaitingForRecourseState> for BillWaitingForRecourseStateWeb {
-    fn from(val: BillWaitingForRecourseState) -> Self {
-        BillWaitingForRecourseStateWeb {
+impl From<bill::BillWaitingForRecourseState> for BillWaitingForRecourseState {
+    fn from(val: bill::BillWaitingForRecourseState) -> Self {
+        BillWaitingForRecourseState {
             time_of_request: val.time_of_request,
             recourser: val.recourser.into(),
             recoursee: val.recoursee.into(),
@@ -149,19 +142,19 @@ impl From<BillWaitingForRecourseState> for BillWaitingForRecourseStateWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillStatusWeb {
-    pub acceptance: BillAcceptanceStatusWeb,
-    pub payment: BillPaymentStatusWeb,
-    pub sell: BillSellStatusWeb,
-    pub recourse: BillRecourseStatusWeb,
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillStatus {
+    pub acceptance: BillAcceptanceStatus,
+    pub payment: BillPaymentStatus,
+    pub sell: BillSellStatus,
+    pub recourse: BillRecourseStatus,
     pub redeemed_funds_available: bool,
     pub has_requested_funds: bool,
 }
 
-impl From<BillStatus> for BillStatusWeb {
-    fn from(val: BillStatus) -> Self {
-        BillStatusWeb {
+impl From<bill::BillStatus> for BillStatus {
+    fn from(val: bill::BillStatus) -> Self {
+        BillStatus {
             acceptance: val.acceptance.into(),
             payment: val.payment.into(),
             sell: val.sell.into(),
@@ -172,8 +165,8 @@ impl From<BillStatus> for BillStatusWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillAcceptanceStatusWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillAcceptanceStatus {
     pub time_of_request_to_accept: Option<u64>,
     pub requested_to_accept: bool,
     pub accepted: bool,
@@ -181,9 +174,9 @@ pub struct BillAcceptanceStatusWeb {
     pub rejected_to_accept: bool,
 }
 
-impl From<BillAcceptanceStatus> for BillAcceptanceStatusWeb {
-    fn from(val: BillAcceptanceStatus) -> Self {
-        BillAcceptanceStatusWeb {
+impl From<bill::BillAcceptanceStatus> for BillAcceptanceStatus {
+    fn from(val: bill::BillAcceptanceStatus) -> Self {
+        BillAcceptanceStatus {
             time_of_request_to_accept: val.time_of_request_to_accept,
             requested_to_accept: val.requested_to_accept,
             accepted: val.accepted,
@@ -193,8 +186,8 @@ impl From<BillAcceptanceStatus> for BillAcceptanceStatusWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillPaymentStatusWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillPaymentStatus {
     pub time_of_request_to_pay: Option<u64>,
     pub requested_to_pay: bool,
     pub paid: bool,
@@ -202,9 +195,9 @@ pub struct BillPaymentStatusWeb {
     pub rejected_to_pay: bool,
 }
 
-impl From<BillPaymentStatus> for BillPaymentStatusWeb {
-    fn from(val: BillPaymentStatus) -> Self {
-        BillPaymentStatusWeb {
+impl From<bill::BillPaymentStatus> for BillPaymentStatus {
+    fn from(val: bill::BillPaymentStatus) -> Self {
+        BillPaymentStatus {
             time_of_request_to_pay: val.time_of_request_to_pay,
             requested_to_pay: val.requested_to_pay,
             paid: val.paid,
@@ -214,8 +207,8 @@ impl From<BillPaymentStatus> for BillPaymentStatusWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillSellStatusWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillSellStatus {
     pub time_of_last_offer_to_sell: Option<u64>,
     pub sold: bool,
     pub offered_to_sell: bool,
@@ -223,9 +216,9 @@ pub struct BillSellStatusWeb {
     pub rejected_offer_to_sell: bool,
 }
 
-impl From<BillSellStatus> for BillSellStatusWeb {
-    fn from(val: BillSellStatus) -> Self {
-        BillSellStatusWeb {
+impl From<bill::BillSellStatus> for BillSellStatus {
+    fn from(val: bill::BillSellStatus) -> Self {
+        BillSellStatus {
             time_of_last_offer_to_sell: val.time_of_last_offer_to_sell,
             sold: val.sold,
             offered_to_sell: val.offered_to_sell,
@@ -235,8 +228,8 @@ impl From<BillSellStatus> for BillSellStatusWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillRecourseStatusWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillRecourseStatus {
     pub time_of_last_request_to_recourse: Option<u64>,
     pub recoursed: bool,
     pub requested_to_recourse: bool,
@@ -244,9 +237,9 @@ pub struct BillRecourseStatusWeb {
     pub rejected_request_to_recourse: bool,
 }
 
-impl From<BillRecourseStatus> for BillRecourseStatusWeb {
-    fn from(val: BillRecourseStatus) -> Self {
-        BillRecourseStatusWeb {
+impl From<bill::BillRecourseStatus> for BillRecourseStatus {
+    fn from(val: bill::BillRecourseStatus) -> Self {
+        BillRecourseStatus {
             time_of_last_request_to_recourse: val.time_of_last_request_to_recourse,
             recoursed: val.recoursed,
             requested_to_recourse: val.requested_to_recourse,
@@ -256,8 +249,8 @@ impl From<BillRecourseStatus> for BillRecourseStatusWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillDataWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillData {
     pub language: String,
     pub time_of_drawing: u64,
     pub issue_date: String,
@@ -269,13 +262,13 @@ pub struct BillDataWeb {
     pub city_of_payment: String,
     pub currency: String,
     pub sum: String,
-    pub files: Vec<FileWeb>,
-    pub active_notification: Option<NotificationWeb>,
+    pub files: Vec<File>,
+    pub active_notification: Option<Notification>,
 }
 
-impl From<BillData> for BillDataWeb {
-    fn from(val: BillData) -> Self {
-        BillDataWeb {
+impl From<bill::BillData> for BillData {
+    fn from(val: bill::BillData) -> Self {
+        BillData {
             language: val.language,
             time_of_drawing: val.time_of_drawing,
             issue_date: val.issue_date,
@@ -293,19 +286,19 @@ impl From<BillData> for BillDataWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillParticipantsWeb {
-    pub drawee: BillIdentParticipantWeb,
-    pub drawer: BillIdentParticipantWeb,
-    pub payee: BillParticipantWeb,
-    pub endorsee: Option<BillParticipantWeb>,
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillParticipants {
+    pub drawee: BillIdentParticipant,
+    pub drawer: BillIdentParticipant,
+    pub payee: BillParticipant,
+    pub endorsee: Option<BillParticipant>,
     pub endorsements_count: u64,
     pub all_participant_node_ids: Vec<String>,
 }
 
-impl From<BillParticipants> for BillParticipantsWeb {
-    fn from(val: BillParticipants) -> Self {
-        BillParticipantsWeb {
+impl From<bill::BillParticipants> for BillParticipants {
+    fn from(val: bill::BillParticipants) -> Self {
+        BillParticipants {
             drawee: val.drawee.into(),
             drawer: val.drawer.into(),
             payee: val.payee.into(),
@@ -316,31 +309,31 @@ impl From<BillParticipants> for BillParticipantsWeb {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub enum BillParticipantWeb {
-    Anon(BillAnonParticipantWeb),
-    Ident(BillIdentParticipantWeb),
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum BillParticipant {
+    Anon(BillAnonParticipant),
+    Ident(BillIdentParticipant),
 }
 
-impl From<BillParticipant> for BillParticipantWeb {
-    fn from(val: BillParticipant) -> Self {
+impl From<contact::BillParticipant> for BillParticipant {
+    fn from(val: contact::BillParticipant) -> Self {
         match val {
-            BillParticipant::Ident(data) => BillParticipantWeb::Ident(data.into()),
-            BillParticipant::Anon(data) => BillParticipantWeb::Anon(data.into()),
+            contact::BillParticipant::Ident(data) => BillParticipant::Ident(data.into()),
+            contact::BillParticipant::Anon(data) => BillParticipant::Anon(data.into()),
         }
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
-pub struct BillAnonParticipantWeb {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BillAnonParticipant {
     pub node_id: String,
     pub email: Option<String>,
     pub nostr_relays: Vec<String>,
 }
 
-impl From<BillAnonParticipant> for BillAnonParticipantWeb {
-    fn from(val: BillAnonParticipant) -> Self {
-        BillAnonParticipantWeb {
+impl From<contact::BillAnonParticipant> for BillAnonParticipant {
+    fn from(val: contact::BillAnonParticipant) -> Self {
+        BillAnonParticipant {
             node_id: val.node_id,
             email: val.email,
             nostr_relays: val.nostr_relays,
@@ -349,20 +342,20 @@ impl From<BillAnonParticipant> for BillAnonParticipantWeb {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BillIdentParticipantWeb {
+pub struct BillIdentParticipant {
     #[serde(rename = "type")]
-    pub t: ContactTypeWeb,
+    pub t: ContactType,
     pub node_id: String,
     pub name: String,
     #[serde(flatten)]
-    pub postal_address: PostalAddressWeb,
+    pub postal_address: PostalAddress,
     pub email: Option<String>,
     pub nostr_relays: Vec<String>,
 }
 
-impl From<BillIdentParticipant> for BillIdentParticipantWeb {
-    fn from(val: BillIdentParticipant) -> Self {
-        BillIdentParticipantWeb {
+impl From<contact::BillIdentParticipant> for BillIdentParticipant {
+    fn from(val: contact::BillIdentParticipant) -> Self {
+        BillIdentParticipant {
             t: val.t.into(),
             name: val.name,
             node_id: val.node_id,
@@ -374,10 +367,10 @@ impl From<BillIdentParticipant> for BillIdentParticipantWeb {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NotificationWeb {
+pub struct Notification {
     pub id: String,
     pub node_id: Option<String>,
-    pub notification_type: NotificationTypeWeb,
+    pub notification_type: NotificationType,
     pub reference_id: Option<String>,
     pub description: String,
     pub datetime: DateTimeUtc,
@@ -385,9 +378,9 @@ pub struct NotificationWeb {
     pub payload: Option<serde_json::Value>,
 }
 
-impl From<Notification> for NotificationWeb {
-    fn from(val: Notification) -> Self {
-        NotificationWeb {
+impl From<notification::Notification> for Notification {
+    fn from(val: notification::Notification) -> Self {
+        Notification {
             id: val.id,
             node_id: val.node_id,
             notification_type: val.notification_type.into(),
@@ -401,16 +394,16 @@ impl From<Notification> for NotificationWeb {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum NotificationTypeWeb {
+pub enum NotificationType {
     General,
     Bill,
 }
 
-impl From<NotificationType> for NotificationTypeWeb {
-    fn from(val: NotificationType) -> Self {
+impl From<notification::NotificationType> for NotificationType {
+    fn from(val: notification::NotificationType) -> Self {
         match val {
-            NotificationType::Bill => NotificationTypeWeb::Bill,
-            NotificationType::General => NotificationTypeWeb::General,
+            notification::NotificationType::Bill => NotificationType::Bill,
+            notification::NotificationType::General => NotificationType::General,
         }
     }
 }
@@ -422,13 +415,13 @@ pub struct RequestToPayBitcreditBillPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BillCombinedBitcoinKeyWeb {
+pub struct BillCombinedBitcoinKey {
     pub private_key: String,
 }
 
-impl From<BillCombinedBitcoinKey> for BillCombinedBitcoinKeyWeb {
-    fn from(val: BillCombinedBitcoinKey) -> Self {
-        BillCombinedBitcoinKeyWeb {
+impl From<bill::BillCombinedBitcoinKey> for BillCombinedBitcoinKey {
+    fn from(val: bill::BillCombinedBitcoinKey) -> Self {
+        BillCombinedBitcoinKey {
             private_key: val.private_key,
         }
     }

--- a/crates/bcr-wdc-webapi/src/contact.rs
+++ b/crates/bcr-wdc-webapi/src/contact.rs
@@ -1,58 +1,58 @@
-use bcr_ebill_api::data::contact::{Contact, ContactType};
+use bcr_ebill_api::data::contact;
 // ----- standard library imports
 // ----- extra library imports
 use serde::{Deserialize, Serialize};
 // ----- local modules
-use crate::identity::{FileWeb, PostalAddressWeb};
+use crate::identity::{File, PostalAddress};
 // ----- end imports
 
 #[repr(u8)]
 #[derive(
     Debug, Copy, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq,
 )]
-pub enum ContactTypeWeb {
+pub enum ContactType {
     Person = 0,
     Company = 1,
     Anon = 2,
 }
 
-impl TryFrom<u64> for ContactTypeWeb {
+impl TryFrom<u64> for ContactType {
     type Error = bcr_ebill_api::service::Error;
 
     fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
-        Ok(ContactType::try_from(value)
+        Ok(contact::ContactType::try_from(value)
             .map_err(Self::Error::Validation)?
             .into())
     }
 }
 
-impl From<ContactType> for ContactTypeWeb {
-    fn from(val: ContactType) -> Self {
+impl From<contact::ContactType> for ContactType {
+    fn from(val: contact::ContactType) -> Self {
         match val {
-            ContactType::Person => ContactTypeWeb::Person,
-            ContactType::Company => ContactTypeWeb::Company,
-            ContactType::Anon => ContactTypeWeb::Anon,
+            contact::ContactType::Person => ContactType::Person,
+            contact::ContactType::Company => ContactType::Company,
+            contact::ContactType::Anon => ContactType::Anon,
         }
     }
 }
 
-impl From<ContactTypeWeb> for ContactType {
-    fn from(value: ContactTypeWeb) -> Self {
+impl From<ContactType> for contact::ContactType {
+    fn from(value: ContactType) -> Self {
         match value {
-            ContactTypeWeb::Person => ContactType::Person,
-            ContactTypeWeb::Company => ContactType::Company,
-            ContactTypeWeb::Anon => ContactType::Anon,
+            ContactType::Person => contact::ContactType::Person,
+            ContactType::Company => contact::ContactType::Company,
+            ContactType::Anon => contact::ContactType::Anon,
         }
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NewContactPayload {
     pub t: u64,
     pub node_id: String,
     pub name: String,
     pub email: Option<String>,
-    pub postal_address: Option<PostalAddressWeb>,
+    pub postal_address: Option<PostalAddress>,
     pub date_of_birth_or_registration: Option<String>,
     pub country_of_birth_or_registration: Option<String>,
     pub city_of_birth_or_registration: Option<String>,
@@ -61,25 +61,25 @@ pub struct NewContactPayload {
     pub proof_document_file_upload_id: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
-pub struct ContactWeb {
-    pub t: ContactTypeWeb,
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Contact {
+    pub t: ContactType,
     pub node_id: String,
     pub name: String,
     pub email: Option<String>,
-    pub postal_address: Option<PostalAddressWeb>,
+    pub postal_address: Option<PostalAddress>,
     pub date_of_birth_or_registration: Option<String>,
     pub country_of_birth_or_registration: Option<String>,
     pub city_of_birth_or_registration: Option<String>,
     pub identification_number: Option<String>,
-    pub avatar_file: Option<FileWeb>,
-    pub proof_document_file: Option<FileWeb>,
+    pub avatar_file: Option<File>,
+    pub proof_document_file: Option<File>,
     pub nostr_relays: Vec<String>,
 }
 
-impl From<Contact> for ContactWeb {
-    fn from(val: Contact) -> Self {
-        ContactWeb {
+impl From<contact::Contact> for Contact {
+    fn from(val: contact::Contact) -> Self {
+        Contact {
             t: val.t.into(),
             node_id: val.node_id,
             name: val.name,

--- a/crates/bcr-wdc-webapi/src/lib.rs
+++ b/crates/bcr-wdc-webapi/src/lib.rs
@@ -1,6 +1,9 @@
 // ----- standard library imports
 // ----- extra library imports
 // ----- local modules
+pub mod bill;
+pub mod contact;
+pub mod identity;
 pub mod keys;
 pub mod quotes;
 pub mod signatures;


### PR DESCRIPTION
* Implements a `ebill-client` for the `ebill-service`
* Implements the refactoring of the shared data models to `bcr-wdc-webapi` crate as mentioned [here](https://github.com/BitcreditProtocol/Wildcat/pull/143#pullrequestreview-2827979646)

@codingpeanut157 

I created a local `devtool` similar to `bcr-wdc-webapi` to test the client, but didn't check it in.

I'm not sure how to test this properly - I could replicate the model as in `bcr-wdc-key-service/client` with the `build_test_server`, however it would be a bit clumsy, since I would have to add mocks for all parts of `AppController` and even then, I'm not sure what value these tests would add, since the mocks wouldn't be very flexible. :thinking: 

Do you have any ideas here?