### PR TITLE
Ebill test setup, upgrade, cargo deny

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Add fmt
         run: rustup component add rustfmt
 
+      - name: Add cargo deny
+        run: cargo install cargo-deny
+
       - name: Check formatting
         run: cargo fmt -- --check
 
@@ -64,6 +67,10 @@ jobs:
           cargo clippy
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        continue-on-error: true
+
+      - name: Cargo deny 
+        run: cargo deny check
         continue-on-error: true
 
       - name: Upload analysis results to GitHub

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ anyhow = {version = "1"}
 async-trait = {version = "0.1"}
 axum = {version = "0.8"}
 axum-test = {version = "17"}
-bcr-ebill-core = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.0"}
-bcr-ebill-api = {git = "https://github.com/BitcreditProtocol/E-Bill.git", branch = "406-anonymous-mode"} #temp until it's merged and released
+bcr-ebill-core = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.11"}
+bcr-ebill-api = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.11"}
 bcr-wdc-key-client = {path = "./crates/bcr-wdc-key-client"}
 bcr-wdc-key-service = {path = "./crates/bcr-wdc-key-service"}
 bcr-wdc-swap-client = {path = "./crates/bcr-wdc-swap-client"}

--- a/crates/bcr-wdc-e2e-tests/Cargo.toml
+++ b/crates/bcr-wdc-e2e-tests/Cargo.toml
@@ -16,7 +16,6 @@ tracing = {workspace = true }
 tracing-subscriber = {workspace = true, features = ["serde"]}
 bcr-wdc-utils = {workspace = true, features = ["test-utils"] }
 bcr-wdc-key-service = {workspace = true, features = ["test-utils"]}
-bcr-ebill-core.workspace = true
 bitcoin.workspace = true
 bdk_wallet = {workspace = true}
 rand = {workspace = true}

--- a/crates/bcr-wdc-e2e-tests/src/test_utils.rs
+++ b/crates/bcr-wdc-e2e-tests/src/test_utils.rs
@@ -1,6 +1,6 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_wdc_webapi::quotes::{BillInfo, IdentityPublicData};
+use bcr_wdc_webapi::{bill::BillParticipant, quotes::BillInfo};
 use rand::Rng;
 // ----- local modules
 use bitcoin::secp256k1::Keypair;
@@ -15,10 +15,10 @@ pub fn random_ebill() -> (Keypair, BillInfo, bitcoin::secp256k1::schnorr::Signat
     let (_, payee) = bcr_wdc_webapi::test_utils::random_identity_public_data();
 
     let endorsees_size = rand::thread_rng().gen_range(0..3);
-    let mut endorsees: Vec<IdentityPublicData> = Vec::with_capacity(endorsees_size);
+    let mut endorsees: Vec<BillParticipant> = Vec::with_capacity(endorsees_size);
 
     let (endorser_kp, endorser) = bcr_wdc_webapi::test_utils::random_identity_public_data();
-    endorsees.push(endorser);
+    endorsees.push(BillParticipant::Ident(endorser));
 
     let owner_key = bcr_wdc_utils::keys::test_utils::generate_random_keypair();
 
@@ -29,7 +29,7 @@ pub fn random_ebill() -> (Keypair, BillInfo, bitcoin::secp256k1::schnorr::Signat
         maturity_date: random_date(),
         drawee,
         drawer,
-        payee,
+        payee: BillParticipant::Ident(payee),
         endorsees,
         sum: amount.into(),
     };

--- a/crates/bcr-wdc-ebill-client/Cargo.toml
+++ b/crates/bcr-wdc-ebill-client/Cargo.toml
@@ -8,3 +8,8 @@ license = "MIT"
 reqwest = {workspace = true, features = ["json"]}
 thiserror.workspace = true
 bcr-wdc-webapi.workspace = true
+bip39.workspace = true
+
+[dev-dependencies]
+bcr-wdc-ebill-service = {workspace = true, features = ["test-utils"]}
+tokio.workspace = true

--- a/crates/bcr-wdc-ebill-client/src/lib.rs
+++ b/crates/bcr-wdc-ebill-client/src/lib.rs
@@ -2,7 +2,8 @@
 // ----- extra library imports
 use bcr_wdc_webapi::{
     bill::{
-        BillCombinedBitcoinKey, BillsResponse, BitcreditBill, RequestToPayBitcreditBillPayload,
+        BillCombinedBitcoinKey, BillsResponse, BitcreditBill, Endorsement,
+        RequestToPayBitcreditBillPayload,
     },
     contact::NewContactPayload,
     identity::{Identity, NewIdentityPayload, SeedPhrase},
@@ -126,6 +127,19 @@ impl EbillClient {
         }
         let bill = res.json::<BitcreditBill>().await?;
         Ok(bill)
+    }
+
+    pub async fn get_bill_endorsements(&self, bill_id: &str) -> Result<Vec<Endorsement>> {
+        let url = self
+            .base
+            .join(&format!("/bill/endorsements/{bill_id}"))
+            .expect("bill detail relative path");
+        let res = self.cl.get(url).send().await?;
+        if res.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(Error::ResourceNotFound(bill_id.into()));
+        }
+        let endorsements = res.json::<Vec<Endorsement>>().await?;
+        Ok(endorsements)
     }
 
     /// Returns the content type and the bytes of the file

--- a/crates/bcr-wdc-ebill-client/tests/bills.rs
+++ b/crates/bcr-wdc-ebill-client/tests/bills.rs
@@ -1,0 +1,37 @@
+use bcr_wdc_ebill_client::{EbillClient, Error};
+
+#[tokio::test]
+async fn bill_calls() {
+    let server = bcr_wdc_ebill_service::test_utils::build_test_server();
+    let server_url = server.server_address().expect("address");
+    let client = EbillClient::new(server_url);
+
+    let response = client.get_bills().await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));
+
+    let response = client.get_bill("some_id").await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));
+
+    let response = client.get_bill_endorsements("some_id").await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));
+
+    let response = client.get_bill_attachment("some_id", "file name").await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));
+
+    let response = client.get_bitcoin_private_key_for_bill("some_id").await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));
+
+    let response = client
+        .request_to_pay_bill(&bcr_wdc_webapi::bill::RequestToPayBitcreditBillPayload {
+            bill_id: "some_id".to_string(),
+            currency: "sat".to_string(),
+        })
+        .await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));
+}

