### PR TITLE
Fix webapi ebill dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ async-trait = {version = "0.1"}
 axum = {version = "0.8"}
 axum-test = {version = "17"}
 bcr-ebill-core = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.12"}
-bcr-ebill-api = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.12"}
 bcr-wdc-key-client = {path = "./crates/bcr-wdc-key-client"}
 bcr-wdc-key-service = {path = "./crates/bcr-wdc-key-service"}
 bcr-wdc-swap-client = {path = "./crates/bcr-wdc-swap-client"}

--- a/crates/bcr-wdc-ebill-service/Cargo.toml
+++ b/crates/bcr-wdc-ebill-service/Cargo.toml
@@ -12,8 +12,8 @@ axum = {workspace = true, features = ["macros"]}
 axum-test = {workspace = true, optional = true}
 mockall = {workspace = true, optional = true}
 bcr-ebill-core = {workspace = true, optional = true}
-bcr-ebill-api = {workspace = true} 
 bcr-ebill-transport = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.12"}
+bcr-ebill-api = {git = "https://github.com/BitcreditProtocol/Bitcredit-Core.git", tag = "v0.3.12"}
 bcr-wdc-webapi.workspace = true
 config.workspace = true
 serde.workspace = true

--- a/crates/bcr-wdc-wallet-aggregator/src/web.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/web.rs
@@ -331,6 +331,7 @@ pub async fn post_restore(
     Ok(Json(response))
 }
 
+#[allow(clippy::enum_variant_names)]
 enum SwapType {
     CrSat2CrSat,
     Sat2Sat,

--- a/crates/bcr-wdc-webapi/Cargo.toml
+++ b/crates/bcr-wdc-webapi/Cargo.toml
@@ -17,7 +17,6 @@ required-features = ["test-utils"]
 [dependencies]
 bcr-ebill-core.workspace = true
 bcr-wdc-utils = {workspace = true, features = ["test-utils"] }
-bcr-ebill-api.workspace = true
 bdk_wallet = {workspace = true}
 bitcoin.workspace = true
 borsh = {workspace = true, features = ["derive"]}

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -1,10 +1,7 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_ebill_api::{
-    data::{bill, contact, notification},
-    util::date::DateTimeUtc,
-};
 pub use bcr_ebill_core::blockchain::bill::block::NodeId;
+use bcr_ebill_core::{bill, contact, notification, util::date::DateTimeUtc};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/crates/bcr-wdc-webapi/src/contact.rs
+++ b/crates/bcr-wdc-webapi/src/contact.rs
@@ -1,4 +1,4 @@
-use bcr_ebill_api::data::contact;
+use bcr_ebill_core::contact;
 // ----- standard library imports
 // ----- extra library imports
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -29,12 +29,10 @@ pub enum ContactType {
 }
 
 impl TryFrom<u64> for ContactType {
-    type Error = bcr_ebill_api::service::Error;
+    type Error = bcr_ebill_core::ValidationError;
 
     fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
-        Ok(contact::ContactType::try_from(value)
-            .map_err(Self::Error::Validation)?
-            .into())
+        Ok(contact::ContactType::try_from(value)?.into())
     }
 }
 

--- a/crates/bcr-wdc-webapi/src/identity.rs
+++ b/crates/bcr-wdc-webapi/src/identity.rs
@@ -3,10 +3,7 @@ use thiserror::Error;
 
 // ----- standard library imports
 // ----- extra library imports
-use bcr_ebill_api::{
-    data::{self, identity},
-    util::BcrKeys,
-};
+use bcr_ebill_core::{self as data, identity, util::BcrKeys};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -38,12 +35,10 @@ pub enum IdentityType {
 }
 
 impl TryFrom<u64> for IdentityType {
-    type Error = bcr_ebill_api::service::Error;
+    type Error = bcr_ebill_core::ValidationError;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        Ok(identity::IdentityType::try_from(value)
-            .map_err(Self::Error::Validation)?
-            .into())
+        Ok(identity::IdentityType::try_from(value)?.into())
     }
 }
 


### PR DESCRIPTION
I wrongly depended on `bcr-ebill-api` in `webapi`, which is 1. unnecessary and 2. would make it impossible for `bcr-abill-api` to depend on `webapi` (cycle).

Now `webapi` correctly only depends on `bcr-ebill-core` again.

This fixes that (plus a clippy lint)