### PR TITLE
[bcr-wdc-wallet-aggregator] determine swap type

### DIFF
--- a/crates/bcr-wdc-wallet-aggregator/Cargo.toml
+++ b/crates/bcr-wdc-wallet-aggregator/Cargo.toml
@@ -17,6 +17,7 @@ bcr-wdc-treasury-client = {workspace = true}
 cashu.workspace = true
 cdk = {workspace = true, features = ["wallet"]}
 config = {workspace = true}
+futures = {workspace = true}
 serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
by querying the crsat's key-service to get information on the keyset ids of inputs and outputs.
Based on the answer we can figure out the type of swap operation and forward the request properly.
Better than the previous solution based on trial and error