--- a/crates/bcr-wdc-ebill-client/tests/contact.rs
+++ b/crates/bcr-wdc-ebill-client/tests/contact.rs
@@ -1,0 +1,26 @@
+use bcr_wdc_ebill_client::{EbillClient, Error};
+
+#[tokio::test]
+async fn contact_calls() {
+    let server = bcr_wdc_ebill_service::test_utils::build_test_server();
+    let server_url = server.server_address().expect("address");
+    let client = EbillClient::new(server_url);
+
+    let response = client
+        .create_contact(&bcr_wdc_webapi::contact::NewContactPayload {
+            t: 0,
+            node_id: "some id".into(),
+            name: "name".into(),
+            email: None,
+            postal_address: None,
+            date_of_birth_or_registration: None,
+            country_of_birth_or_registration: None,
+            city_of_birth_or_registration: None,
+            identification_number: None,
+            avatar_file_upload_id: None,
+            proof_document_file_upload_id: None,
+        })
+        .await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::InvalidRequest));
+}

--- a/crates/bcr-wdc-ebill-client/tests/identity.rs
+++ b/crates/bcr-wdc-ebill-client/tests/identity.rs
@@ -1,0 +1,44 @@
+use bcr_wdc_ebill_client::{EbillClient, Error};
+
+#[tokio::test]
+async fn identity_calls() {
+    let server = bcr_wdc_ebill_service::test_utils::build_test_server();
+    let server_url = server.server_address().expect("address");
+    let client = EbillClient::new(server_url);
+
+    let response = client.backup_seed_phrase().await;
+    assert!(response.is_ok());
+
+    let response = client
+        .restore_from_seed_phrase(&bcr_wdc_webapi::identity::SeedPhrase {
+            seed_phrase: bip39::Mnemonic::generate(12).unwrap(),
+        })
+        .await;
+    assert!(response.is_ok());
+
+    let response = client.get_identity().await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));
+
+    let response = client
+        .create_identity(&bcr_wdc_webapi::identity::NewIdentityPayload {
+            t: 0,
+            name: "name".into(),
+            email: None,
+            postal_address: bcr_wdc_webapi::identity::OptionalPostalAddress {
+                country: None,
+                city: None,
+                zip: None,
+                address: None,
+            },
+            date_of_birth: None,
+            country_of_birth: None,
+            city_of_birth: None,
+            identification_number: None,
+            profile_picture_file_upload_id: None,
+            identity_document_file_upload_id: None,
+        })
+        .await;
+    assert!(response.is_err());
+    assert!(matches!(response.unwrap_err(), Error::InvalidRequest));
+}

--- a/crates/bcr-wdc-ebill-service/Cargo.toml
+++ b/crates/bcr-wdc-ebill-service/Cargo.toml
@@ -4,8 +4,14 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
+[features]
+test-utils = ["axum-test", "mockall", "async-broadcast", "bcr-ebill-core"]
+
 [dependencies]
 axum = {workspace = true, features = ["macros"]}
+axum-test = {workspace = true, optional = true}
+mockall = {workspace = true, optional = true}
+bcr-ebill-core = {workspace = true, optional = true}
 bcr-ebill-api = {workspace = true} 
 bcr-ebill-transport = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.11"}
 bcr-wdc-webapi.workspace = true
@@ -22,3 +28,5 @@ url = {workspace = true, features = ["serde"]}
 bip39 = {workspace = true, features = ["serde"]}
 serde_repr.workspace = true 
 rustls = "0.23"
+async-broadcast = { version = "0.7.2", optional = true }
+async-trait.workspace = true

--- a/crates/bcr-wdc-ebill-service/Cargo.toml
+++ b/crates/bcr-wdc-ebill-service/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 [dependencies]
 axum = {workspace = true, features = ["macros"]}
 bcr-ebill-api = {workspace = true} 
-bcr-ebill-transport = {git = "https://github.com/BitcreditProtocol/E-Bill.git", branch = "406-anonymous-mode"} #temp until it's merged and released
+bcr-ebill-transport = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.11"}
 bcr-wdc-webapi.workspace = true
 config.workspace = true
 serde.workspace = true

--- a/crates/bcr-wdc-ebill-service/src/lib.rs
+++ b/crates/bcr-wdc-ebill-service/src/lib.rs
@@ -127,6 +127,10 @@ pub fn routes(ctrl: AppController) -> Router {
         .route("/bill/list", get(web::get_bills))
         .route("/bill/detail/{bill_id}", get(web::get_bill_detail))
         .route(
+            "/bill/endorsements/{bill_id}",
+            get(web::get_bill_endorsements),
+        )
+        .route(
             "/bill/attachment/{bill_id}/{file_name}",
             get(web::get_bill_attachment),
         )

--- a/crates/bcr-wdc-ebill-service/src/lib.rs
+++ b/crates/bcr-wdc-ebill-service/src/lib.rs
@@ -12,9 +12,7 @@ use bcr_ebill_api::{
         bill_service::{service::BillService, BillServiceApi},
         contact_service::{ContactService, ContactServiceApi},
         identity_service::{IdentityService, IdentityServiceApi},
-        notification_service::{
-            create_nostr_clients, create_nostr_consumer, create_notification_service, NostrConsumer,
-        },
+        notification_service::{create_notification_service, NostrClient},
     },
 };
 use bcr_ebill_transport::{NotificationServiceApi, PushApi, PushService};
