### PR TITLE
feat(docker): parameterize base image via ARG WILDCAT_BASE_IMAGE

### DIFF
--- a/docker/ebill-service/Dockerfile
+++ b/docker/ebill-service/Dockerfile
@@ -1,4 +1,5 @@
-FROM wildcat/base-image AS rust-builder
+ARG WILDCAT_BASE_IMAGE=wildcat/base-image
+FROM ${WILDCAT_BASE_IMAGE} AS rust-builder
 
 ##############################
 ## Create image

--- a/docker/ebpp/Dockerfile
+++ b/docker/ebpp/Dockerfile
@@ -1,4 +1,5 @@
-FROM wildcat/base-image AS rust-builder
+ARG WILDCAT_BASE_IMAGE=wildcat/base-image
+FROM ${WILDCAT_BASE_IMAGE} AS rust-builder
 
 ##############################
 ## Create image

--- a/docker/key-service/Dockerfile
+++ b/docker/key-service/Dockerfile
@@ -1,4 +1,5 @@
-FROM wildcat/base-image AS rust-builder
+ARG WILDCAT_BASE_IMAGE=wildcat/base-image
+FROM ${WILDCAT_BASE_IMAGE} AS rust-builder
 
 ##############################
 ## Create image

--- a/docker/quote-service/Dockerfile
+++ b/docker/quote-service/Dockerfile
@@ -1,4 +1,5 @@
-FROM wildcat/base-image AS rust-builder
+ARG WILDCAT_BASE_IMAGE=wildcat/base-image
+FROM ${WILDCAT_BASE_IMAGE} AS rust-builder
 
 ##############################
 ## Create image

--- a/docker/swap-service/Dockerfile
+++ b/docker/swap-service/Dockerfile
@@ -1,4 +1,5 @@
-FROM wildcat/base-image AS rust-builder
+ARG WILDCAT_BASE_IMAGE=wildcat/base-image
+FROM ${WILDCAT_BASE_IMAGE} AS rust-builder
 
 ##############################
 ## Create image

--- a/docker/treasury-service/Dockerfile
+++ b/docker/treasury-service/Dockerfile
@@ -1,4 +1,5 @@
-FROM wildcat/base-image AS rust-builder
+ARG WILDCAT_BASE_IMAGE=wildcat/base-image
+FROM ${WILDCAT_BASE_IMAGE} AS rust-builder
 
 ##############################
 ## Create image

--- a/docker/wallet-aggregator/Dockerfile
+++ b/docker/wallet-aggregator/Dockerfile
@@ -1,4 +1,5 @@
-FROM wildcat/base-image AS rust-builder
+ARG WILDCAT_BASE_IMAGE=wildcat/base-image
+FROM ${WILDCAT_BASE_IMAGE} AS rust-builder
 
 ##############################
 ## Create image


### PR DESCRIPTION
Make every service Dockerfile accept a WILDCAT_BASE_IMAGE build-arg so CI can pull the base image from registry and enable remote caching.

- Adds ARG WILDCAT_BASE_IMAGE before the first FROM in each service Dockerfile
- Defaults to wildcat/base-image for local builds
- Enables use of default buildx container driver and cache type=gha