### PR TITLE
Don't store signature twice

### DIFF
--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -226,7 +226,6 @@ where
         let mut signatures = Vec::with_capacity(outputs.len());
         for blind in &outputs {
             let signature = self.sign_blind(blind).await?;
-            self.signatures.store(blind, &signature).await?;
             signatures.push(signature);
         }
         self.keys.mark_as_minted(&kid).await?;


### PR DESCRIPTION
Small fix, see part 2 https://github.com/BitcreditProtocol/Wildcat/issues/169#issuecomment-2892178736

If we store the signature in sign blind the signatures get stored twice, as they are also stored during minting.

It should be sufficient to only store it only once, I have kept the store of signatures in the keyservice sign_blind(blind), as the swap service also generates new signatures from blinds when doing the swap, and these need to be stored as well.

This change removes storing them during minting and keeps them in sign_blind (which gets called during minting)