### PR TITLE
ci: build & push images to GAR with base image caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,12 +63,11 @@ jobs:
         DOCKER_BUILDKIT=1 docker buildx build \
           --platform linux/amd64 \
           --file docker/base-image/Dockerfile \
-          --tag ${BASE_IMAGE_NAME}:latest \
           --tag  ${GAR_PATH}/${BASE_IMAGE_NAME}:${CACHE_TAG} \
           --push \
           --cache-from=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}" \
           --cache-to=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}",mode=max \
-          --output type=docker,dest="${BASE_TAR}",name="${BASE_IMAGE_NAME}" \
+          --output type=docker,dest="${BASE_TAR}",name=${BASE_IMAGE_NAME}:latest \
           .
 
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,7 @@ jobs:
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Set up Docker Buildx
+      id: buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       #with:
       #  driver: docker
@@ -141,9 +142,10 @@ jobs:
 
     - name: Import base image into BuildKit
       run: |
-        BUILDER=$(docker buildx inspect --format '{{.Nodes.0.Name}}')
-        docker cp "${BASE_TAR}" "${BUILDER}:/tmp/base.tar"
-        docker exec "${BUILDER}" ctr --namespace buildkit images import /tmp/base.tar
+        BUILDER_CONT="buildx_buildkit_${{ steps.buildx.outputs.name }}0"
+        echo "Using builder: ${BUILDER_CONT}"
+        docker cp "${BASE_TAR}" "${BUILDER_CONT}:/tmp/base.tar"
+        docker exec "${BUILDER_CONT}" ctr --namespace buildkit images import /tmp/base.tar
 
         
     #- name: Load base image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build & push Docker images to GCP Artifact Registry
 
 on:
   push:
-    #branches: [ "**" ] # only for testing
+    branches: [ "**" ] # only for testing
     tags:
       - "v*.*.*"
   schedule:
@@ -14,15 +14,13 @@ concurrency:
 
 permissions:
   contents: read
-  #id-token: write # required for Workload Identity Federation & provenance
-  #contents: write # required for provenance
+  #id-token: write # required for Workload Identity Federation
 
 env:
     PROJECT_ID: "bitcr-shared"
     GAR_LOCATION: "europe-west1"
     REPOSITORY: "bitcr-wildcat-dev"
     GAR_PATH: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev"
-    # base image
     BASE_IMAGE_NAME: "wildcat/base-image"
     BASE_IMAGE_CACHE: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/wildcat-base-cache"
     BASE_TAR: "base-image.tar"
@@ -73,6 +71,10 @@ jobs:
   wildcat-images:
     needs: base-image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for attest-build-provenance
+      attestations: write # required for attest-build-provenance
     strategy:
       fail-fast: false
       matrix:
@@ -146,8 +148,8 @@ jobs:
     # ─────────────────────────────
     # provenance
     # ─────────────────────────────
-    # - uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-    #   with:
-    #     subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
-    #     subject-digest: ${{ steps.push.outputs.digest }}
-    #     push-to-registry: true
+    - uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+      with:
+        subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ concurrency:
 
 permissions:
   contents: read
-  #id-token: write # required for Workload Identity Federation
+  id-token: write # required for Workload Identity Federation
 
 env:
     PROJECT_ID: "bitcr-shared"
@@ -40,7 +40,12 @@ jobs:
     - name: Authenticate to GCP
       uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
-        credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        #credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        workload_identity_provider: ${{ secrets.GCLOUD_WIF_PROVIDER }}
+        service_account: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+        token_format: access_token
+
+
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -99,9 +104,13 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Authenticate to GCP
+      id: auth
       uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
-        credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        #credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        workload_identity_provider: ${{ secrets.GCLOUD_WIF_PROVIDER }}
+        service_account: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+        token_format: access_token
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -148,6 +157,17 @@ jobs:
     # ─────────────────────────────
     # provenance
     # ─────────────────────────────
