### PR TITLE
[bff-dashboard-service] Add wildcard CORS to Envoy for local testing

### DIFF
--- a/docker/bff-dashboard-service/envoy.yaml
+++ b/docker/bff-dashboard-service/envoy.yaml
@@ -16,6 +16,16 @@ static_resources:
                   virtual_hosts:
                     - name: admin_api
                       domains: ["*"]
+                      typed_per_filter_config:
+                        envoy.filters.http.cors:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                          allow_origin_string_match:
+                          - safe_regex:
+                              regex: \*
+                          allow_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+                          allow_headers: "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Access-Control-Allow-Origin"
+                          allow_credentials: true
+                          max_age: "1728000"
                       routes:
                         - match: { prefix: "/v1/admin/credit" }
                           route: { cluster: quote_service }
@@ -30,6 +40,9 @@ static_resources:
                             cluster: ebpp_service
                             prefix_rewrite: "/v1/onchain"
                 http_filters:
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
                   - name: envoy.filters.http.jwt_authn
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication


### PR DESCRIPTION
This PR adds wildcard CORS configuration (`allow_origin_string_match: "*"`) to the Envoy configuration to facilitate local testing and development for the admin dashboard.

**Unsecure for production**, reminder to have a separate config with exact origin match for dashboard and other services which need the admin endpoint