### PR TITLE
[Keycloak] Allow all origins for dashboard client (development)

### DIFF
--- a/docker/keycloak/realm-dev.json
+++ b/docker/keycloak/realm-dev.json
@@ -8,7 +8,8 @@
         "publicClient": false,
         "secret": "cute-kitties",
         "directAccessGrantsEnabled": true,
-        "redirectUris": ["*"]
+        "redirectUris": ["*"],
+        "webOrigins": ["*"]
       },
       {
         "clientId": "bff-local-dev",

--- a/docker/keycloak/realm-dev.json
+++ b/docker/keycloak/realm-dev.json
@@ -5,7 +5,7 @@
       {
         "clientId": "bff-dashboard",
         "enabled": true,
-        "publicClient": false,
+        "publicClient": true,
         "secret": "cute-kitties",
         "directAccessGrantsEnabled": true,
         "redirectUris": ["*"],


### PR DESCRIPTION
Small change to allow all origins for dashboard client `"webOrigins": ["*"]`