@@ -46,25 +44,24 @@ pub struct AppController {
     pub contact_service: Arc<dyn ContactServiceApi>,
     pub bill_service: Arc<dyn BillServiceApi>,
     pub identity_service: Arc<dyn IdentityServiceApi>,
-    pub nostr_consumer: NostrConsumer,
     pub notification_service: Arc<dyn NotificationServiceApi>,
     pub push_service: Arc<dyn PushApi>,
 }
 
 impl AppController {
-    pub async fn new(cfg: bcr_ebill_api::Config, db: bcr_ebill_api::DbContext) -> Self {
+    pub async fn new(
+        cfg: bcr_ebill_api::Config,
+        nostr_clients: Vec<Arc<NostrClient>>,
+        db: bcr_ebill_api::DbContext,
+    ) -> Self {
         let contact_service = Arc::new(ContactService::new(
             db.contact_store.clone(),
             db.file_upload_store.clone(),
             db.identity_store.clone(),
         ));
 
-        let nostr_clients =
-            create_nostr_clients(&cfg, db.identity_store.clone(), db.company_store.clone())
-                .await
-                .expect("Failed to create nostr clients");
         let notification_service = create_notification_service(
-            nostr_clients.clone(),
+            nostr_clients,
             db.notification_store.clone(),
             contact_service.clone(),
             db.queued_message_store.clone(),
@@ -94,23 +91,10 @@ impl AppController {
 
         let push_service = Arc::new(PushService::new());
 
-        let nostr_consumer = create_nostr_consumer(
-            nostr_clients,
-            contact_service.clone(),
-            db.nostr_event_offset_store.clone(),
-            db.notification_store.clone(),
-            push_service.clone(),
-            db.bill_blockchain_store.clone(),
-            db.bill_store.clone(),
-        )
-        .await
-        .expect("Failed to create Nostr consumer");
-
         Self {
             contact_service,
             bill_service,
             identity_service: Arc::new(identity_service),
-            nostr_consumer,
             notification_service,
             push_service,
         }
@@ -137,4 +121,394 @@ pub fn routes(ctrl: AppController) -> Router {
         .route("/bill/request_to_pay", put(web::request_to_pay_bill))
         .route("/bill/bitcoin_key/{bill_id}", get(web::bill_bitcoin_key))
         .with_state(ctrl)
+}
+
+#[cfg(feature = "test-utils")]
+pub mod test_utils {
+    use super::*;
+    use async_broadcast::Receiver;
+    use async_trait::async_trait;
+    use bcr_ebill_api::{
+        data::{
+            bill::{
+                BillAction, BillCombinedBitcoinKey, BillIssueData, BillKeys, BillsBalanceOverview,
+                BillsFilterRole, BitcreditBill, BitcreditBillResult, Endorsement,
+                LightBitcreditBillResult, PastEndorsee, PastPaymentResult,
+            },
+            contact::{BillIdentParticipant, BillParticipant, Contact, ContactType},
+            identity::{ActiveIdentityState, Identity, IdentityType, IdentityWithAll},
+            notification::{ActionType, Notification},
+            File, OptionalPostalAddress, PostalAddress,
+        },
+        service::{
+            bill_service::Error as BillError, bill_service::Result as BillResult, Error, Result,
+        },
+        util::BcrKeys,
+        NotificationFilter,
+    };
+    use bcr_ebill_core::{blockchain::bill::BillBlockchain, ServiceTraitBounds};
+    use bcr_ebill_transport::{event::chain_event::BillChainEvent, Result as NotifResult};
+    use std::collections::HashMap;
+
+    mockall::mock! {
+        pub BillServiceApi {}
+
+        impl ServiceTraitBounds for BillServiceApi {}
+
+        #[async_trait]
+        impl BillServiceApi for BillServiceApi {
+            async fn get_bill_balances(
+                &self,
+                currency: &str,
+                current_identity_node_id: &str,
+            ) -> BillResult<BillsBalanceOverview>;
+            async fn search_bills(
+                &self,
+                currency: &str,
+                search_term: &Option<String>,
+                date_range_from: Option<u64>,
+                date_range_to: Option<u64>,
+                role: &BillsFilterRole,
+                current_identity_node_id: &str,
+            ) -> BillResult<Vec<LightBitcreditBillResult>>;
+            async fn get_bills(&self, current_identity_node_id: &str) -> BillResult<Vec<BitcreditBillResult>>;
+            async fn get_combined_bitcoin_key_for_bill(
+                &self,
+                bill_id: &str,
+                caller_public_data: &BillParticipant,
+                caller_keys: &BcrKeys,
+            ) -> BillResult<BillCombinedBitcoinKey>;
+            async fn get_detail(
+                &self,
+                bill_id: &str,
+                local_identity: &Identity,
+                current_identity_node_id: &str,
+                current_timestamp: u64,
+            ) -> BillResult<BitcreditBillResult>;
+            async fn get_bill_keys(&self, bill_id: &str) -> BillResult<BillKeys>;
+            async fn open_and_decrypt_attached_file(
+                &self,
+                bill_id: &str,
+                file_name: &str,
+                bill_private_key: &str,
+            ) -> BillResult<Vec<u8>>;
+            async fn encrypt_and_save_uploaded_file(
+                &self,
+                file_name: &str,
+                file_bytes: &[u8],
+                bill_id: &str,
+                bill_public_key: &str,
+            ) -> BillResult<File>;
+            async fn issue_new_bill(&self, data: BillIssueData) -> BillResult<BitcreditBill>;
+            async fn execute_bill_action(
+                &self,
+                bill_id: &str,
+                bill_action: BillAction,
+                signer_public_data: &BillParticipant,
+                signer_keys: &BcrKeys,
+                timestamp: u64,
+            ) -> BillResult<BillBlockchain>;
+            async fn check_bills_payment(&self) -> BillResult<()>;
+            async fn check_payment_for_bill(&self, bill_id: &str, identity: &Identity) -> BillResult<()>;
+            async fn check_bills_offer_to_sell_payment(&self) -> BillResult<()>;
+            async fn check_offer_to_sell_payment_for_bill(
+                &self,
+                bill_id: &str,
+                identity: &IdentityWithAll,
+            ) -> BillResult<()>;
+            async fn check_bills_in_recourse_payment(&self) -> BillResult<()>;
+            async fn check_recourse_payment_for_bill(
+                &self,
+                bill_id: &str,
+                identity: &IdentityWithAll,
+            ) -> BillResult<()>;
+            async fn check_bills_timeouts(&self, now: u64) -> BillResult<()>;
+            async fn get_past_endorsees(
+                &self,
+                bill_id: &str,
+                current_identity_node_id: &str,
+            ) -> BillResult<Vec<PastEndorsee>>;
+            async fn get_past_payments(
+                &self,
+                bill_id: &str,
+                caller_public_data: &BillParticipant,
+                caller_keys: &BcrKeys,
+                timestamp: u64,
+            ) -> BillResult<Vec<PastPaymentResult>>;
+            async fn get_endorsements(
+                &self,
+                bill_id: &str,
+                current_identity_node_id: &str,
+            ) -> BillResult<Vec<Endorsement>>;
+            async fn clear_bill_cache(&self) -> BillResult<()>;
+        }
+    }
+
+    mockall::mock! {
+        pub PushApi {}
+
+        #[async_trait]
+        impl PushApi for PushApi {
+            async fn send(&self, value: serde_json::Value);
+            async fn subscribe(&self) -> Receiver<serde_json::Value>;
+        }
+    }
+
+    mockall::mock! {
+        pub ContactServiceApi {}
+
+        #[async_trait]
+        impl ContactServiceApi for ContactServiceApi {
+            async fn search(&self, search_term: &str) -> Result<Vec<Contact>>;
+            async fn get_contacts(&self) -> Result<Vec<Contact>>;
+            async fn get_contact(&self, node_id: &str) -> Result<Contact>;
+            async fn get_identity_by_node_id(&self, node_id: &str) -> Result<Option<BillParticipant>>;
+            async fn delete(&self, node_id: &str) -> Result<()>;
+            async fn update_contact(
+                &self,
+                node_id: &str,
+                name: Option<String>,
+                email: Option<String>,
+                postal_address: OptionalPostalAddress,
+                date_of_birth_or_registration: Option<String>,
+                country_of_birth_or_registration: Option<String>,
+                city_of_birth_or_registration: Option<String>,
+                identification_number: Option<String>,
+                avatar_file_upload_id: Option<String>,
+                proof_document_file_upload_id: Option<String>,
+            ) -> Result<()>;
+            async fn add_contact(
+                &self,
+                node_id: &str,
+                t: ContactType,
+                name: String,
+                email: Option<String>,
+                postal_address: Option<PostalAddress>,
+                date_of_birth_or_registration: Option<String>,
+                country_of_birth_or_registration: Option<String>,
+                city_of_birth_or_registration: Option<String>,
+                identification_number: Option<String>,
+                avatar_file_upload_id: Option<String>,
+                proof_document_file_upload_id: Option<String>,
+            ) -> Result<Contact>;
+            async fn deanonymize_contact(
+                &self,
+                node_id: &str,
+                t: ContactType,
+                name: String,
+                email: Option<String>,
+                postal_address: Option<PostalAddress>,
+                date_of_birth_or_registration: Option<String>,
+                country_of_birth_or_registration: Option<String>,
+                city_of_birth_or_registration: Option<String>,
+                identification_number: Option<String>,
+                avatar_file_upload_id: Option<String>,
+                proof_document_file_upload_id: Option<String>,
+            ) -> Result<Contact>;
+            async fn is_known_npub(&self, npub: &str) -> Result<bool>;
+            async fn open_and_decrypt_file(
+                &self,
+                id: &str,
+                file_name: &str,
+                private_key: &str,
+            ) -> Result<Vec<u8>>;
+        }
+    }
+
+    mockall::mock! {
+        pub IdentityServiceApi {}
+
+        #[async_trait]
+        impl IdentityServiceApi for IdentityServiceApi {
+            async fn update_identity(
+                &self,
+                name: Option<String>,
+                email: Option<String>,
+                postal_address: OptionalPostalAddress,
+                date_of_birth: Option<String>,
+                country_of_birth: Option<String>,
+                city_of_birth: Option<String>,
+                identification_number: Option<String>,
+                profile_picture_file_upload_id: Option<String>,
+                identity_document_file_upload_id: Option<String>,
+                timestamp: u64,
+            ) -> Result<()>;
+            async fn get_full_identity(&self) -> Result<IdentityWithAll>;
+            async fn get_identity(&self) -> Result<Identity>;
+            async fn identity_exists(&self) -> bool;
+            async fn create_identity(
+                &self,
+                t: IdentityType,
+                name: String,
+                email: Option<String>,
+                postal_address: OptionalPostalAddress,
+                date_of_birth: Option<String>,
+                country_of_birth: Option<String>,
+                city_of_birth: Option<String>,
+                identification_number: Option<String>,
+                profile_picture_file_upload_id: Option<String>,
+                identity_document_file_upload_id: Option<String>,
+                timestamp: u64,
+            ) -> Result<()>;
+            async fn deanonymize_identity(
+                &self,
+                t: IdentityType,
+                name: String,
+                email: Option<String>,
+                postal_address: OptionalPostalAddress,
+                date_of_birth: Option<String>,
+                country_of_birth: Option<String>,
+                city_of_birth: Option<String>,
+                identification_number: Option<String>,
+                profile_picture_file_upload_id: Option<String>,
+                identity_document_file_upload_id: Option<String>,
+                timestamp: u64,
+            ) -> Result<()>;
+            async fn get_seedphrase(&self) -> Result<String>;
+            async fn recover_from_seedphrase(&self, seed: &str) -> Result<()>;
+            async fn open_and_decrypt_file(
+                &self,
+                id: &str,
+                file_name: &str,
+                private_key: &str,
+            ) -> Result<Vec<u8>>;
+            async fn get_current_identity(&self) -> Result<ActiveIdentityState>;
+            async fn set_current_personal_identity(&self, node_id: &str) -> Result<()>;
+            async fn set_current_company_identity(&self, node_id: &str) -> Result<()>;
+        }
+    }
+    mockall::mock! {
+        pub NotificationServiceApi {}
+
+        impl ServiceTraitBounds for NotificationServiceApi {}
+
+        #[async_trait]
+        impl NotificationServiceApi for NotificationServiceApi {
+            async fn send_bill_is_signed_event(&self, event: &BillChainEvent) -> NotifResult<()>;
+            async fn send_bill_is_accepted_event(&self, event: &BillChainEvent) -> NotifResult<()>;
+            async fn send_request_to_accept_event(&self, event: &BillChainEvent) -> NotifResult<()>;
+            async fn send_request_to_pay_event(&self, event: &BillChainEvent) -> NotifResult<()>;
+            async fn send_bill_is_paid_event(&self, event: &BillChainEvent) -> NotifResult<()>;
+            async fn send_bill_is_endorsed_event(&self, event: &BillChainEvent) -> NotifResult<()>;
+            async fn send_offer_to_sell_event(
+                &self,
+                event: &BillChainEvent,
+                buyer: &BillParticipant,
+            ) -> NotifResult<()>;
+            async fn send_bill_is_sold_event(
+                &self,
+                event: &BillChainEvent,
+                buyer: &BillParticipant,
+            ) -> NotifResult<()>;
+            async fn send_bill_recourse_paid_event(
+                &self,
+                event: &BillChainEvent,
+                recoursee: &BillIdentParticipant,
+            ) -> NotifResult<()>;
+            async fn send_request_to_action_rejected_event(
+                &self,
+                event: &BillChainEvent,
+                rejected_action: ActionType,
+            ) -> NotifResult<()>;
+            async fn send_request_to_action_timed_out_event(
+                &self,
+                sender_node_id: &str,
+                bill_id: &str,
+                sum: Option<u64>,
+                timed_out_action: ActionType,
+                recipients: Vec<BillParticipant>,
+            ) -> NotifResult<()>;
+            async fn send_recourse_action_event(
+                &self,
+                event: &BillChainEvent,
+                action: ActionType,
+                recoursee: &BillIdentParticipant,
+            ) -> NotifResult<()>;
+            async fn send_request_to_mint_event(
+                &self,
+                sender_node_id: &str,
+                bill: &BitcreditBill,
+            ) -> NotifResult<()>;
+            async fn send_new_quote_event(&self, quote: &BitcreditBill) -> NotifResult<()>;
+            async fn send_quote_is_approved_event(&self, quote: &BitcreditBill) -> NotifResult<()>;
+            async fn get_client_notifications(
+                &self,
+                filter: NotificationFilter,
+            ) -> NotifResult<Vec<Notification>>;
+            async fn mark_notification_as_done(&self, notification_id: &str) -> NotifResult<()>;
+            async fn get_active_bill_notification(&self, bill_id: &str) -> Option<Notification>;
+            async fn get_active_bill_notifications(
+                &self,
+                bill_ids: &[String],
+            ) -> HashMap<String, Notification>;
+            async fn check_bill_notification_sent(
+                &self,
+                bill_id: &str,
+                block_height: i32,
+                action: ActionType,
+            ) -> NotifResult<bool>;
+            async fn mark_bill_notification_sent(
+                &self,
+                bill_id: &str,
+                block_height: i32,
+                action: ActionType,
+            ) -> NotifResult<()>;
+            async fn send_retry_messages(&self) -> NotifResult<()>;
+        }
+    }
+
+    impl std::default::Default for AppController {
+        fn default() -> Self {
+            let mut mock_contact_service = MockContactServiceApi::new();
+            mock_contact_service.expect_add_contact().returning(
+                |_, _, _, _, _, _, _, _, _, _, _| {
+                    Err(Error::Validation(
+                        bcr_ebill_core::ValidationError::FieldEmpty(bcr_ebill_core::Field::Name),
+                    ))
+                },
+            );
+            let mut mock_bill_service = MockBillServiceApi::new();
+            mock_bill_service
+                .expect_get_bill_keys()
+                .returning(|_| Err(BillError::NotFound));
+            mock_bill_service
+                .expect_open_and_decrypt_attached_file()
+                .returning(|_, _, _| Err(BillError::NotFound));
+            let mock_notification_service = MockNotificationServiceApi::new();
+            let mock_push_api = MockPushApi::new();
+            let mut mock_identity_service = MockIdentityServiceApi::new();
+            mock_identity_service
+                .expect_get_identity()
+                .returning(|| Err(Error::NotFound));
+            mock_identity_service
+                .expect_get_full_identity()
+                .returning(|| Err(Error::NotFound));
+            mock_identity_service
+                .expect_recover_from_seedphrase()
+                .returning(|_| Ok(()));
+            mock_identity_service
+                .expect_get_seedphrase()
+                .returning(|| Ok(bip39::Mnemonic::generate(12).unwrap().to_string()));
+            mock_identity_service
+                .expect_identity_exists()
+                .returning(|| true);
+            Self {
+                contact_service: Arc::new(mock_contact_service),
+                bill_service: Arc::new(mock_bill_service),
+                identity_service: Arc::new(mock_identity_service),
+                notification_service: Arc::new(mock_notification_service),
+                push_service: Arc::new(mock_push_api),
+            }
+        }
+    }
+
+    pub fn build_test_server() -> axum_test::TestServer {
+        let cfg = axum_test::TestServerConfig {
+            transport: Some(axum_test::Transport::HttpRandomPort),
+            ..Default::default()
+        };
+        let cntrl = AppController::default();
+        axum_test::TestServer::new_with_config(routes(cntrl), cfg)
+            .expect("failed to start test server")
+    }
 }

--- a/crates/bcr-wdc-ebill-service/src/web.rs
+++ b/crates/bcr-wdc-ebill-service/src/web.rs
@@ -144,8 +144,7 @@ pub async fn get_bill_endorsements(
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn get_bill_attachment(
     State(ctrl): State<AppController>,
-    Path(bill_id): Path<String>,
-    Path(file_name): Path<String>,
+    Path((bill_id, file_name)): Path<(String, String)>,
 ) -> Result<impl IntoResponse> {
     tracing::debug!("Received get bill attachment request");
     let keys = ctrl.bill_service.get_bill_keys(&bill_id).await?;

--- a/crates/bcr-wdc-ebill-service/src/web.rs
+++ b/crates/bcr-wdc-ebill-service/src/web.rs
@@ -14,7 +14,8 @@ use bcr_ebill_api::{
 };
 use bcr_wdc_webapi::{
     bill::{
-        BillCombinedBitcoinKey, BillsResponse, BitcreditBill, RequestToPayBitcreditBillPayload,
+        BillCombinedBitcoinKey, BillsResponse, BitcreditBill, Endorsement,
+        RequestToPayBitcreditBillPayload,
     },
     contact::{Contact, ContactType, NewContactPayload},
     identity::{Identity, IdentityType, NewIdentityPayload, SeedPhrase},
@@ -124,6 +125,20 @@ pub async fn get_bill_detail(
         .get_detail(&bill_id, &identity, &identity.node_id, current_timestamp)
         .await?;
     Ok(Json(bill_detail.into()))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn get_bill_endorsements(
+    State(ctrl): State<AppController>,
+    Path(bill_id): Path<String>,
+) -> Result<Json<Vec<Endorsement>>> {
+    tracing::debug!("Received get bill detail request");
+    let identity = ctrl.identity_service.get_identity().await?;
+    let endorsements = ctrl
+        .bill_service
+        .get_endorsements(&bill_id, &identity.node_id)
+        .await?;
+    Ok(Json(endorsements.into_iter().map(|e| e.into()).collect()))
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]

--- a/crates/bcr-wdc-key-client/tests/keys.rs
+++ b/crates/bcr-wdc-key-client/tests/keys.rs
@@ -10,7 +10,7 @@ async fn keys_not_found() {
     let server_url = server.server_address().expect("address");
     let client = KeyClient::new(server_url);
 
-    let kid = keys_utils::generate_random_keysetid().into();
+    let kid = keys_utils::generate_random_keysetid();
     let response = client.keys(kid).await;
     assert!(response.is_err());
     assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));

--- a/crates/bcr-wdc-key-client/tests/keyset_info.rs
+++ b/crates/bcr-wdc-key-client/tests/keyset_info.rs
@@ -10,7 +10,7 @@ async fn keyset_info_not_found() {
     let server_url = server.server_address().expect("address");
     let client = KeyClient::new(server_url);
 
-    let kid = keys_utils::generate_random_keysetid().into();
+    let kid = keys_utils::generate_random_keysetid();
     let response = client.keyset_info(kid).await;
     assert!(response.is_err());
     assert!(matches!(response.unwrap_err(), Error::ResourceNotFound(_)));

--- a/crates/bcr-wdc-quote-service/src/lib.rs
+++ b/crates/bcr-wdc-quote-service/src/lib.rs
@@ -98,17 +98,18 @@ pub fn credit_routes(ctrl: AppController) -> Router {
 #[derive(utoipa::OpenApi)]
 #[openapi(
     components(schemas(
+        bcr_wdc_webapi::contact::ContactType,
+        bcr_wdc_webapi::bill::BillIdentParticipant,
+        bcr_wdc_webapi::bill::BillParticipant,
+        bcr_wdc_webapi::identity::PostalAddress,
         bcr_wdc_webapi::quotes::BillInfo,
-        bcr_wdc_webapi::quotes::ContactType,
         bcr_wdc_webapi::quotes::EnquireReply,
         bcr_wdc_webapi::quotes::EnquireRequest,
-        bcr_wdc_webapi::quotes::IdentityPublicData,
         bcr_wdc_webapi::quotes::InfoReply,
         bcr_wdc_webapi::quotes::LightInfo,
         bcr_wdc_webapi::quotes::ListReply,
         bcr_wdc_webapi::quotes::ListReplyLight,
         bcr_wdc_webapi::quotes::ListSort,
-        bcr_wdc_webapi::quotes::PostalAddress,
         bcr_wdc_webapi::quotes::ResolveOffer,
         bcr_wdc_webapi::quotes::StatusReply,
         bcr_wdc_webapi::quotes::StatusReplyDiscriminants,

--- a/crates/bcr-wdc-quote-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-quote-service/src/persistence/inmemory.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 // ----- extra library imports
 use anyhow::Result as AnyResult;
 use async_trait::async_trait;
+use bcr_wdc_webapi::bill::NodeId;
 use strum::IntoDiscriminant;
 use uuid::Uuid;
 // ----- local modules
@@ -30,7 +31,7 @@ impl Repository for QuotesIDMap {
                     .endorsees
                     .last()
                     .unwrap_or(&quote.bill.payee)
-                    .node_id;
+                    .node_id();
                 quote.bill.id == bill && holder == endorser
             })
             .map(|x| x.1.clone())
@@ -133,7 +134,7 @@ impl Repository for QuotesIDMap {
                     }
                 }
                 if let Some(bill_payer_id) = bill_payer_id {
-                    if quote.bill.payee.node_id != *bill_payer_id {
+                    if quote.bill.payee.node_id() != *bill_payer_id {
                         return false;
                     }
                 }
@@ -143,7 +144,7 @@ impl Repository for QuotesIDMap {
                         .endorsees
                         .last()
                         .unwrap_or(&quote.bill.payee)
-                        .node_id;
+                        .node_id();
                     if *holder_id != *bill_holder_id {
                         return false;
                     }

--- a/crates/bcr-wdc-quote-service/src/quotes.rs
+++ b/crates/bcr-wdc-quote-service/src/quotes.rs
@@ -1,7 +1,7 @@
 // ----- standard library imports
 use std::str::FromStr;
 // ----- extra library imports
-use bcr_ebill_core::contact::IdentityPublicData;
+use bcr_ebill_core::contact::{BillIdentParticipant, BillParticipant};
 use bitcoin::Amount;
 use cashu::{nut01 as cdk01, nut02 as cdk02};
 use uuid::Uuid;
@@ -10,14 +10,14 @@ use uuid::Uuid;
 use crate::error::{Error, Result};
 use crate::TStamp;
 
-#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BillInfo {
     pub id: String,
-    pub drawee: IdentityPublicData,
-    pub drawer: IdentityPublicData,
-    pub payee: IdentityPublicData,
-    pub endorsees: Vec<IdentityPublicData>,
-    pub current_holder: IdentityPublicData,
+    pub drawee: BillIdentParticipant,
+    pub drawer: BillIdentParticipant,
+    pub payee: BillParticipant,
+    pub endorsees: Vec<BillParticipant>,
+    pub current_holder: BillParticipant,
     pub sum: Amount,
     pub maturity_date: TStamp,
 }

--- a/crates/bcr-wdc-quote-service/src/web.rs
+++ b/crates/bcr-wdc-quote-service/src/web.rs
@@ -2,7 +2,7 @@
 use std::str::FromStr;
 // ----- extra library imports
 use axum::extract::{Json, Path, State};
-use bcr_wdc_webapi::quotes as web_quotes;
+use bcr_wdc_webapi::{bill::NodeId, quotes as web_quotes};
 // ----- local imports
 use crate::error::Result;
 use crate::{
@@ -43,7 +43,7 @@ where
 
 fn verify_signature(req: &web_quotes::EnquireRequest) -> Result<()> {
     let holder = req.content.endorsees.last().unwrap_or(&req.content.payee);
-    let pub_key = bitcoin::secp256k1::PublicKey::from_str(&holder.node_id)?;
+    let pub_key = bitcoin::secp256k1::PublicKey::from_str(&holder.node_id())?;
     bcr_wdc_utils::keys::schnorr_verify_borsh_msg_with_key(
         &req.content,
         &req.signature,

--- a/crates/bcr-wdc-treasury-client/Cargo.toml
+++ b/crates/bcr-wdc-treasury-client/Cargo.toml
@@ -10,5 +10,5 @@ cashu.workspace = true
 chrono.workspace = true
 reqwest = {workspace = true, features = ["json"]}
 thiserror.workspace = true
-url = {version = "2.4"}
+url.workspace = true
 uuid.workspace = true

--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -179,11 +179,10 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let blinds: Vec<_> =
-            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(8_u64)])
-                .into_iter()
-                .map(|b| b.0)
-                .collect();
+        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(8_u64)])
+            .into_iter()
+            .map(|b| b.0)
+            .collect();
 
         service.redeem(&[], &blinds).await.unwrap_err();
     }
@@ -201,7 +200,7 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
+        let proofs = signatures_test::generate_proofs(&keyset, &[Amount::from(8_u64)]);
 
         service.redeem(&proofs, &[]).await.unwrap_err();
     }
@@ -219,12 +218,11 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> =
-            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
-                .into_iter()
-                .map(|b| b.0)
-                .collect();
+        let proofs = signatures_test::generate_proofs(&keyset, &[Amount::from(8_u64)]);
+        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(16_u64)])
+            .into_iter()
+            .map(|b| b.0)
+            .collect();
 
         service.redeem(&proofs, &blinds).await.unwrap_err();
     }
@@ -254,12 +252,11 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> =
-            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
-                .into_iter()
-                .map(|b| b.0)
-                .collect();
+        let proofs = signatures_test::generate_proofs(&keyset, &[Amount::from(8_u64)]);
+        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(16_u64)])
+            .into_iter()
+            .map(|b| b.0)
+            .collect();
 
         service.redeem(&proofs, &blinds).await.unwrap_err();
     }
@@ -280,12 +277,11 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let proofs = signatures_test::generate_proofs(&keyset, &vec![Amount::from(8_u64)]);
-        let blinds: Vec<_> =
-            signatures_test::generate_blinds(keyset.id, &vec![Amount::from(16_u64)])
-                .into_iter()
-                .map(|b| b.0)
-                .collect();
+        let proofs = signatures_test::generate_proofs(&keyset, &[Amount::from(8_u64)]);
+        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(16_u64)])
+            .into_iter()
+            .map(|b| b.0)
+            .collect();
 
         service.redeem(&proofs, &blinds).await.unwrap_err();
     }