+
+    - name: Auth w/ registry
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+      env:
+        REGISTRY: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+
+
     - uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
       with:
         subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,76 +22,31 @@ env:
     GAR_PATH: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev"
     # base image
     BASE_IMAGE_NAME: "wildcat/base-image"
-    BASE_IMAGE_CACHE_GAR_TAG: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/wildcat-base-cache:${{ github.ref_name }}"
+    BASE_IMAGE_CACHE: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/wildcat-base-cache"
+
 
 jobs:
-  base-image:
-    name: Build Base Docker Image
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Authenticate to GCP
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Docker auth for GAR (for base image cache)
-      run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
-
-
-    # ----------------------------------------------------------------------
-    # Build and Cache Base image
-    # ----------------------------------------------------------------------
-
-    - name: Build Docker Base Image (with GAR cache)
-      run: |
-        echo "Building base image. Local tag: ${{ env.BASE_IMAGE_NAME }}. Cache target: ${{ env.BASE_IMAGE_CACHE_GAR_TAG }}"
-        DOCKER_BUILDKIT=1 docker buildx build \
-          --tag ${{ env.BASE_IMAGE_NAME }} \
-          --file docker/base-image/Dockerfile \
-          --cache-from=type=registry,ref=${{ env.BASE_IMAGE_CACHE_GAR_TAG }} \
-          --cache-to=type=registry,ref=${{ env.BASE_IMAGE_CACHE_GAR_TAG }},mode=max \
-          --load \
-          . # Build context is repository root
-        echo "Base image build complete and loaded as ${{ env.BASE_IMAGE_NAME }}"
-
-      # cache-from: type=gha
-
-        
-
   wildcat-images:
-    name: Build and Push Wildcat Images
     runs-on: ubuntu-latest
-    needs: base-image    
-  
-    # ----------------------------------------------------------------------
-    # Wildcat services
-    # ----------------------------------------------------------------------
     strategy:
       fail-fast: false
+      max-parallel: 1 # eveluate if we need to parallelize this
       matrix:
         service:
           - name: bcr-wdc-key-service
-            dockerfile_path: docker/key-service/Dockerfile
+            dockerfile: docker/key-service/Dockerfile
           - name: bcr-wdc-treasury-service
-            dockerfile_path: docker/treasury-service/Dockerfile
+            dockerfile: docker/treasury-service/Dockerfile
           - name: bcr-wdc-swap-service
-            dockerfile_path: docker/swap-service/Dockerfile
+            dockerfile: docker/swap-service/Dockerfile
           - name: bcr-wdc-quote-service
-            dockerfile_path: docker/quote-service/Dockerfile
+            dockerfile: docker/quote-service/Dockerfile
           - name: bcr-wdc-wallet-aggregator
-            dockerfile_path: docker/wallet-aggregator/Dockerfile
+            dockerfile: docker/wallet-aggregator/Dockerfile
           - name: bcr-wdc-ebpp
-            dockerfile_path: docker/ebpp/Dockerfile
+            dockerfile: docker/ebpp/Dockerfile
           - name: bcr-wdc-ebill-service
-            dockerfile_path: docker/ebill-service/Dockerfile
-
+            dockerfile: docker/ebill-service/Dockerfile
 
     steps:
     - name: Checkout code
@@ -100,19 +55,35 @@ jobs:
     - name: Authenticate to GCP
       uses: google-github-actions/auth@v2
       with:
-        credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
+        credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Docker auth
+    - name: Docker auth for Artifact Registry
       run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
