### PR TITLE
[bcr-wdc-quote-service] add Canceled and OfferExpired states + deny retention period

### DIFF
--- a/crates/bcr-wdc-quote-service/src/admin.rs
+++ b/crates/bcr-wdc-quote-service/src/admin.rs
@@ -169,9 +169,10 @@ fn convert_to_info_reply(quote: quotes::Quote) -> web_quotes::InfoReply {
             bill: quote.bill.into(),
             tstamp,
         },
-        quotes::QuoteStatus::Denied => web_quotes::InfoReply::Denied {
+        quotes::QuoteStatus::Denied { tstamp } => web_quotes::InfoReply::Denied {
             id: quote.id,
             bill: quote.bill.into(),
+            tstamp,
         },
         quotes::QuoteStatus::Accepted { keyset_id } => web_quotes::InfoReply::Accepted {
             id: quote.id,
@@ -237,10 +238,10 @@ where
     QuotesRepo: Repository,
 {
     tracing::debug!("Received mint quote update request");
-
+    let now = chrono::Utc::now();
     let response = match req {
         web_quotes::UpdateQuoteRequest::Deny => {
-            ctrl.deny(id).await?;
+            ctrl.deny(id, now).await?;
             web_quotes::UpdateQuoteResponse::Denied
         }
         web_quotes::UpdateQuoteRequest::Offer { discounted, ttl } => {

--- a/crates/bcr-wdc-quote-service/src/lib.rs
+++ b/crates/bcr-wdc-quote-service/src/lib.rs
@@ -1,7 +1,7 @@
 // ----- standard library imports
 // ----- extra library imports
 use axum::extract::FromRef;
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::Router;
 use cashu::nuts::nut00 as cdk00;
 use cashu::nuts::nut02 as cdk02;
@@ -71,6 +71,7 @@ pub fn credit_routes(ctrl: AppController) -> Router {
     let user_routes = Router::new()
         .route("/v1/mint/credit/quote", post(web::enquire_quote))
         .route("/v1/mint/credit/quote/{id}", get(web::lookup_quote))
+        .route("/v1/mint/credit/quote/{id}", delete(web::cancel))
         .route("/v1/mint/credit/quote/{id}", post(web::resolve_offer));
 
     let admin_routes = Router::new()
@@ -125,12 +126,13 @@ pub fn credit_routes(ctrl: AppController) -> Router {
         cdk14::HTLCWitness,
     ),),
     paths(
-        crate::web::enquire_quote,
-        crate::web::lookup_quote,
-        crate::admin::list_pending_quotes,
-        crate::admin::list_quotes,
         crate::admin::admin_lookup_quote,
         crate::admin::admin_update_quote,
+        crate::admin::list_pending_quotes,
+        crate::admin::list_quotes,
+        crate::web::cancel,
+        crate::web::enquire_quote,
+        crate::web::lookup_quote,
         crate::web::resolve_offer,
     )
 )]

--- a/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-quote-service/src/persistence/surreal.rs
@@ -427,12 +427,13 @@ mod tests {
     #[tokio::test]
     async fn update_status_if_offered_ko() {
         let db = init_mem_db().await;
+        let now = TStamp::from_timestamp(10000, 0).unwrap();
 
         let mut quote = quotes::Quote {
             bill: quotes::BillInfo::default(),
             id: Uuid::new_v4(),
             submitted: TStamp::default(),
-            status: quotes::QuoteStatus::Denied,
+            status: quotes::QuoteStatus::Denied { tstamp: now },
         };
         let dbquote = QuoteDBEntry::from(quote.clone());
         let rid = RecordId::from_table_key(&db.table, quote.id);
@@ -455,7 +456,7 @@ mod tests {
         let content: Option<QuoteDBEntry> = db.db.select(rid).await.unwrap();
         assert!(content.is_some());
         let content = content.unwrap();
-        assert!(matches!(content.status, quotes::QuoteStatus::Denied));
+        assert!(matches!(content.status, quotes::QuoteStatus::Denied { .. }));
     }
 
     #[tokio::test]

--- a/crates/bcr-wdc-quote-service/src/quotes.rs
+++ b/crates/bcr-wdc-quote-service/src/quotes.rs
@@ -63,7 +63,9 @@ pub enum QuoteStatus {
     Canceled {
         tstamp: TStamp,
     },
-    Denied,
+    Denied {
+        tstamp: TStamp,
+    },
     Offered {
         keyset_id: cdk02::Id,
         ttl: TStamp,
@@ -114,9 +116,9 @@ impl Quote {
         }
     }
 
-    pub fn deny(&mut self) -> Result<()> {
+    pub fn deny(&mut self, tstamp: TStamp) -> Result<()> {
         if let QuoteStatus::Pending { .. } = self.status {
-            self.status = QuoteStatus::Denied;
+            self.status = QuoteStatus::Denied { tstamp };
             Ok(())
         } else {
             Err(Error::QuoteAlreadyResolved(self.id))

--- a/crates/bcr-wdc-quote-service/src/web.rs
+++ b/crates/bcr-wdc-quote-service/src/web.rs
@@ -57,7 +57,7 @@ fn convert_to_enquire_reply(quote: quotes::Quote) -> web_quotes::StatusReply {
     match quote.status {
         quotes::QuoteStatus::Pending { .. } => web_quotes::StatusReply::Pending,
         quotes::QuoteStatus::Canceled { tstamp } => web_quotes::StatusReply::Canceled { tstamp },
-        quotes::QuoteStatus::Denied => web_quotes::StatusReply::Denied,
+        quotes::QuoteStatus::Denied { tstamp } => web_quotes::StatusReply::Denied { tstamp },
         quotes::QuoteStatus::Offered {
             keyset_id,
             ttl,

--- a/crates/bcr-wdc-webapi/src/quotes.rs
+++ b/crates/bcr-wdc-webapi/src/quotes.rs
@@ -44,12 +44,18 @@ pub struct EnquireReply {
 #[serde(tag = "status")]
 pub enum StatusReply {
     Pending,
+    Canceled {
+        tstamp: DateTime<Utc>,
+    },
     Denied,
     Offered {
         keyset_id: cdk02::Id,
         expiration_date: DateTime<Utc>,
         #[schema(value_type = u64)]
         discounted: bitcoin::Amount,
+    },
+    OfferExpired {
+        tstamp: DateTime<Utc>,
     },
     Accepted {
         keyset_id: cdk02::Id,
@@ -107,11 +113,21 @@ pub enum InfoReply {
         submitted: DateTime<Utc>,
         suggested_expiration: DateTime<Utc>,
     },
+    Canceled {
+        id: uuid::Uuid,
+        bill: BillInfo,
+        tstamp: DateTime<Utc>,
+    },
     Offered {
         id: uuid::Uuid,
         bill: BillInfo,
         ttl: DateTime<Utc>,
         keyset_id: cdk02::Id,
+    },
+    OfferExpired {
+        id: uuid::Uuid,
+        bill: BillInfo,
+        tstamp: DateTime<Utc>,
     },
     Denied {
         id: uuid::Uuid,

--- a/crates/bcr-wdc-webapi/src/quotes.rs
+++ b/crates/bcr-wdc-webapi/src/quotes.rs
@@ -47,7 +47,9 @@ pub enum StatusReply {
     Canceled {
         tstamp: DateTime<Utc>,
     },
-    Denied,
+    Denied {
+        tstamp: DateTime<Utc>,
+    },
     Offered {
         keyset_id: cdk02::Id,
         expiration_date: DateTime<Utc>,
@@ -132,6 +134,7 @@ pub enum InfoReply {
     Denied {
         id: uuid::Uuid,
         bill: BillInfo,
+        tstamp: DateTime<Utc>,
     },
     Accepted {
         id: uuid::Uuid,


### PR DESCRIPTION
Users can cancel their quote inquiry before wildcat admins make a
decision over it.
The quote offer expires after offer's ttl timepoint has passed.
Both states have a retention period and users cannot resubmit a quote
inquiry for the same eBill before such time has passed

--------------------
deny has a retention period
it's not a definite decision any more but rather one that
"expires" after a retention period.
Users can then re-submit the same eBill to the wildcat to enquire the
wildcat for a new offer