### PR TITLE
[bcr-wdc-quote-service] Expose discounted offer from admin to user clients

### DIFF
--- a/crates/bcr-wdc-e2e-tests/src/main.rs
+++ b/crates/bcr-wdc-e2e-tests/src/main.rs
@@ -126,7 +126,7 @@ async fn can_mint_ebill(cfg: &MainConfig) {
 
     info!(keyset_info_id = ?keyset_info.id, "Confirmed active keyset");
 
-    let amounts = get_amounts(offered_discount.into())
+    let amounts = get_amounts(offered_discount.to_sat())
         .iter()
         .map(|a| cashu::Amount::from(*a))
         .collect::<Vec<_>>();
@@ -149,7 +149,7 @@ async fn can_mint_ebill(cfg: &MainConfig) {
         .iter()
         .map(|s| u64::from(s.amount))
         .sum::<u64>();
-    assert_eq!(cashu::Amount::from(total_amount), offered_discount);
+    assert_eq!(total_amount, offered_discount.to_sat());
     info!(amount = total_amount, "Mint Successful obtained signatures");
     for signature in blinded_signatures {
         info!(c_= ?signature.c, amount = ?signature.amount, keyset_id = ?signature.keyset_id, "Signature");

--- a/crates/bcr-wdc-quote-service/src/admin.rs
+++ b/crates/bcr-wdc-quote-service/src/admin.rs
@@ -137,7 +137,7 @@ fn convert_to_info_reply(quote: quotes::Quote) -> web_quotes::InfoReply {
             submitted: quote.submitted,
             suggested_expiration: calculate_default_expiration_date_for_quote(chrono::Utc::now()),
         },
-        quotes::QuoteStatus::Offered { keyset_id, ttl } => web_quotes::InfoReply::Offered {
+        quotes::QuoteStatus::Offered { keyset_id, ttl, discounted : _ } => web_quotes::InfoReply::Offered {
             id: quote.id,
             bill: quote.bill.into(),
             ttl,

--- a/crates/bcr-wdc-quote-service/src/admin.rs
+++ b/crates/bcr-wdc-quote-service/src/admin.rs
@@ -137,7 +137,11 @@ fn convert_to_info_reply(quote: quotes::Quote) -> web_quotes::InfoReply {
             submitted: quote.submitted,
             suggested_expiration: calculate_default_expiration_date_for_quote(chrono::Utc::now()),
         },
-        quotes::QuoteStatus::Offered { keyset_id, ttl, discounted : _ } => web_quotes::InfoReply::Offered {
+        quotes::QuoteStatus::Offered {
+            keyset_id,
+            ttl,
+            discounted: _,
+        } => web_quotes::InfoReply::Offered {
             id: quote.id,
             bill: quote.bill.into(),
             ttl,

--- a/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
@@ -348,7 +348,7 @@ mod tests {
         quote.status = quotes::QuoteStatus::Offered {
             keyset_id: keys_test::generate_random_keysetid(),
             ttl: TStamp::default(),
-            discounted: cashu::Amount::from(quote.bill.sum.to_sat()),
+            discounted: quote.bill.sum,
         };
         let res = db.update_status_if_pending(quote.id, quote.status).await;
         assert!(res.is_ok());
@@ -379,7 +379,7 @@ mod tests {
         quote.status = quotes::QuoteStatus::Offered {
             keyset_id: keys_test::generate_random_keysetid(),
             ttl: TStamp::default(),
-            discounted: cashu::Amount::from(quote.bill.sum.to_sat()),
+            discounted: quote.bill.sum,
         };
         let res = db.update_status_if_pending(quote.id, quote.status).await;
         assert!(res.is_err());
@@ -404,7 +404,7 @@ mod tests {
             status: quotes::QuoteStatus::Offered {
                 keyset_id: keys_test::generate_random_keysetid(),
                 ttl: TStamp::default(),
-                discounted: cashu::Amount::default(),
+                discounted: bitcoin::Amount::default(),
             },
         };
         let dbquote = QuoteDBEntry::from(quote.clone());
@@ -441,7 +441,7 @@ mod tests {
         quote.status = quotes::QuoteStatus::Offered {
             keyset_id: keys_test::generate_random_keysetid(),
             ttl: TStamp::default(),
-            discounted: cashu::Amount::from(quote.bill.sum.to_sat()),
+            discounted: quote.bill.sum,
         };
         let res = db.update_status_if_offered(quote.id, quote.status).await;
         assert!(res.is_err());

--- a/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
@@ -348,6 +348,7 @@ mod tests {
         quote.status = quotes::QuoteStatus::Offered {
             keyset_id: keys_test::generate_random_keysetid(),
             ttl: TStamp::default(),
+            discounted: cashu::Amount::from(quote.bill.sum.to_sat()),
         };
         let res = db.update_status_if_pending(quote.id, quote.status).await;
         assert!(res.is_ok());
@@ -378,6 +379,7 @@ mod tests {
         quote.status = quotes::QuoteStatus::Offered {
             keyset_id: keys_test::generate_random_keysetid(),
             ttl: TStamp::default(),
+            discounted: cashu::Amount::from(quote.bill.sum.to_sat()),
         };
         let res = db.update_status_if_pending(quote.id, quote.status).await;
         assert!(res.is_err());
@@ -402,6 +404,7 @@ mod tests {
             status: quotes::QuoteStatus::Offered {
                 keyset_id: keys_test::generate_random_keysetid(),
                 ttl: TStamp::default(),
+                discounted: cashu::Amount::default(),
             },
         };
         let dbquote = QuoteDBEntry::from(quote.clone());
@@ -438,6 +441,7 @@ mod tests {
         quote.status = quotes::QuoteStatus::Offered {
             keyset_id: keys_test::generate_random_keysetid(),
             ttl: TStamp::default(),
+            discounted: cashu::Amount::from(quote.bill.sum.to_sat()),
         };
         let res = db.update_status_if_offered(quote.id, quote.status).await;
         assert!(res.is_err());

--- a/crates/bcr-wdc-quote-service/src/quotes.rs
+++ b/crates/bcr-wdc-quote-service/src/quotes.rs
@@ -64,7 +64,7 @@ pub enum QuoteStatus {
     Offered {
         keyset_id: cdk02::Id,
         ttl: TStamp,
-        discounted: cashu::Amount,
+        discounted: bitcoin::Amount,
     },
     Rejected {
         tstamp: TStamp,
@@ -112,7 +112,7 @@ impl Quote {
         &mut self,
         keyset_id: cdk02::Id,
         ttl: TStamp,
-        discounted: cashu::Amount,
+        discounted: bitcoin::Amount,
     ) -> Result<()> {
         let QuoteStatus::Pending { .. } = self.status else {
             return Err(Error::QuoteAlreadyResolved(self.id));

--- a/crates/bcr-wdc-quote-service/src/quotes.rs
+++ b/crates/bcr-wdc-quote-service/src/quotes.rs
@@ -59,7 +59,7 @@ impl From<BillInfo> for bcr_wdc_webapi::quotes::BillInfo {
 pub enum QuoteStatus {
     Pending { public_key: cdk01::PublicKey },
     Denied,
-    Offered { keyset_id: cdk02::Id, ttl: TStamp },
+    Offered { keyset_id: cdk02::Id, ttl: TStamp, discounted: cashu::Amount },
     Rejected { tstamp: TStamp },
     Accepted { keyset_id: cdk02::Id },
 }
@@ -98,12 +98,12 @@ impl Quote {
         }
     }
 
-    pub fn offer(&mut self, keyset_id: cdk02::Id, ttl: TStamp) -> Result<()> {
+    pub fn offer(&mut self, keyset_id: cdk02::Id, ttl: TStamp, discounted: cashu::Amount) -> Result<()> {
         let QuoteStatus::Pending { .. } = self.status else {
             return Err(Error::QuoteAlreadyResolved(self.id));
         };
 
-        self.status = QuoteStatus::Offered { keyset_id, ttl };
+        self.status = QuoteStatus::Offered { keyset_id, ttl, discounted };
         Ok(())
     }
 

--- a/crates/bcr-wdc-quote-service/src/quotes.rs
+++ b/crates/bcr-wdc-quote-service/src/quotes.rs
@@ -57,11 +57,21 @@ impl From<BillInfo> for bcr_wdc_webapi::quotes::BillInfo {
 #[strum_discriminants(derive(serde::Serialize, serde::Deserialize))]
 #[serde(tag = "status")]
 pub enum QuoteStatus {
-    Pending { public_key: cdk01::PublicKey },
+    Pending {
+        public_key: cdk01::PublicKey,
+    },
     Denied,
-    Offered { keyset_id: cdk02::Id, ttl: TStamp, discounted: cashu::Amount },
-    Rejected { tstamp: TStamp },
-    Accepted { keyset_id: cdk02::Id },
+    Offered {
+        keyset_id: cdk02::Id,
+        ttl: TStamp,
+        discounted: cashu::Amount,
+    },
+    Rejected {
+        tstamp: TStamp,
+    },
+    Accepted {
+        keyset_id: cdk02::Id,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -98,12 +108,21 @@ impl Quote {
         }
     }
 
-    pub fn offer(&mut self, keyset_id: cdk02::Id, ttl: TStamp, discounted: cashu::Amount) -> Result<()> {
+    pub fn offer(
+        &mut self,
+        keyset_id: cdk02::Id,
+        ttl: TStamp,
+        discounted: cashu::Amount,
+    ) -> Result<()> {
         let QuoteStatus::Pending { .. } = self.status else {
             return Err(Error::QuoteAlreadyResolved(self.id));
         };
 
-        self.status = QuoteStatus::Offered { keyset_id, ttl, discounted };
+        self.status = QuoteStatus::Offered {
+            keyset_id,
+            ttl,
+            discounted,
+        };
         Ok(())
     }
 

--- a/crates/bcr-wdc-quote-service/src/service.rs
+++ b/crates/bcr-wdc-quote-service/src/service.rs
@@ -288,9 +288,7 @@ where
             .store_signatures(request_id, expiration, signatures_fees)
             .await?;
 
-        let discounted_amount = cashu::Amount::from(discounted.to_sat());
-
-        quote.offer(kid, expiration, discounted_amount)?;
+        quote.offer(kid, expiration, discounted)?;
         self.quotes
             .update_status_if_pending(quote.id, quote.status)
             .await
@@ -512,7 +510,6 @@ mod tests {
         let public_key = keys_utils::publics()[0];
         let cloned = rnd_bill.clone();
         let mut repo = MockRepository::new();
-        let discounted_amount = cashu::Amount::from(rnd_bill.sum.to_sat());
         repo.expect_search_by_bill()
             .with(
                 eq(rnd_bill.id.clone()),
@@ -523,7 +520,7 @@ mod tests {
                     status: QuoteStatus::Offered {
                         keyset_id,
                         ttl: chrono::Utc::now() + chrono::Duration::days(1),
-                        discounted: discounted_amount,
+                        discounted: rnd_bill.sum,
                     },
                     id,
                     bill: cloned.clone(),
@@ -557,7 +554,6 @@ mod tests {
         let keyset_id = keys_utils::generate_random_keysetid();
         let public_key = keys_utils::publics()[0];
         let mut repo = MockRepository::new();
-        let discounted_amount = cashu::Amount::from(rnd_bill.sum.to_sat());
         repo.expect_search_by_bill()
             .with(
                 eq(rnd_bill.id.clone()),
@@ -568,7 +564,7 @@ mod tests {
                     status: QuoteStatus::Offered {
                         keyset_id,
                         ttl: chrono::Utc::now(),
-                        discounted: discounted_amount,
+                        discounted: rnd_bill.sum,
                     },
                     id,
                     bill: cloned.clone(),

--- a/crates/bcr-wdc-quote-service/src/service.rs
+++ b/crates/bcr-wdc-quote-service/src/service.rs
@@ -288,7 +288,9 @@ where
             .store_signatures(request_id, expiration, signatures_fees)
             .await?;
 
-        quote.offer(kid, expiration)?;
+        let discounted_amount = cashu::Amount::from(discounted.to_sat());
+
+        quote.offer(kid, expiration, discounted_amount)?;
         self.quotes
             .update_status_if_pending(quote.id, quote.status)
             .await
@@ -510,6 +512,7 @@ mod tests {
         let public_key = keys_utils::publics()[0];
         let cloned = rnd_bill.clone();
         let mut repo = MockRepository::new();
+        let discounted_amount = cashu::Amount::from(rnd_bill.sum.to_sat());
         repo.expect_search_by_bill()
             .with(
                 eq(rnd_bill.id.clone()),
@@ -520,6 +523,7 @@ mod tests {
                     status: QuoteStatus::Offered {
                         keyset_id,
                         ttl: chrono::Utc::now() + chrono::Duration::days(1),
+                        discounted: discounted_amount,
                     },
                     id,
                     bill: cloned.clone(),
@@ -553,6 +557,7 @@ mod tests {
         let keyset_id = keys_utils::generate_random_keysetid();
         let public_key = keys_utils::publics()[0];
         let mut repo = MockRepository::new();
+        let discounted_amount = cashu::Amount::from(rnd_bill.sum.to_sat());
         repo.expect_search_by_bill()
             .with(
                 eq(rnd_bill.id.clone()),
@@ -563,6 +568,7 @@ mod tests {
                     status: QuoteStatus::Offered {
                         keyset_id,
                         ttl: chrono::Utc::now(),
+                        discounted: discounted_amount,
                     },
                     id,
                     bill: cloned.clone(),

--- a/crates/bcr-wdc-quote-service/src/web.rs
+++ b/crates/bcr-wdc-quote-service/src/web.rs
@@ -57,10 +57,14 @@ fn convert_to_enquire_reply(quote: quotes::Quote) -> web_quotes::StatusReply {
     match quote.status {
         quotes::QuoteStatus::Pending { .. } => web_quotes::StatusReply::Pending,
         quotes::QuoteStatus::Denied => web_quotes::StatusReply::Denied,
-        quotes::QuoteStatus::Offered { keyset_id, ttl, discounted } => web_quotes::StatusReply::Offered {
+        quotes::QuoteStatus::Offered {
+            keyset_id,
+            ttl,
+            discounted,
+        } => web_quotes::StatusReply::Offered {
             keyset_id,
             expiration_date: ttl,
-            discounted
+            discounted,
         },
         quotes::QuoteStatus::Rejected { tstamp } => web_quotes::StatusReply::Rejected { tstamp },
         quotes::QuoteStatus::Accepted { keyset_id } => {

--- a/crates/bcr-wdc-quote-service/src/web.rs
+++ b/crates/bcr-wdc-quote-service/src/web.rs
@@ -57,9 +57,10 @@ fn convert_to_enquire_reply(quote: quotes::Quote) -> web_quotes::StatusReply {
     match quote.status {
         quotes::QuoteStatus::Pending { .. } => web_quotes::StatusReply::Pending,
         quotes::QuoteStatus::Denied => web_quotes::StatusReply::Denied,
-        quotes::QuoteStatus::Offered { keyset_id, ttl } => web_quotes::StatusReply::Offered {
+        quotes::QuoteStatus::Offered { keyset_id, ttl, discounted } => web_quotes::StatusReply::Offered {
             keyset_id,
             expiration_date: ttl,
+            discounted
         },
         quotes::QuoteStatus::Rejected { tstamp } => web_quotes::StatusReply::Rejected { tstamp },
         quotes::QuoteStatus::Accepted { keyset_id } => {

--- a/crates/bcr-wdc-webapi/src/quotes.rs
+++ b/crates/bcr-wdc-webapi/src/quotes.rs
@@ -47,7 +47,8 @@ pub enum StatusReply {
     Offered {
         keyset_id: cdk02::Id,
         expiration_date: chrono::DateTime<chrono::Utc>,
-        discounted: cashu::Amount,
+        #[schema(value_type = u64)]
+        discounted: bitcoin::Amount,
     },
     Accepted {
         keyset_id: cdk02::Id,

--- a/crates/bcr-wdc-webapi/src/quotes.rs
+++ b/crates/bcr-wdc-webapi/src/quotes.rs
@@ -47,6 +47,7 @@ pub enum StatusReply {
     Offered {
         keyset_id: cdk02::Id,
         expiration_date: chrono::DateTime<chrono::Utc>,
+        discounted: cashu::Amount,
     },
     Accepted {
         keyset_id: cdk02::Id,


### PR DESCRIPTION
### **User description**
When querying the status of a quote, the user needs the discounted amount from the operator in order to make a decision whether to proceed.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Expose discounted offer amount to user clients in quote status.
  - Add `discounted` field to `Offered` status in API and service.
  - Propagate discounted amount through quote lifecycle and web responses.

- Update and extend tests for discounted offer handling.
  - Adjust e2e and unit tests to verify discounted field.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>quotes.rs</strong><dd><code>Add discounted field to Offered status reply</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/155/files#diff-42911c9e24e041418ffc2f1e92de4be1171ef724642b15b4228d37b60499f496">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>web.rs</strong><dd><code>Return discounted amount in Offered status web reply</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/155/files#diff-1bd0e6958ea77d8d30de256aa68ee557a88bc615c71586889a98edca3ea18e30">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>quotes.rs</strong><dd><code>Add discounted to Offered status and quote offer logic</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/155/files#diff-03545ff0e2dffaef5dbb0e2990ee74cf84c03a3c10f8f0f069b28ac5734f1ef8">+25/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service.rs</strong><dd><code>Pass discounted amount through offer and update tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/155/files#diff-186f7e8fe93bbc7070dc420fa5c734f262aa91e2cc4a5585eecc838222112f36">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>admin.rs</strong><dd><code>Update admin info reply for new Offered status structure</code>&nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/155/files#diff-0ac7a81b04baaf01768d8526f8dceb0754d20adf93d53808f189a4b810752acb">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>surreal.rs</strong><dd><code>Update persistence and tests for discounted in Offered status</code></dd></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/155/files#diff-e0caddd16b02b3646a69fca2fb0c9f351fcb57dcd7d613a1c750a4e1bd051a0b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.rs</strong><dd><code>Update e2e tests to check discounted offer propagation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/155/files#diff-7dfaf4fa6e45c9464ca129bab5799f4ef75cb2e6e8bb38769a49b510506f6a86">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>