-    # ----------------------------------------------------------------------
-    # Metadata 
-    # ----------------------------------------------------------------------
-    - name: Docker Metadata for ${{ matrix.service.name }}
-      id: meta
+    # ───────────────────────────────
+    # Build & load the base image
+    # ───────────────────────────────
+    - name: Build base image (remote-cache, local load)
+      run: |
+        CACHE_TAG="${GITHUB_REF_NAME//\//-}"
+
+        echo "→ building ${BASE_IMAGE_NAME} using cache tag ${CACHE_TAG}"
+        DOCKER_BUILDKIT=1 docker buildx build \
+          --file docker/base-image/Dockerfile \
+          --tag "${BASE_IMAGE_NAME}" \
+          --cache-from=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}" \
+          --cache-to=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}",mode=max \
+          --load \
+          .
+
+    # ───────────────────────────────
+    # Service image metadata
+    # ───────────────────────────────
+    - id: meta
+      name: Metadata for ${{ matrix.service.name }}
       uses: docker/metadata-action@v5
       with:
         images: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
@@ -124,32 +95,28 @@ jobs:
           # Add 'latest' tag if on the default branch
           type=match,pattern=master,value=latest
 
-    # ----------------------------------------------------------------------
-    # Build and Push Wildcat Images
-    # ----------------------------------------------------------------------
-    - name: Build and Push ${{ matrix.service.name }}
-      id: push
+    # ───────────────────────────────
+    # Build & push the service image
+    # ───────────────────────────────
+    - id: push
+      name: Build & push ${{ matrix.service.name }}
       uses: docker/build-push-action@v6
       with:
         context: .
-        file: ${{ matrix.service.dockerfile_path }}
-        
-        push: true 
-        # Optional: push: ${{ github.event_name != 'pull_request' }}
-        
+        file: ${{ matrix.service.dockerfile }}
+        push: true
+        #platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
-        
         labels: ${{ steps.meta.outputs.labels }}
-        
+
         # Optional: Add build caching for the service image itself if it has many layers
         # cache-from: type=registry,ref=${{ env.GAR_PATH }}/${{ matrix.service.name }}:buildcache
         # cache-to: type=registry,ref=${{ env.GAR_PATH }}/${{ matrix.service.name }}:buildcache,mode=max
 
-    # ----------------------------------------------------------------------
-    # Artifact attestation
-    # ----------------------------------------------------------------------
-
-    - name: Generate artifact attestation
+    # ───────────────────────────────
+    # Provenance attestation
+    # ───────────────────────────────
+    - name: Attest provenance
       uses: actions/attest-build-provenance@v2
       with:
         subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,10 @@ jobs:
         DOCKER_BUILDKIT=1 docker buildx build \
           --platform linux/amd64 \
           --file docker/base-image/Dockerfile \
-          --tag  ${GAR_PATH}/${BASE_IMAGE_NAME}:${CACHE_TAG} \
-          --push \
+          --tag "${BASE_IMAGE_NAME}" \
           --cache-from=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}" \
           --cache-to=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}",mode=max \
-          --output type=docker,dest="${BASE_TAR}",name=${BASE_IMAGE_NAME}:latest \
+          --output type=docker,dest="${BASE_TAR}",name="${BASE_IMAGE_NAME}" \
           .
 
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Authenticate to GCP
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
         credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
     - name: Docker auth for Artifact Registry
       run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
@@ -61,7 +61,7 @@ jobs:
           --output=type=docker,dest="${BASE_TAR}",name="${BASE_IMAGE_NAME}" \
           .
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: base-image
         path: "${{ env.BASE_TAR }}"
@@ -94,22 +94,22 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Authenticate to GCP
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
         credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       with:
         driver: docker
 
     - name: Docker auth for Artifact Registry
       run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: base-image
         path: .
@@ -119,7 +119,7 @@ jobs:
 
     - id: meta
       name: Metadata for ${{ matrix.service.name }}
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
         images: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
         tags: |
@@ -132,7 +132,7 @@ jobs:
 
     - id: push
       name: Build & push ${{ matrix.service.name }}
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
       with:
         context: .
         file: ${{ matrix.service.dockerfile }}
@@ -146,7 +146,7 @@ jobs:
     # ─────────────────────────────
     # provenance
     # ─────────────────────────────
-    # - uses: actions/attest-build-provenance@v2
+    # - uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
     #   with:
     #     subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
     #     subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,6 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-      with:
