### PR TITLE
[bcr-wdc-key-service] implement restore endpoint

### DIFF
--- a/crates/bcr-wdc-key-client/src/lib.rs
+++ b/crates/bcr-wdc-key-client/src/lib.rs
@@ -1,7 +1,9 @@
 // ----- standard library imports
 // ----- extra library imports
 use bcr_wdc_webapi::keys as web_keys;
-use cashu::{nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut04 as cdk04, nut20 as cdk20};
+use cashu::{
+    nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut04 as cdk04, nut09 as cdk09, nut20 as cdk20,
+};
 use thiserror::Error;
 // ----- local imports
 pub use reqwest::Url;
@@ -192,6 +194,26 @@ impl KeyClient {
         let response = result.json::<cdk04::MintBolt11Response>().await?;
         Ok(response.signatures)
     }
+
+    pub async fn restore(
+        &self,
+        outputs: Vec<cdk00::BlindedMessage>,
+    ) -> Result<Vec<(cdk00::BlindedMessage, cdk00::BlindSignature)>> {
+        let url = self.base.join("v1/restore").expect("restore relative path");
+        let msg = cdk09::RestoreRequest { outputs };
+        let response = self.cl.post(url).json(&msg).send().await?;
+        let msg: cdk09::RestoreResponse = response.json().await?;
+        let cdk09::RestoreResponse {
+            outputs,
+            signatures,
+            ..
+        } = msg;
+        let ret_val = outputs
+            .into_iter()
+            .zip(signatures.into_iter())
+            .collect::<Vec<_>>();
+        Ok(ret_val)
+    }
 }
 
 #[cfg(feature = "test-utils")]
@@ -267,6 +289,13 @@ pub mod test_utils {
             _outputs: &[cdk00::BlindedMessage],
             _sk: cdk01::SecretKey,
         ) -> Result<()> {
+            todo!()
+        }
+
+        pub async fn restore(
+            &self,
+            _outputs: Vec<cdk00::BlindedMessage>,
+        ) -> Result<Vec<(cdk00::BlindedMessage, cdk00::BlindSignature)>> {
             todo!()
         }
     }

