### PR TITLE
[bcr-wdc-quote-service] Fix list pending quotes endpoint

### DIFF
--- a/crates/bcr-wdc-quote-service/src/admin.rs
+++ b/crates/bcr-wdc-quote-service/src/admin.rs
@@ -22,7 +22,7 @@ use crate::service::{KeysHandler, ListFilters, Repository, Service, SortOrder, W
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn list_pending_quotes<KeysHndlr, Wlt, QuotesRepo>(
     State(ctrl): State<Service<KeysHndlr, Wlt, QuotesRepo>>,
-    Query(since): Query<Option<chrono::DateTime<chrono::Utc>>>,
+    Query(req): Query<web_quotes::ListPendingQueryRequest>,
 ) -> Result<Json<web_quotes::ListReply>>
 where
     KeysHndlr: KeysHandler,
@@ -31,7 +31,7 @@ where
 {
     tracing::debug!("Received request to list pending quotes");
 
-    let quotes = ctrl.list_pendings(since).await?;
+    let quotes = ctrl.list_pendings(req.since).await?;
     Ok(Json(web_quotes::ListReply { quotes }))
 }
 

--- a/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
@@ -181,16 +181,20 @@ impl DBQuotes {
         status: quotes::QuoteStatusDiscriminants,
         since: Option<TStamp>,
     ) -> SurrealResult<Vec<Uuid>> {
-        let mut query = String::from("SELECT qid, submitted FROM type::table($table) WHERE status.status == $status");
+        let mut query = String::from(
+            "SELECT qid, submitted FROM type::table($table) WHERE status.status == $status",
+        );
         if since.is_some() {
             query += " AND submitted >= $since";
         }
         query += " ORDER BY submitted DESC";
 
-        let mut db_query = self.db.query(query)
+        let mut db_query = self
+            .db
+            .query(query)
             .bind(("table", self.table.clone()))
             .bind(("status", status));
-        
+
         if let Some(since) = since {
             db_query = db_query.bind(("since", since));
         }

--- a/crates/bcr-wdc-webapi/src/quotes.rs
+++ b/crates/bcr-wdc-webapi/src/quotes.rs
@@ -1,4 +1,5 @@
 // ----- standard library imports
+use chrono::{DateTime, Utc};
 // ----- extra library imports
 use borsh::{BorshDeserialize, BorshSerialize};
 use cashu::{nut01 as cdk01, nut02 as cdk02};
@@ -46,7 +47,7 @@ pub enum StatusReply {
     Denied,
     Offered {
         keyset_id: cdk02::Id,
-        expiration_date: chrono::DateTime<chrono::Utc>,
+        expiration_date: DateTime<Utc>,
         #[schema(value_type = u64)]
         discounted: bitcoin::Amount,
     },
@@ -54,7 +55,7 @@ pub enum StatusReply {
         keyset_id: cdk02::Id,
     },
     Rejected {
-        tstamp: chrono::DateTime<chrono::Utc>,
+        tstamp: DateTime<Utc>,
     },
 }
 
@@ -103,13 +104,13 @@ pub enum InfoReply {
     Pending {
         id: uuid::Uuid,
         bill: BillInfo,
-        submitted: chrono::DateTime<chrono::Utc>,
-        suggested_expiration: chrono::DateTime<chrono::Utc>,
+        submitted: DateTime<Utc>,
+        suggested_expiration: DateTime<Utc>,
     },
     Offered {
         id: uuid::Uuid,
         bill: BillInfo,
-        ttl: chrono::DateTime<chrono::Utc>,
+        ttl: DateTime<Utc>,
         keyset_id: cdk02::Id,
     },
     Denied {
@@ -124,8 +125,14 @@ pub enum InfoReply {
     Rejected {
         id: uuid::Uuid,
         bill: BillInfo,
-        tstamp: chrono::DateTime<chrono::Utc>,
+        tstamp: DateTime<Utc>,
     },
+}
+
+
+#[derive(Serialize, Deserialize, ToSchema, Debug)]
+pub struct ListPendingQueryRequest {
+    pub since: Option<DateTime<Utc>>,
 }
 
 /// --------------------------- Update quote status request
@@ -136,7 +143,7 @@ pub enum UpdateQuoteRequest {
     Offer {
         #[schema(value_type = u64)]
         discounted: bitcoin::Amount,
-        ttl: Option<chrono::DateTime<chrono::Utc>>,
+        ttl: Option<DateTime<Utc>>,
     },
 }
 #[derive(Serialize, Deserialize, ToSchema)]
@@ -146,7 +153,7 @@ pub enum UpdateQuoteResponse {
     Offered {
         #[schema(value_type = u64)]
         discounted: bitcoin::Amount,
-        ttl: chrono::DateTime<chrono::Utc>,
+        ttl: DateTime<Utc>,
     },
 }
 

--- a/crates/bcr-wdc-webapi/src/quotes.rs
+++ b/crates/bcr-wdc-webapi/src/quotes.rs
@@ -129,7 +129,6 @@ pub enum InfoReply {
     },
 }
 
-
 #[derive(Serialize, Deserialize, ToSchema, Debug)]
 pub struct ListPendingQueryRequest {
     pub since: Option<DateTime<Utc>>,


### PR DESCRIPTION
### **User description**
* Fixed the query inputs which Closes #154 
* Fixes Surreal query


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes deserialization of optional `since` parameter in pending quotes endpoint
  - Introduces `ListPendingQueryRequest` struct for query parsing
  - Updates handler to accept new struct

- Corrects SurrealDB query for filtering by `since` timestamp
  - Dynamically builds query string based on presence of `since`
  - Ensures correct field selection and binding

- Refactors date/time type usage to consistently use `chrono::DateTime<Utc>`
  - Updates all relevant struct fields and enums


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Fix pending quotes endpoint to accept optional parameter</code>&nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/admin.rs

<li>Changes endpoint handler to accept <code>ListPendingQueryRequest</code> for query <br>parsing<br> <li> Updates call to <code>list_pendings</code> to use new struct's <code>since</code> field


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/161/files#diff-0ac7a81b04baaf01768d8526f8dceb0754d20adf93d53808f189a4b810752acb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>surreal.rs</strong><dd><code>Fix and enhance SurrealDB query for pending quotes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/persistence/surreal.rs

<li>Refactors SurrealDB query construction for filtering by <code>since</code><br> <li> Uses dynamic query string and corrects field selection to <code>qid</code><br> <li> Binds <code>since</code> parameter only if present


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/161/files#diff-e0caddd16b02b3646a69fca2fb0c9f351fcb57dcd7d613a1c750a4e1bd051a0b">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>quotes.rs</strong><dd><code>Add query struct and unify date/time types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-webapi/src/quotes.rs

<li>Adds <code>ListPendingQueryRequest</code> struct for query parsing<br> <li> Refactors all date/time fields to use <code>chrono::DateTime<Utc></code><br> <li> Updates relevant enums and structs for consistency


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/161/files#diff-42911c9e24e041418ffc2f1e92de4be1171ef724642b15b4228d37b60499f496">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>