-        driver: docker
 
     - name: Docker auth for Artifact Registry
       run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
@@ -60,11 +58,8 @@ jobs:
           --tag "${BASE_IMAGE_NAME}" \
           --cache-from=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}" \
           --cache-to=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}",mode=max \
-          --load \
+          --output=type=docker,dest="${BASE_TAR}",name="${BASE_IMAGE_NAME}" \
           .
-
-    - name: Save base image to tarball
-      run: docker save -o "${BASE_TAR}" "${BASE_IMAGE_NAME}"
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write # For Workload Identity Federation
+  #id-token: write # required for Workload Identity Federation & provenance
+  #contents: write # required for provenance
 
 env:
     PROJECT_ID: "bitcr-shared"
@@ -25,10 +26,11 @@ env:
     BASE_IMAGE_CACHE: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/wildcat-base-cache"
     BASE_TAR: "base-image.tar"
 
+jobs:
+
 # ───────────────────────────────
 # 1) build base once, upload tar
 # ───────────────────────────────
-jobs:
   base-image:
     runs-on: ubuntu-latest
 
@@ -153,8 +155,8 @@ jobs:
     # ─────────────────────────────
     # provenance
     # ─────────────────────────────
-    - uses: actions/attest-build-provenance@v2
-      with:
-        subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
-        subject-digest: ${{ steps.push.outputs.digest }}
-        push-to-registry: true
+    # - uses: actions/attest-build-provenance@v2
+    #   with:
+    #     subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
+    #     subject-digest: ${{ steps.push.outputs.digest }}
+    #     push-to-registry: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,13 @@
 name: Build & push Docker images to GCP Artifact Registry
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - cleot/build-push-to-registry
-#   push:
-#     branches: [ "master" ]
+    #branches: [ "**" ] # only for testing
+    tags:
+      - "v*.*.*"
+  schedule:
+      - cron: "0 10 * * *"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -29,7 +30,7 @@ env:
 jobs:
 
 # ───────────────────────────────
-# 1) build base once, upload tar
+# build base image, cache, upload local artifact
 # ───────────────────────────────
   base-image:
     runs-on: ubuntu-latest
@@ -49,9 +50,6 @@ jobs:
     - name: Docker auth for Artifact Registry
       run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
-    # ───────────────────────────────
-    # Build & load the base image
-    # ───────────────────────────────
     - name: Build base image (remote cache, local load)
       run: |
         CACHE_TAG="${GITHUB_REF_NAME//\//-}"
@@ -67,17 +65,16 @@ jobs:
       with:
         name: base-image
         path: "${{ env.BASE_TAR }}"
-        retention-days: 1          # keep just long enough for this workflow
+        retention-days: 1
 
 # ───────────────────────────────
-# 2) service matrix (needs base)
+# build & push wildcat images
 # ───────────────────────────────
   wildcat-images:
     needs: base-image
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false 
-      #max-parallel: 1
+      fail-fast: false
       matrix:
         service:
           - name: bcr-wdc-key-service
@@ -120,9 +117,6 @@ jobs:
     - name: Load base image
       run: docker load -i "${BASE_TAR}"
 
-    # ─────────────────────────────
-    # metadata for service image
-    # ─────────────────────────────
     - id: meta
       name: Metadata for ${{ matrix.service.name }}
       uses: docker/metadata-action@v5
@@ -136,9 +130,6 @@ jobs:
           # Add 'latest' tag if on the default branch
           type=match,pattern=master,value=latest
 
-    # ─────────────────────────────
-    # build & push service image
-    # ─────────────────────────────
     - id: push
       name: Build & push ${{ matrix.service.name }}
       uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 permissions:
   contents: read
-  # id-token: write # For Workload Identity Federation
+  id-token: write # For Workload Identity Federation
 
 env:
     PROJECT_ID: "bitcr-shared"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,64 @@ env:
     # base image
     BASE_IMAGE_NAME: "wildcat/base-image"
     BASE_IMAGE_CACHE: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/wildcat-base-cache"