--- a/crates/bcr-wdc-key-client/tests/keys.rs
+++ b/crates/bcr-wdc-key-client/tests/keys.rs
@@ -6,7 +6,7 @@ use bcr_wdc_utils::keys::test_utils as keys_utils;
 
 #[tokio::test]
 async fn keys_not_found() {
-    let server = bcr_wdc_key_service::test_utils::build_test_server();
+    let server = bcr_wdc_key_service::test_utils::build_test_server(None);
     let server_url = server.server_address().expect("address");
     let client = KeyClient::new(server_url);
 

--- a/crates/bcr-wdc-key-client/tests/keyset_info.rs
+++ b/crates/bcr-wdc-key-client/tests/keyset_info.rs
@@ -6,7 +6,7 @@ use bcr_wdc_utils::keys::test_utils as keys_utils;
 
 #[tokio::test]
 async fn keyset_info_not_found() {
-    let server = bcr_wdc_key_service::test_utils::build_test_server();
+    let server = bcr_wdc_key_service::test_utils::build_test_server(None);
     let server_url = server.server_address().expect("address");
     let client = KeyClient::new(server_url);
 

--- a/crates/bcr-wdc-key-client/tests/list_keys.rs
+++ b/crates/bcr-wdc-key-client/tests/list_keys.rs
@@ -5,7 +5,7 @@ use bcr_wdc_key_client::KeyClient;
 
 #[tokio::test]
 async fn list_keys_empty() {
-    let server = bcr_wdc_key_service::test_utils::build_test_server();
+    let server = bcr_wdc_key_service::test_utils::build_test_server(None);
     let server_url = server.server_address().expect("address");
     let client = KeyClient::new(server_url);
 

--- a/crates/bcr-wdc-key-client/tests/list_keyset_info.rs
+++ b/crates/bcr-wdc-key-client/tests/list_keyset_info.rs
@@ -5,7 +5,7 @@ use bcr_wdc_key_client::KeyClient;
 
 #[tokio::test]
 async fn list_keyset_info_empty() {
-    let server = bcr_wdc_key_service::test_utils::build_test_server();
+    let server = bcr_wdc_key_service::test_utils::build_test_server(None);
     let server_url = server.server_address().expect("address");
     let client = KeyClient::new(server_url);
 

--- a/crates/bcr-wdc-key-client/tests/pre_sign.rs
+++ b/crates/bcr-wdc-key-client/tests/pre_sign.rs
@@ -7,7 +7,7 @@ use cashu::Amount;
 
 #[tokio::test]
 async fn pre_sign() {
-    let server = bcr_wdc_key_service::test_utils::build_test_server();
+    let server = bcr_wdc_key_service::test_utils::build_test_server(None);
     let server_url = server.server_address().expect("address");
     let client = KeyClient::new(server_url);
 

--- a/crates/bcr-wdc-key-client/tests/restore.rs
+++ b/crates/bcr-wdc-key-client/tests/restore.rs
@@ -1,0 +1,32 @@
+// ----- standard library imports
+// ----- extra library imports
+use bcr_wdc_key_client::KeyClient;
+use bcr_wdc_utils::keys::test_utils as keys_test;
+use cashu::{nut00 as cdk00, Amount};
+// ----- local imports
+
+#[tokio::test]
+async fn restore() {
+    let entry = keys_test::generate_random_keyset();
+    let server = bcr_wdc_key_service::test_utils::build_test_server(Some(entry.clone()));
+    let server_url = server.server_address().expect("address");
+    let client = KeyClient::new(server_url);
+
+    let (msg, _, _) = keys_test::generate_blind(entry.0.id, Amount::from(16));
+
+    client
+        .sign(&msg)
+        .await
+        .expect("sign blind in prep for test");
+
+    let test_msg = [cdk00::BlindedMessage {
+        amount: Amount::ZERO,
+        blinded_secret: msg.blinded_secret,
+        keyset_id: keys_test::generate_random_keysetid(),
+        witness: None,
+    }];
+
+    let resp = client.restore(test_msg.to_vec()).await.expect("restore");
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0].1.amount, msg.amount);
+}

--- a/crates/bcr-wdc-key-service/src/admin.rs
+++ b/crates/bcr-wdc-key-service/src/admin.rs
@@ -5,7 +5,7 @@ use bcr_wdc_webapi::keys as web_keys;
 use cashu::{nut00 as cdk00, nut02 as cdk02};
 // ----- local imports
 use crate::error::Result;
-use crate::service::{KeysRepository, QuoteKeysRepository, Service};
+use crate::service::{KeysRepository, QuoteKeysRepository, Service, SignaturesRepository};
 
 #[utoipa::path(
     post,
@@ -17,12 +17,13 @@ use crate::service::{KeysRepository, QuoteKeysRepository, Service};
     )
 )]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn sign_blind<QuotesKeysRepo, KeysRepo>(
-    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo>>,
+pub async fn sign_blind<QuotesKeysRepo, KeysRepo, SignsRepo>(
+    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo, SignsRepo>>,
     Json(blind): Json<cdk00::BlindedMessage>,
 ) -> Result<Json<cdk00::BlindSignature>>
 where
     KeysRepo: KeysRepository,
+    SignsRepo: SignaturesRepository,
 {
     tracing::debug!("Received sign blind request");
     ctrl.sign_blind(&blind).await.map(Json)
@@ -38,8 +39,8 @@ where
     )
 )]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn verify_proof<QuotesKeysRepo, KeysRepo>(
-    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo>>,
+pub async fn verify_proof<QuotesKeysRepo, KeysRepo, SignsRepo>(
+    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo, SignsRepo>>,
     Json(proof): Json<cdk00::Proof>,
 ) -> Result<()>
 where
@@ -59,8 +60,8 @@ where
     )
 )]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn generate<QuotesKeysRepo, KeysRepo>(
-    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo>>,
+pub async fn generate<QuotesKeysRepo, KeysRepo, SignsRepo>(
+    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo, SignsRepo>>,
     Json(request): Json<web_keys::GenerateKeysetRequest>,
 ) -> Result<Json<cdk02::Id>>
 where
@@ -88,8 +89,8 @@ where
     )
 )]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn pre_sign<QuotesKeysRepo, KeysRepo>(
-    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo>>,
+pub async fn pre_sign<QuotesKeysRepo, KeysRepo, SignsRepo>(
+    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo, SignsRepo>>,
     Json(request): Json<web_keys::PreSignRequest>,
 ) -> Result<Json<cdk00::BlindSignature>>
 where
@@ -110,8 +111,8 @@ where
     )
 )]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn activate<QuotesKeysRepo, KeysRepo>(
-    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo>>,
+pub async fn activate<QuotesKeysRepo, KeysRepo, SignsRepo>(
+    State(ctrl): State<Service<QuotesKeysRepo, KeysRepo, SignsRepo>>,
     Json(request): Json<web_keys::ActivateKeysetRequest>,
 ) -> Result<()>
 where

--- a/crates/bcr-wdc-key-service/src/error.rs
+++ b/crates/bcr-wdc-key-service/src/error.rs
@@ -17,13 +17,15 @@ pub enum Error {
     SignKeys(#[from] keys_utils::SignWithKeysError),
     #[error("verify with keys {0}")]
     VerifyKeys(#[from] keys_utils::VerifyWithKeysError),
+    #[error("signatures repository error {0}")]
+    SignaturesRepository(AnyError),
 
     #[error("Unknown keyset {0}")]
     UnknownKeyset(cdk02::Id),
     #[error("Unknown keyset from id {0}")]
     UnknownKeysetFromId(uuid::Uuid),
-    #[error("invalid mint request")]
-    InvalidMintRequest,
+    #[error("invalid mint request: {0}")]
+    InvalidMintRequest(String),
     #[error("invalid generate request {0}")]
     InvalidGenerateRequest(uuid::Uuid),
 }
@@ -36,9 +38,9 @@ impl axum::response::IntoResponse for Error {
                 StatusCode::BAD_REQUEST,
                 String::from("Invalid generate request"),
             ),
-            Error::InvalidMintRequest => (
+            Error::InvalidMintRequest(msg) => (
                 StatusCode::BAD_REQUEST,
-                String::from("Invalid mint request"),
+                format!("Invalid mint request: {msg}"),
             ),
             Error::UnknownKeysetFromId(_) => (
                 StatusCode::NOT_FOUND,
@@ -46,6 +48,7 @@ impl axum::response::IntoResponse for Error {
             ),
             Error::UnknownKeyset(_) => (StatusCode::NOT_FOUND, String::from("Unknown keyset")),
 
+            Error::SignaturesRepository(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::VerifyKeys(_) => (StatusCode::BAD_REQUEST, String::new()),
             Error::SignKeys(_) => (StatusCode::BAD_REQUEST, String::new()),
             Error::KeysRepository(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),

--- a/crates/bcr-wdc-key-service/src/lib.rs
+++ b/crates/bcr-wdc-key-service/src/lib.rs
@@ -4,7 +4,7 @@ use axum::extract::FromRef;
 use axum::routing::{get, post};
 use axum::Router;
 use bitcoin::bip32 as btc32;
-use cashu::{nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut04 as cdk04};
+use cashu::{nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut04 as cdk04, nut09 as cdk09};
 use utoipa::OpenApi;
 // ----- local modules
 mod admin;
@@ -22,12 +22,15 @@ type TStamp = chrono::DateTime<chrono::Utc>;
 
 pub type ProdQuoteKeysRepository = persistence::surreal::DBQuoteKeys;
 pub type ProdKeysRepository = persistence::surreal::DBKeys;
-pub type ProdKeysService = service::Service<ProdQuoteKeysRepository, ProdKeysRepository>;
+pub type ProdSignaturesRepository = persistence::surreal::DBSignatures;
+pub type ProdKeysService =
+    service::Service<ProdQuoteKeysRepository, ProdKeysRepository, ProdSignaturesRepository>;
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
 pub struct AppConfig {
     keys: persistence::surreal::ConnectionConfig,
     quotekeys: persistence::surreal::ConnectionConfig,
+    signatures: persistence::surreal::ConnectionConfig,
     starting_derivation_path: btc32::DerivationPath,
 }
 
@@ -41,6 +44,7 @@ impl AppController {
         let AppConfig {
             keys,
             quotekeys,
+            signatures,
             starting_derivation_path,
         } = cfg;
 
@@ -50,32 +54,38 @@ impl AppController {
         let quotekeys_repo = ProdQuoteKeysRepository::new(quotekeys)
             .await
             .expect("DB connection to quotekeys failed");
+        let signatures_repo = ProdSignaturesRepository::new(signatures)
+            .await
+            .expect("DB connection to signatures failed");
         let keygen = factory::Factory::new(seed, starting_derivation_path);
         let srv = ProdKeysService {
             keys: keys_repo,
             quote_keys: quotekeys_repo,
+            signatures: signatures_repo,
             keygen,
         };
         Self { keys: srv }
     }
 }
 
-pub fn routes<Cntrlr, Q, K>(ctrl: Cntrlr) -> Router
+pub fn routes<Cntrlr, QuoteKeysRepo, KeysRepo, SignsRepo>(ctrl: Cntrlr) -> Router
 where
-    Q: service::QuoteKeysRepository + Send + Sync + 'static,
-    K: service::KeysRepository + Send + Sync + 'static,
-    service::Service<Q, K>: FromRef<Cntrlr>,
+    QuoteKeysRepo: service::QuoteKeysRepository + Send + Sync + 'static,
+    KeysRepo: service::KeysRepository + Send + Sync + 'static,
+    SignsRepo: service::SignaturesRepository + Send + Sync + 'static,
+    service::Service<QuoteKeysRepo, KeysRepo, SignsRepo>: FromRef<Cntrlr> + Send + Sync + 'static,
     Cntrlr: Send + Sync + Clone + 'static,
 {
     let swagger = utoipa_swagger_ui::SwaggerUi::new("/swagger-ui")
         .url("/api-docs/openapi.json", ApiDoc::openapi());
 
     let web = Router::new()
-        .route("/v1/keysets/{kid}", get(web::lookup_keysets))
+        .route("/v1/keysets/{kid}", get(web::lookup_keyset))
         .route("/v1/keysets", get(web::list_keysets))
         .route("/v1/keys/{kid}", get(web::lookup_keys))
         .route("/v1/keys", get(web::list_keys))
-        .route("/v1/mint/ebill", post(web::mint_ebill));
+        .route("/v1/mint/ebill", post(web::mint_ebill))
+        .route("/v1/restore", post(web::restore));
     // separate admin as it will likely have different auth requirements
     let admin = Router::new()
         .route("/v1/admin/keys/sign", post(admin::sign_blind))
@@ -108,6 +118,8 @@ where
         cdk02::KeysetResponse,
         cdk04::MintBolt11Request<String>,
         cdk04::MintBolt11Response,
+        cdk09::RestoreRequest,
+        cdk09::RestoreResponse,
     ),),
     paths(
         admin::activate,
@@ -118,8 +130,9 @@ where
         web::list_keys,
         web::list_keysets,
         web::lookup_keys,
-        web::lookup_keysets,
+        web::lookup_keyset,
         web::mint_ebill,
+        web::restore,
     )
 )]
 struct ApiDoc;
@@ -127,11 +140,15 @@ struct ApiDoc;
 #[cfg(feature = "test-utils")]
 pub mod test_utils {
     use super::*;
+    use bcr_wdc_utils::{keys::test_utils as keys_test, KeysetEntry};
+    use cashu::Amount;
 
-    pub type InMemoryRepository = persistence::inmemory::InMemoryMap;
+    pub type InMemoryRepository = persistence::inmemory::InMemoryKeyMap;
     pub type TestQuoteKeysRepository = persistence::inmemory::InMemoryQuoteKeyMap;
-    pub type TestKeysRepository = persistence::inmemory::InMemoryMap;
-    pub type TestKeysService = service::Service<TestQuoteKeysRepository, TestKeysRepository>;
+    pub type TestKeysRepository = persistence::inmemory::InMemoryKeyMap;
+    pub type TestSignaturesRepository = persistence::inmemory::InMemorySignatureMap;
+    pub type TestKeysService =
+        service::Service<TestQuoteKeysRepository, TestKeysRepository, TestSignaturesRepository>;
 
     #[derive(Clone, FromRef)]
     pub struct AppController {
@@ -144,22 +161,36 @@ pub mod test_utils {
             let derivation_path = btc32::DerivationPath::default();
             let keys_repo = TestKeysRepository::default();
             let quotekeys_repo = TestQuoteKeysRepository::default();
+            let signatures_repo = TestSignaturesRepository::default();
             let keygen = factory::Factory::new(&seed, derivation_path);
             let srv = TestKeysService {
                 keys: keys_repo,
                 quote_keys: quotekeys_repo,
+                signatures: signatures_repo,
                 keygen,
             };
             Self { keys: srv }
         }
     }
 
-    pub fn build_test_server() -> axum_test::TestServer {
+    pub fn build_test_server(keyset: Option<KeysetEntry>) -> axum_test::TestServer {
         let cfg = axum_test::TestServerConfig {
             transport: Some(axum_test::Transport::HttpRandomPort),
             ..Default::default()
         };
         let cntrl = AppController::default();
+        if let Some(entry) = keyset {
+            let condition = MintCondition {
+                is_minted: true,
+                pub_key: keys_test::publics()[0],
+                target: Amount::ZERO,
+            };
+            cntrl
+                .keys
+                .keys
+                .store(entry, condition)
+                .expect("store keyset");
+        }
         axum_test::TestServer::new_with_config(routes(cntrl), cfg)
             .expect("failed to start test server")
     }

--- a/docker/key-service/config.toml
+++ b/docker/key-service/config.toml
@@ -15,5 +15,11 @@ namespace = "test"
 database = "key"
 table = "quotes"
 
+[appcfg.signatures]
+connection = "ws://surrealdb:8000"
+namespace = "test"
+database = "key"
+table = "signatures"
+
 [appcfg]
 starting_derivation_path = "m/129372'/0/0"


### PR DESCRIPTION
as in NUT09.
This commit introduces a DB for signatures where the key-service stores all signatures generated indexed by the blinded secret sent by the user