### PR TITLE
[bcr-wdc-ebpp] Add example treasury service public key

### DIFF
--- a/docker/ebpp/config.toml
+++ b/docker/ebpp/config.toml
@@ -7,6 +7,7 @@ bind_address = "0.0.0.0:3338"
 grpc_address = "0.0.0.0:9090"
 electrum_url = "electrs:50001"
 refresh_interval_secs=30
+treasury_service_public_key = "0234dd69c56c36a41230d573d68adeae0030c9bc0bf26f24d3e1b64c604d293c68"
 
 [appcfg.onchain]
 mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"


### PR DESCRIPTION
### **User description**
Add missing config key example to start ebpp, otherwise preventing bff-dashboard-service from starting in the compose configuration.


___

### **PR Type**
enhancement


___

### **Description**
- Added example `treasury_service_public_key` to EBPP config.

- Ensures BFF dashboard service can start with compose.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.toml</strong><dd><code>Add example treasury public key to config.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/ebpp/config.toml

<li>Added <code>treasury_service_public_key</code> example to <code>[appcfg]</code> section.<br> <li> Improves configuration completeness for service startup.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/159/files#diff-48502a787caf5ebdcd9d9f3884b405a0d2adf49a1dfe18b19537e78f855367e4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>