+    BASE_TAR: "base-image.tar"
 
-
+# ───────────────────────────────
+# 1) build base once, upload tar
+# ───────────────────────────────
 jobs:
+  base-image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
+
+    - name: Docker auth for Artifact Registry
+      run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
+
+    # ───────────────────────────────
+    # Build & load the base image
+    # ───────────────────────────────
+    - name: Build base image (remote cache, local load)
+      run: |
+        CACHE_TAG="${GITHUB_REF_NAME//\//-}"
+        DOCKER_BUILDKIT=1 docker buildx build \
+          --file docker/base-image/Dockerfile \
+          --tag "${BASE_IMAGE_NAME}" \
+          --cache-from=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}" \
+          --cache-to=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}",mode=max \
+          --load \
+          .
+
+    - name: Save base image to tarball
+      run: docker save -o "${BASE_TAR}" "${BASE_IMAGE_NAME}"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: base-image
+        path: "${{ env.BASE_TAR }}"
+        retention-days: 1          # keep just long enough for this workflow
+
+# ───────────────────────────────
+# 2) service matrix (needs base)
+# ───────────────────────────────
   wildcat-images:
+    needs: base-image
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
-      max-parallel: 1 # eveluate if we need to parallelize this
+      fail-fast: false 
+      #max-parallel: 1
       matrix:
         service:
           - name: bcr-wdc-key-service
@@ -59,29 +109,23 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
 
     - name: Docker auth for Artifact Registry
       run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
-    # ───────────────────────────────
-    # Build & load the base image
-    # ───────────────────────────────
-    - name: Build base image (remote-cache, local load)
-      run: |
-        CACHE_TAG="${GITHUB_REF_NAME//\//-}"
+    - uses: actions/download-artifact@v4
+      with:
+        name: base-image
+        path: .
 
-        echo "→ building ${BASE_IMAGE_NAME} using cache tag ${CACHE_TAG}"
-        DOCKER_BUILDKIT=1 docker buildx build \
-          --file docker/base-image/Dockerfile \
-          --tag "${BASE_IMAGE_NAME}" \
-          --cache-from=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}" \
-          --cache-to=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}",mode=max \
-          --load \
-          .
+    - name: Load base image
+      run: docker load -i "${BASE_TAR}"
 
-    # ───────────────────────────────
-    # Service image metadata
-    # ───────────────────────────────
+    # ─────────────────────────────
+    # metadata for service image
+    # ─────────────────────────────
     - id: meta
       name: Metadata for ${{ matrix.service.name }}
       uses: docker/metadata-action@v5
@@ -95,9 +139,9 @@ jobs:
           # Add 'latest' tag if on the default branch
           type=match,pattern=master,value=latest
 
-    # ───────────────────────────────
-    # Build & push the service image
-    # ───────────────────────────────
+    # ─────────────────────────────
+    # build & push service image
+    # ─────────────────────────────
     - id: push
       name: Build & push ${{ matrix.service.name }}
       uses: docker/build-push-action@v6
@@ -105,19 +149,16 @@ jobs:
         context: .
         file: ${{ matrix.service.dockerfile }}
         push: true
-        #platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-
-        # Optional: Add build caching for the service image itself if it has many layers
+        # Uncomment for per-service cache
         # cache-from: type=registry,ref=${{ env.GAR_PATH }}/${{ matrix.service.name }}:buildcache
-        # cache-to: type=registry,ref=${{ env.GAR_PATH }}/${{ matrix.service.name }}:buildcache,mode=max
+        # cache-to:   type=registry,ref=${{ env.GAR_PATH }}/${{ matrix.service.name }}:buildcache,mode=max
 
