### PR TITLE
[bcr-wdc-key-service] Fix mint verification

### DIFF
--- a/crates/bcr-wdc-key-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-key-service/src/persistence/inmemory.rs
@@ -46,6 +46,7 @@ impl InMemoryMap {
                 return Err(Error::InvalidMintRequest);
             }
             condition.is_minted = true;
+            return Ok(());
         }
         Err(Error::UnknownKeyset(*kid))
     }

--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -214,7 +214,7 @@ where
         if is_minted {
             return Err(Error::InvalidMintRequest);
         }
-        let blinds_sum = outputs.iter().fold(Amount::ZERO, |acc, b| {acc + b.amount});
+        let blinds_sum = outputs.iter().fold(Amount::ZERO, |acc, b| acc + b.amount);
         if blinds_sum != target {
             return Err(Error::InvalidMintRequest);
         }
@@ -235,9 +235,9 @@ mod tests {
     use crate::btc32::DerivationPath;
     use crate::persistence;
     use crate::service;
+    use bcr_wdc_utils::signatures::test_utils::generate_blinds;
     use std::str::FromStr;
     use uuid::Uuid;
-    use bcr_wdc_utils::signatures::test_utils::generate_blinds;
 
     // Helper function to setup test service
     async fn setup_test_service() -> (TestKeysService, cdk02::Id, Uuid) {

--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -214,8 +214,8 @@ where
         if is_minted {
             return Err(Error::InvalidMintRequest);
         }
-        let blind_sum = outputs.iter().map(|o| u64::from(o.amount)).sum::<u64>();
-        if blind_sum != u64::from(target) {
+        let blinds_sum = outputs.iter().fold(Amount::ZERO, |acc, b| {acc + b.amount});
+        if blinds_sum != target {
             return Err(Error::InvalidMintRequest);
         }
 

--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -237,21 +237,7 @@ mod tests {
     use crate::service;
     use std::str::FromStr;
     use uuid::Uuid;
-
-    // Helper function to generate blinded messages
-    fn generate_blinds(
-        keyset_id: cdk02::Id,
-        amounts: &[Amount],
-    ) -> Vec<(
-        cashu::BlindedMessage,
-        cashu::secret::Secret,
-        cashu::SecretKey,
-    )> {
-        amounts
-            .iter()
-            .map(|amount| bcr_wdc_utils::keys::test_utils::generate_blind(keyset_id, *amount))
-            .collect()
-    }
+    use bcr_wdc_utils::signatures::test_utils::generate_blinds;
 
     // Helper function to setup test service
     async fn setup_test_service() -> (TestKeysService, cdk02::Id, Uuid) {

--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -294,9 +294,9 @@ mod tests {
 
         let outputs = generate_blinds(kid, &[Amount::from(128), Amount::from(64)]);
         let blinds = outputs.iter().map(|o| o.0.clone()).collect::<Vec<_>>();
-        
+
         let signatures = service.mint(qid, blinds).await.unwrap();
-        
+
         assert_eq!(signatures.len(), 2, "Should have 2 signatures");
         assert_eq!(
             signatures.iter().map(|s| u64::from(s.amount)).sum::<u64>(),
@@ -310,8 +310,11 @@ mod tests {
         let (service, kid, qid) = setup_test_service().await;
         let outputs = generate_blinds(kid, &[Amount::from(128), Amount::from(64), Amount::from(1)]);
         let blinds = outputs.iter().map(|o| o.0.clone()).collect::<Vec<_>>();
-        
-        assert!(service.mint(qid, blinds).await.is_err(), "Mint should fail with invalid amount");
+
+        assert!(
+            service.mint(qid, blinds).await.is_err(),
+            "Mint should fail with invalid amount"
+        );
     }
 
     #[tokio::test]
@@ -319,7 +322,10 @@ mod tests {
         let (service, kid, qid) = setup_test_service().await;
         let outputs = generate_blinds(kid, &[Amount::from(128), Amount::from(32)]);
         let blinds = outputs.iter().map(|o| o.0.clone()).collect::<Vec<_>>();
-        
-        assert!(service.mint(qid, blinds).await.is_err(), "Mint should fail with invalid amount");
+
+        assert!(
+            service.mint(qid, blinds).await.is_err(),
+            "Mint should fail with invalid amount"
+        );
     }
 }

--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -228,3 +228,111 @@ where
         Ok(signatures)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::btc32::DerivationPath;
+    use crate::persistence;
+    use crate::service;
+    use std::str::FromStr;
+    use uuid::Uuid;
+
+    pub fn generate_blinds(
+        keyset_id: cdk02::Id,
+        amounts: &[Amount],
+    ) -> Vec<(
+        cashu::BlindedMessage,
+        cashu::secret::Secret,
+        cashu::SecretKey,
+    )> {
+        let mut blinds = Vec::new();
+        for amount in amounts {
+            let blind = bcr_wdc_utils::keys::test_utils::generate_blind(keyset_id, *amount);
+            blinds.push(blind);
+        }
+        blinds
+    }
+
+    #[tokio::test]
+    async fn test_mint_success() {
+        // Setup
+        let seed = bip39::Mnemonic::from_str("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").unwrap().to_seed("");
+        let maturity = chrono::DateTime::parse_from_rfc3339("2029-01-01T00:00:00Z")
+            .unwrap()
+            .to_utc();
+        let factory = Factory::new(&seed, DerivationPath::default());
+
+        pub type TestQuoteKeysRepository = persistence::inmemory::InMemoryQuoteKeyMap;
+        pub type TestKeysRepository = persistence::inmemory::InMemoryMap;
+        pub type TestKeysService = service::Service<TestQuoteKeysRepository, TestKeysRepository>;
+
+        let service = TestKeysService {
+            quote_keys: TestQuoteKeysRepository::default(),
+            keys: TestKeysRepository::default(),
+            keygen: factory,
+        };
+
+        let kp = bcr_wdc_utils::keys::test_utils::generate_random_keypair();
+        let pub_key = kp.public_key();
+        let target = Amount::from(192);
+
+        let qid = Uuid::new_v4();
+        let kid = service
+            .generate_keyset(qid, target, pub_key.into(), maturity)
+            .await
+            .unwrap();
+
+        service.activate(&qid).await.unwrap();
+        let _ = service.authorized_public_key_to_mint(kid).await.unwrap();
+
+        let outputs = generate_blinds(kid, &[Amount::from(128), Amount::from(64)]);
+        let blinds = outputs.iter().map(|o| o.0.clone()).collect::<Vec<_>>();
+        let result = service.mint(qid, blinds).await;
+        assert!(result.is_ok(), "Mint should succeed");
+        let signatures = result.unwrap();
+
+        let total = signatures.iter().map(|s| u64::from(s.amount)).sum::<u64>();
+        assert_eq!(total, 192, "Total amount should match target");
+
+        assert_eq!(signatures.len(), 2, "Should have 2 signatures");
+    }
+
+    #[tokio::test]
+    async fn test_mint_different() {
+        // Setup
+        let seed = bip39::Mnemonic::from_str("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").unwrap().to_seed("");
+        let maturity = chrono::DateTime::parse_from_rfc3339("2029-01-01T00:00:00Z")
+            .unwrap()
+            .to_utc();
+        let factory = Factory::new(&seed, DerivationPath::default());
+
+        pub type TestQuoteKeysRepository = persistence::inmemory::InMemoryQuoteKeyMap;
+        pub type TestKeysRepository = persistence::inmemory::InMemoryMap;
+        pub type TestKeysService = service::Service<TestQuoteKeysRepository, TestKeysRepository>;
+
+        let service = TestKeysService {
+            quote_keys: TestQuoteKeysRepository::default(),
+            keys: TestKeysRepository::default(),
+            keygen: factory,
+        };
+
+        let kp = bcr_wdc_utils::keys::test_utils::generate_random_keypair();
+        let pub_key = kp.public_key();
+        let target = Amount::from(192);
+
+        let qid = Uuid::new_v4();
+        let kid = service
+            .generate_keyset(qid, target, pub_key.into(), maturity)
+            .await
+            .unwrap();
+        service.activate(&qid).await.unwrap();
+
+        let _ = service.authorized_public_key_to_mint(kid).await.unwrap();
+
+        let outputs = generate_blinds(kid, &[Amount::from(128), Amount::from(64), Amount::from(1)]);
+        let blinds = outputs.iter().map(|o| o.0.clone()).collect::<Vec<_>>();
+        let result = service.mint(qid, blinds).await;
+        assert!(result.is_err(), "Mint should fail");
+    }
+}

--- a/crates/bcr-wdc-quote-service/src/service.rs
+++ b/crates/bcr-wdc-quote-service/src/service.rs
@@ -270,7 +270,7 @@ where
         let maturity_date = quote.bill.maturity_date;
         let kid = self
             .keys_hndlr
-            .generate(qid, quote.bill.sum, public_key, maturity_date)
+            .generate(qid, discounted, public_key, maturity_date)
             .await?;
 
         let (request_id, fees_blinds) = self.wallet.get_blinds(kid, fees).await?;

--- a/crates/bcr-wdc-swap-client/tests/swap.rs
+++ b/crates/bcr-wdc-swap-client/tests/swap.rs
@@ -28,7 +28,7 @@ async fn swap() {
         .expect("store");
 
     let amounts = vec![Amount::from(8_u64)];
-    let blinds = signatures_test::generate_blinds(&keys_entry.1, &amounts)
+    let blinds = signatures_test::generate_blinds(keys_entry.1.id, &amounts)
         .into_iter()
         .map(|bbb| bbb.0)
         .collect();
@@ -120,7 +120,7 @@ async fn swap_p2pk() {
     // Swap 2,2,4 proofs into a single 8 blinded message
     let single_amount = [Amount::from(8)];
     let blinds: Vec<cashu::BlindedMessage> =
-        signatures_test::generate_blinds(&mint_keyset, &single_amount)
+        signatures_test::generate_blinds(mint_keyset.id, &single_amount)
             .into_iter()
             .map(|bbb| bbb.0)
             .collect();

--- a/crates/bcr-wdc-swap-service/src/service.rs
+++ b/crates/bcr-wdc-swap-service/src/service.rs
@@ -149,7 +149,7 @@ mod tests {
         let signatures =
             signatures_test::generate_signatures(&keyset, vec![Amount::from(8)].as_slice());
         let outputs: Vec<_> =
-            signatures_test::generate_blinds(&keyset, vec![Amount::from(8)].as_slice())
+            signatures_test::generate_blinds(keyset.id, vec![Amount::from(8)].as_slice())
                 .into_iter()
                 .map(|a| a.0)
                 .collect();
@@ -183,7 +183,7 @@ mod tests {
         let kid = keyset.id;
         let inputs = signatures_test::generate_proofs(&keyset, vec![Amount::from(8)].as_slice());
         let outputs: Vec<_> =
-            signatures_test::generate_blinds(&keyset, vec![Amount::from(8)].as_slice())
+            signatures_test::generate_blinds(keyset.id, vec![Amount::from(8)].as_slice())
                 .into_iter()
                 .map(|a| a.0)
                 .collect();
@@ -212,7 +212,7 @@ mod tests {
             signatures_test::generate_proofs(&keyset, vec![Amount::from(8)].as_slice());
         inputs.get_mut(0).unwrap().c = keys_test::publics()[0];
         let outputs: Vec<_> =
-            signatures_test::generate_blinds(&keyset, vec![Amount::from(8)].as_slice())
+            signatures_test::generate_blinds(keyset.id, vec![Amount::from(8)].as_slice())
                 .into_iter()
                 .map(|a| a.0)
                 .collect();
@@ -244,7 +244,7 @@ mod tests {
         let signatures =
             signatures_test::generate_signatures(&keyset, vec![Amount::from(8)].as_slice());
         let outputs: Vec<_> =
-            signatures_test::generate_blinds(&keyset, vec![Amount::from(16)].as_slice())
+            signatures_test::generate_blinds(keyset.id, vec![Amount::from(16)].as_slice())
                 .into_iter()
                 .map(|a| a.0)
                 .collect();
@@ -276,7 +276,7 @@ mod tests {
         let amounts = vec![Amount::from(4), Amount::from(4)];
         let inputs = signatures_test::generate_proofs(&keyset, vec![Amount::from(8)].as_slice());
         let signatures = signatures_test::generate_signatures(&keyset, &amounts);
-        let outputs: Vec<_> = signatures_test::generate_blinds(&keyset, &amounts)
+        let outputs: Vec<_> = signatures_test::generate_blinds(keyset.id, &amounts)
             .into_iter()
             .map(|a| a.0)
             .collect();
@@ -327,7 +327,7 @@ mod tests {
         );
         let amounts = vec![Amount::from(8)];
         let signatures = signatures_test::generate_signatures(&keyset, &amounts);
-        let outputs: Vec<_> = signatures_test::generate_blinds(&keyset, &amounts)
+        let outputs: Vec<_> = signatures_test::generate_blinds(keyset.id, &amounts)
             .into_iter()
             .map(|a| a.0)
             .collect();

--- a/crates/bcr-wdc-treasury-service/src/credit/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/credit/mod.rs
@@ -223,7 +223,7 @@ mod tests {
         let (info, keyset) = keys_utils::generate_random_keyset();
 
         let (blinds, secrets, _): (Vec<_>, Vec<_>, Vec<_>) =
-            signatures_test::generate_blinds(&keyset, &[Amount::from(16)])
+            signatures_test::generate_blinds(keyset.id, &[Amount::from(16)])
                 .into_iter()
                 .map(|(b, s, k)| {
                     (

--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -179,7 +179,7 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &vec![Amount::from(8_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(8_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();
@@ -219,7 +219,7 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &vec![Amount::from(16_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();
@@ -253,7 +253,7 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &vec![Amount::from(16_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();
@@ -278,7 +278,7 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &vec![Amount::from(16_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();

--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -179,10 +179,11 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(8_u64)])
-            .into_iter()
-            .map(|b| b.0)
-            .collect();
+        let blinds: Vec<_> =
+            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(8_u64)])
+                .into_iter()
+                .map(|b| b.0)
+                .collect();
 
         service.redeem(&[], &blinds).await.unwrap_err();
     }
@@ -219,10 +220,11 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
-            .into_iter()
-            .map(|b| b.0)
-            .collect();
+        let blinds: Vec<_> =
+            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
+                .into_iter()
+                .map(|b| b.0)
+                .collect();
 
         service.redeem(&proofs, &blinds).await.unwrap_err();
     }
@@ -253,10 +255,11 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
-            .into_iter()
-            .map(|b| b.0)
-            .collect();
+        let blinds: Vec<_> =
+            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
+                .into_iter()
+                .map(|b| b.0)
+                .collect();
 
         service.redeem(&proofs, &blinds).await.unwrap_err();
     }
@@ -278,10 +281,11 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
-            .into_iter()
-            .map(|b| b.0)
-            .collect();
+        let blinds: Vec<_> =
+            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
+                .into_iter()
+                .map(|b| b.0)
+                .collect();
 
         service.redeem(&proofs, &blinds).await.unwrap_err();
     }

--- a/crates/bcr-wdc-utils/src/signatures.rs
+++ b/crates/bcr-wdc-utils/src/signatures.rs
@@ -74,7 +74,7 @@ pub mod test_utils {
     }
 
     pub fn generate_blinds(
-        id : Id,
+        id: Id,
         amounts: &[Amount],
     ) -> Vec<(cdk00::BlindedMessage, secret::Secret, cdk01::SecretKey)> {
         let mut blinds: Vec<(cdk00::BlindedMessage, secret::Secret, cdk01::SecretKey)> = Vec::new();

--- a/crates/bcr-wdc-utils/src/signatures.rs
+++ b/crates/bcr-wdc-utils/src/signatures.rs
@@ -57,7 +57,7 @@ pub fn basic_proofs_checks(proofs: &[cdk00::Proof]) -> ChecksResult<()> {
 pub mod test_utils {
     use super::*;
     use crate::keys::test_utils::{generate_blind, publics};
-    use cashu::{dhke, secret};
+    use cashu::{dhke, secret, Id};
 
     pub fn generate_proofs(keyset: &cdk02::MintKeySet, amounts: &[Amount]) -> Vec<cdk00::Proof> {
         let mut proofs: Vec<cdk00::Proof> = Vec::new();
@@ -74,12 +74,12 @@ pub mod test_utils {
     }
 
     pub fn generate_blinds(
-        keyset: &cdk02::MintKeySet,
+        id : Id,
         amounts: &[Amount],
     ) -> Vec<(cdk00::BlindedMessage, secret::Secret, cdk01::SecretKey)> {
         let mut blinds: Vec<(cdk00::BlindedMessage, secret::Secret, cdk01::SecretKey)> = Vec::new();
         for amount in amounts {
-            blinds.push(generate_blind(keyset.id, *amount));
+            blinds.push(generate_blind(id, *amount));
         }
         blinds
     }
@@ -147,7 +147,7 @@ mod tests {
         let (_, keyset) = generate_keyset();
         let amounts = vec![Amount::from(64), Amount::from(2)];
 
-        let mut blinds: Vec<_> = generate_blinds(&keyset, &amounts)
+        let mut blinds: Vec<_> = generate_blinds(keyset.id, &amounts)
             .into_iter()
             .map(|(blind, _, _)| blind)
             .collect();
@@ -170,7 +170,7 @@ mod tests {
         let (_, keyset) = generate_keyset();
         let amounts = vec![Amount::from(64), Amount::from(8)];
 
-        let mut blinds: Vec<_> = generate_blinds(&keyset, &amounts)
+        let mut blinds: Vec<_> = generate_blinds(keyset.id, &amounts)
             .into_iter()
             .map(|(blind, _, _)| blind)
             .collect();


### PR DESCRIPTION
### **User description**
Please review carefully as there are big logic changes, and I'm not 100% sure what the implications are for only storing (only) the discounted amount.

When generating the keyset, I've switched to using the discounted amount.
Something to think about is potentially storing the original bill amount, as well as the discounted amount.

The discounted amount is needed to verify the exact sum of the blinds matches it.

Previously, we could mint up the total amount of the Bill, more than the discount the wildcat mint offered the user.

This PR also enforces the requirement for the amount of blinds to match exactly the discounted amount, as the wallet client is able to do so using the information provided, freeing the mint from selecting blinds.

Closes #144


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforces minting only up to the discounted offer amount.
  - Validates sum of blinded outputs matches discounted amount.
  - Prevents minting for more than the discounted value.

- Removes and refactors blind selection logic for minting.

- Adds comprehensive tests for minting logic and edge cases.

- Fixes in-memory persistence to correctly mark keysets as minted.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Enforce discounted minting and refactor mint logic with tests</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/service.rs

<li>Validates that the sum of blinded outputs equals the discounted <br>amount.<br> <li> Removes <code>select_blinds_to_target</code> and related logic.<br> <li> Refactors minting to sign all provided outputs if valid.<br> <li> Adds new async tests for minting success and failure cases.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/149/files#diff-0bf63ca2bfa682f3961784061646602648f6450798339852bae9daf95e784e52">+103/-186</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Fix in-memory keyset minting state update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/persistence/inmemory.rs

<li>Fixes <code>mark_as_minted</code> to return early after marking as minted.<br> <li> Ensures correct error handling for unknown keysets.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/149/files#diff-3f12dfeeadb01ce475140bd0f334bac22948a837c7d6f5ce31a4120e1a8ef560">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Use discounted amount for keyset generation in quotes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/service.rs

<li>Changes keyset generation to use discounted amount instead of bill <br>sum.<br> <li> Ensures minting is based on the correct discounted value.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/149/files#diff-186f7e8fe93bbc7070dc420fa5c734f262aa91e2cc4a5585eecc838222112f36">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>