--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -179,7 +179,7 @@ mod tests {
         };
 
         let (_, keyset) = generate_keyset();
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(8_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &[Amount::from(8_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();
@@ -219,7 +219,7 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &[Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(16_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &[Amount::from(16_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();
@@ -253,7 +253,7 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &[Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(16_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &[Amount::from(16_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();
@@ -278,7 +278,7 @@ mod tests {
 
         let (_, keyset) = generate_keyset();
         let proofs = signatures_test::generate_proofs(&keyset, &[Amount::from(8_u64)]);
-        let blinds: Vec<_> = signatures_test::generate_blinds(&keyset, &[Amount::from(16_u64)])
+        let blinds: Vec<_> = signatures_test::generate_blinds(keyset.id, &[Amount::from(16_u64)])
             .into_iter()
             .map(|b| b.0)
             .collect();

--- a/crates/bcr-wdc-webapi/src/bin/devtool.rs
+++ b/crates/bcr-wdc-webapi/src/bin/devtool.rs
@@ -1,7 +1,10 @@
 // ----- standard library imports
 // ----- extra library imports
 use bcr_wdc_utils::keys::test_utils as keys_test;
-use bcr_wdc_webapi::quotes::{BillInfo, EnquireRequest, IdentityPublicData};
+use bcr_wdc_webapi::{
+    bill::BillParticipant,
+    quotes::{BillInfo, EnquireRequest},
+};
 use bdk_wallet::serde_json;
 use cashu::Amount;
 use rand::Rng;
@@ -16,10 +19,10 @@ fn main() -> std::io::Result<()> {
     let (mut signing_key, payee) = random_identity_public_data();
 
     let endorsees_size = rand::thread_rng().gen_range(0..3);
-    let mut endorsees: Vec<IdentityPublicData> = Vec::with_capacity(endorsees_size);
+    let mut endorsees: Vec<BillParticipant> = Vec::with_capacity(endorsees_size);
     for _ in 0..endorsees_size {
         let (keypair, endorse) = random_identity_public_data();
-        endorsees.push(endorse);
+        endorsees.push(BillParticipant::Ident(endorse));
         signing_key = keypair;
     }
 
@@ -31,7 +34,7 @@ fn main() -> std::io::Result<()> {
         maturity_date: random_date(),
         drawee,
         drawer,
-        payee,
+        payee: BillParticipant::Ident(payee),
         endorsees,
         sum: amount.into(),
     };

--- a/crates/bcr-wdc-webapi/src/contact.rs
+++ b/crates/bcr-wdc-webapi/src/contact.rs
@@ -1,15 +1,27 @@
 use bcr_ebill_api::data::contact;
 // ----- standard library imports
 // ----- extra library imports
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 // ----- local modules
 use crate::identity::{File, PostalAddress};
 // ----- end imports
 
 #[repr(u8)]
 #[derive(
-    Debug, Copy, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq,
+    Debug,
+    Copy,
+    Clone,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    ToSchema,
 )]
+#[borsh(use_discriminant = true)]
 pub enum ContactType {
     Person = 0,
     Company = 1,

--- a/crates/bcr-wdc-webapi/src/identity.rs
+++ b/crates/bcr-wdc-webapi/src/identity.rs
@@ -7,7 +7,9 @@ use bcr_ebill_api::{
     data::{self, identity},
     util::BcrKeys,
 };
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 // ----- local imports
 // ----- end imports
 
@@ -21,7 +23,14 @@ pub enum Error {
 
 #[repr(u8)]
 #[derive(
-    Debug, Copy, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq,
+    Debug,
+    Copy,
+    Clone,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    PartialEq,
+    Eq,
+    ToSchema,
 )]
 pub enum IdentityType {
     Ident = 0,
@@ -120,7 +129,7 @@ pub struct NewIdentityPayload {
     pub identity_document_file_upload_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize, ToSchema)]
 pub struct PostalAddress {
     pub country: String,
     pub city: String,
@@ -150,7 +159,7 @@ impl From<PostalAddress> for data::PostalAddress {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize, ToSchema)]
 pub struct OptionalPostalAddress {
     pub country: Option<String>,
     pub city: Option<String>,
@@ -189,7 +198,7 @@ impl From<OptionalPostalAddress> for data::OptionalPostalAddress {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct File {
     pub name: String,
     pub hash: String,

--- a/crates/bcr-wdc-webapi/src/test_utils.rs
+++ b/crates/bcr-wdc-webapi/src/test_utils.rs
@@ -3,7 +3,7 @@ use chrono::NaiveTime;
 // ----- extra library imports
 use rand::Rng;
 // ----- local imports
-use crate::quotes::{ContactType, IdentityPublicData, PostalAddress};
+use crate::{bill::BillIdentParticipant, contact::ContactType, identity::PostalAddress};
 use bcr_wdc_utils::keys::test_utils as keys_test;
 // ----- end imports
 
@@ -23,10 +23,10 @@ pub fn random_date() -> String {
     random_date.to_rfc3339()
 }
 
-pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPublicData) {
+pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, BillIdentParticipant) {
     let keypair = keys_test::generate_random_keypair();
     let sample = [
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Person,
             email: Some(String::from("Carissa@kemp.com")),
             name: String::from("Carissa Kemp"),
@@ -37,9 +37,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("5196")),
                 address: String::from("Auf der Stift 17c"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Person,
             email: Some(String::from("alana@carrillo.com")),
             name: String::from("Alana Carrillo"),
@@ -50,9 +50,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("81015")),
                 address: String::from("Paseo José Emilio Ruíz 69"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Person,
             email: Some(String::from("geremia@pisani.com")),
             name: String::from("Geremia Pisani"),
@@ -63,9 +63,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("50141")),
                 address: String::from("Piazza Principale Umberto 148"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Person,
             email: Some(String::from("andreas@koenig.com")),
             name: String::from("Andreas Koenig"),
@@ -76,9 +76,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("9556")),
                 address: String::from("Haiden 96"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Person,
             email: Some(String::from("logistilla@fournier.com")),
             name: String::from("Logistilla Fournier"),
@@ -89,9 +89,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("31000")),
                 address: String::from("25, rou Pierre de Coubertin"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Company,
             email: Some(String::from("moonlimited@ltd.com")),
             name: String::from("Moon Limited"),
@@ -102,9 +102,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("86659-2593")),
                 address: String::from("3443 Joanny Bypass"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Company,
             email: Some(String::from("blanco@spa.com")),
             name: String::from("Blanco y Asoc."),
@@ -115,9 +115,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("38074")),
                 address: String::from("Isidora 96 0 7"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Company,
             email: Some(String::from("alexanderurner@grimm.com")),
             name: String::from("Grimm GmbH"),
@@ -128,9 +128,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("3512")),
                 address: String::from("Barthring 342"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Company,
             email: Some(String::from("antoniosegovia@santiago.com")),
             name: String::from("Empresa Santiago"),
@@ -141,9 +141,9 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("88191")),
                 address: String::from("Avinguida José Antonio, 20"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
-        IdentityPublicData {
+        BillIdentParticipant {
             t: ContactType::Company,
             email: Some(String::from("santoro_group@spa.com")),
             name: String::from("Santoro Group"),
@@ -154,7 +154,7 @@ pub fn random_identity_public_data() -> (bitcoin::secp256k1::Keypair, IdentityPu
                 zip: Some(String::from("51020")),
                 address: String::from("Corso Vittorio Emanuele, 90"),
             },
-            nostr_relay: Some(String::from("")),
+            nostr_relays: vec![String::from("")],
         },
     ];
 


### PR DESCRIPTION
* Fixed some clippy errors
* Added cargo deny to github workflow (as warning)
* Add basic test setup for ebill client and server
* Upgrade all ebill deps to 0.3.11 and use updated types
* Add endpoint to fetch bill endorsements (since the mint needs access to the previous endorsees)