-    # ───────────────────────────────
-    # Provenance attestation
-    # ───────────────────────────────
-    - name: Attest provenance
-      uses: actions/attest-build-provenance@v2
+    # ─────────────────────────────
+    # provenance
+    # ─────────────────────────────
+    - uses: actions/attest-build-provenance@v2
       with:
         subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
         subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           --tag ${{ env.BASE_IMAGE_NAME }} \
           --file docker/base-image/Dockerfile \
           --cache-from=type=registry,ref=${{ env.BASE_IMAGE_CACHE_GAR_TAG }} \
-          --cache-to=type=registry,ref=${{ env.BASE_IMAGE_CACHE_GAR_TAG }},mode=max \ #
+          --cache-to=type=registry,ref=${{ env.BASE_IMAGE_CACHE_GAR_TAG }},mode=max \
           --load \
           . # Build context is repository root
         echo "Base image build complete and loaded as ${{ env.BASE_IMAGE_NAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,18 +57,18 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-    #- name: Docker auth for Artifact Registry
-    #  run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
-
     - name: Build base image (remote cache, local load)
       run: |
         CACHE_TAG="${GITHUB_REF_NAME//\//-}"
         DOCKER_BUILDKIT=1 docker buildx build \
+          --platform linux/amd64 \
           --file docker/base-image/Dockerfile \
-          --tag "${BASE_IMAGE_NAME}" \
+          --tag ${BASE_IMAGE_NAME}:latest \
+          --tag  ${GAR_PATH}/${BASE_IMAGE_NAME}:${CACHE_TAG} \
+          --push \
           --cache-from=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}" \
           --cache-to=type=registry,ref="${BASE_IMAGE_CACHE}:${CACHE_TAG}",mode=max \
-          --output=type=docker,dest="${BASE_TAR}",name="${BASE_IMAGE_NAME}" \
+          --output type=docker,dest="${BASE_TAR}",name="${BASE_IMAGE_NAME}" \
           .
 
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -89,6 +89,7 @@ jobs:
       attestations: write # required for attest-build-provenance
     strategy:
       fail-fast: false
+      #max-parallel: 1
       matrix:
         service:
           - name: bcr-wdc-key-service
@@ -129,27 +130,25 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-      #with:
-      #  driver: docker
+      with:
+        driver: docker
 
-    #- name: Docker auth for Artifact Registry
-    #  run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: base-image
         path: .
 
