### PR TITLE
add swap service checkstate to nginx

### DIFF
--- a/docker/bff-wallet-service/nginx.conf
+++ b/docker/bff-wallet-service/nginx.conf
@@ -21,6 +21,15 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+
+        location /v1/checkstate {
+            proxy_pass http://swap-service:3338/v1/checkstate;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location /v1/mint/ebill {
             proxy_pass http://key-service:3338/v1/mint/ebill;
             proxy_set_header Host $host;


### PR DESCRIPTION
* Adds the `swap-service/v1/checkstate` request to nginx, since we have to make it from E-Bill to check if proofs were already spent