-    - name: Import base image into BuildKit
-      run: |
-        BUILDER_CONT="buildx_buildkit_${{ steps.buildx.outputs.name }}0"
-        echo "Using builder: ${BUILDER_CONT}"
-        docker cp "${BASE_TAR}" "${BUILDER_CONT}:/tmp/base.tar"
-        docker exec "${BUILDER_CONT}" ctr --namespace buildkit images import /tmp/base.tar
+    # - name: Import base image into BuildKit
+    #   run: |
+    #     BUILDER_CONT="buildx_buildkit_${{ steps.buildx.outputs.name }}0"
+    #     echo "Using builder: ${BUILDER_CONT}"
+    #     docker cp "${BASE_TAR}" "${BUILDER_CONT}:/tmp/base.tar"
+    #     docker exec "${BUILDER_CONT}" ctr --namespace buildkit images import /tmp/base.tar
 
         
-    #- name: Load base image
-    #  run: docker load -i "${BASE_TAR}"
+    - name: Load base image
+      run: docker load -i "${BASE_TAR}"
 
     - id: meta
       name: Metadata for ${{ matrix.service.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Authenticate to GCP
+      id: auth
       uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
         #credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
@@ -45,13 +46,19 @@ jobs:
         service_account: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
         token_format: access_token
 
+    - name: Auth w/ registry
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
 
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-    - name: Docker auth for Artifact Registry
-      run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
+    #- name: Docker auth for Artifact Registry
+    #  run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
     - name: Build base image (remote cache, local load)
       run: |
@@ -112,21 +119,35 @@ jobs:
         service_account: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
         token_format: access_token
 
+    - name: Auth w/ registry
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-      with:
-        driver: docker
+      #with:
+      #  driver: docker
 
-    - name: Docker auth for Artifact Registry
-      run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
+    #- name: Docker auth for Artifact Registry
+    #  run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: base-image
         path: .
 
-    - name: Load base image
-      run: docker load -i "${BASE_TAR}"
+    - name: Import base image into BuildKit
+      run: |
+        BUILDER=$(docker buildx inspect --format '{{.Nodes.0.Name}}')
+        docker cp "${BASE_TAR}" "${BUILDER}:/tmp/base.tar"
+        docker exec "${BUILDER}" ctr --namespace buildkit images import /tmp/base.tar
+
+        
+    #- name: Load base image
+    #  run: docker load -i "${BASE_TAR}"
 
     - id: meta
       name: Metadata for ${{ matrix.service.name }}
@@ -157,17 +178,6 @@ jobs:
     # ─────────────────────────────
     # provenance
     # ─────────────────────────────
-
-    - name: Auth w/ registry
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: oauth2accesstoken
-        password: ${{ steps.auth.outputs.access_token }}
-      env:
-        REGISTRY: ${{ env.GAR_LOCATION }}-docker.pkg.dev
-
-
     - uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
       with:
         subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
-name: Build & push Docker images to GCP Artifact Registry
+name: build and push Docker images
 
 on:
   push:
-    branches: [ "**" ] # only for testing
     tags:
       - "v*.*.*"
   schedule:
@@ -14,7 +13,7 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write # required for Workload Identity Federation
+  id-token: write
 
 env:
     PROJECT_ID: "bitcr-shared"
@@ -41,7 +40,6 @@ jobs:
       id: auth
       uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
-        #credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
         workload_identity_provider: ${{ secrets.GCLOUD_WIF_PROVIDER }}
         service_account: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
         token_format: access_token
@@ -82,9 +80,7 @@ jobs:
     needs: base-image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write # required for attest-build-provenance
-      attestations: write # required for attest-build-provenance
+      attestations: write
     strategy:
       fail-fast: false
       #max-parallel: 1
@@ -113,7 +109,6 @@ jobs:
       id: auth
       uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
-        #credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
         workload_identity_provider: ${{ secrets.GCLOUD_WIF_PROVIDER }}
         service_account: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
         token_format: access_token
@@ -137,14 +132,6 @@ jobs:
         name: base-image
         path: .
 
-    # - name: Import base image into BuildKit
-    #   run: |
-    #     BUILDER_CONT="buildx_buildkit_${{ steps.buildx.outputs.name }}0"
-    #     echo "Using builder: ${BUILDER_CONT}"
-    #     docker cp "${BASE_TAR}" "${BUILDER_CONT}:/tmp/base.tar"
-    #     docker exec "${BUILDER_CONT}" ctr --namespace buildkit images import /tmp/base.tar
-
-        
     - name: Load base image
       run: docker load -i "${BASE_TAR}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,157 @@
+name: Build & push Docker images to GCP Artifact Registry
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - cleot/build-push-to-registry
+#   push:
+#     branches: [ "master" ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # id-token: write # For Workload Identity Federation
+
+env:
+    PROJECT_ID: "bitcr-shared"
+    GAR_LOCATION: "europe-west1"
+    REPOSITORY: "bitcr-wildcat-dev"
+    GAR_PATH: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev"
+    # base image
+    BASE_IMAGE_NAME: "wildcat/base-image"
+    BASE_IMAGE_CACHE_GAR_TAG: "europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/wildcat-base-cache:${{ github.ref_name }}"
+
+jobs:
+  base-image:
+    name: Build Base Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker auth for GAR (for base image cache)
+      run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
+
+
+    # ----------------------------------------------------------------------
+    # Build and Cache Base image
+    # ----------------------------------------------------------------------
+
+    - name: Build Docker Base Image (with GAR cache)
+      run: |
+        echo "Building base image. Local tag: ${{ env.BASE_IMAGE_NAME }}. Cache target: ${{ env.BASE_IMAGE_CACHE_GAR_TAG }}"
+        DOCKER_BUILDKIT=1 docker buildx build \
+          --tag ${{ env.BASE_IMAGE_NAME }} \
+          --file docker/base-image/Dockerfile \
+          --cache-from=type=registry,ref=${{ env.BASE_IMAGE_CACHE_GAR_TAG }} \
+          --cache-to=type=registry,ref=${{ env.BASE_IMAGE_CACHE_GAR_TAG }},mode=max \ #
+          --load \
+          . # Build context is repository root
+        echo "Base image build complete and loaded as ${{ env.BASE_IMAGE_NAME }}"
+
+      # cache-from: type=gha
+
+        
+
+  wildcat-images:
+    name: Build and Push Wildcat Images
+    runs-on: ubuntu-latest
+    needs: base-image    
+  
+    # ----------------------------------------------------------------------
+    # Wildcat services
+    # ----------------------------------------------------------------------
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: bcr-wdc-key-service
+            dockerfile_path: docker/key-service/Dockerfile
+          - name: bcr-wdc-treasury-service
+            dockerfile_path: docker/treasury-service/Dockerfile
+          - name: bcr-wdc-swap-service
+            dockerfile_path: docker/swap-service/Dockerfile
+          - name: bcr-wdc-quote-service
+            dockerfile_path: docker/quote-service/Dockerfile
+          - name: bcr-wdc-wallet-aggregator
+            dockerfile_path: docker/wallet-aggregator/Dockerfile
+          - name: bcr-wdc-ebpp
+            dockerfile_path: docker/ebpp/Dockerfile
+          - name: bcr-wdc-ebill-service
+            dockerfile_path: docker/ebill-service/Dockerfile
+
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker auth
+      run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
+
+    # ----------------------------------------------------------------------
+    # Metadata 
+    # ----------------------------------------------------------------------
+    - name: Docker Metadata for ${{ matrix.service.name }}
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
+        tags: |
+          type=ref,event=branch
+          type=sha,prefix=sha-
+          type=semver,pattern={{version}}
+          type=schedule,pattern=nightly
+          # Add 'latest' tag if on the default branch
+          type=match,pattern=master,value=latest
+
+    # ----------------------------------------------------------------------
+    # Build and Push Wildcat Images
+    # ----------------------------------------------------------------------
+    - name: Build and Push ${{ matrix.service.name }}
+      id: push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ matrix.service.dockerfile_path }}
+        
+        push: true 
+        # Optional: push: ${{ github.event_name != 'pull_request' }}
+        
+        tags: ${{ steps.meta.outputs.tags }}
+        
+        labels: ${{ steps.meta.outputs.labels }}
+        
+        # Optional: Add build caching for the service image itself if it has many layers
+        # cache-from: type=registry,ref=${{ env.GAR_PATH }}/${{ matrix.service.name }}:buildcache
+        # cache-to: type=registry,ref=${{ env.GAR_PATH }}/${{ matrix.service.name }}:buildcache,mode=max
+
+    # ----------------------------------------------------------------------
+    # Artifact attestation
+    # ----------------------------------------------------------------------
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ${{ env.GAR_PATH }}/${{ matrix.service.name }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true


### PR DESCRIPTION
partially replaces #157

[latest test run](https://github.com/BitcreditProtocol/Wildcat/actions/runs/15143209427)


Adds a GitHub Actions workflow that builds a reusable base Docker image, caches it in Google Artifact Registry (GAR), and then builds and pushes multiple service images using that cache.

- Introduces a two-stage workflow: one job to build and upload the base image artifact, and another to load that base and build/push service images.
- Configures remote caching for faster rebuilds
- Adds provenance attestation for each pushed image.

repo:
<img width="709" alt="image" src="https://github.com/user-attachments/assets/f02932ee-05c5-4121-b67e-1887854da062" />


package:
<img width="941" alt="image" src="https://github.com/user-attachments/assets/c40eaed0-68c8-4bc4-9afc-b9f49445e609" />