### PR TITLE
[bcr-wdc-ebpp] fix docker config

### DIFF
--- a/docker/ebpp/config.toml
+++ b/docker/ebpp/config.toml
@@ -7,7 +7,7 @@ bind_address = "0.0.0.0:3338"
 grpc_address = "0.0.0.0:9090"
 electrum_url = "electrs:50001"
 refresh_interval_secs=30
-treasury_service_public_key = "0234dd69c56c36a41230d573d68adeae0030c9bc0bf26f24d3e1b64c604d293c68"
+treasury_service_public_key = "038139c78cd7cf8ca3af105a64f29c21b91584eddbdb8f3a64bb9fbb4b19d545f9"
 
 [appcfg.onchain]
 network = "regtest"


### PR DESCRIPTION
### **User description**
ebpp config contains the treasury-service's public key used to sign request_to_mint_from_ebill messages

should fix #215 
___

### **PR Type**
enhancement


___

### **Description**
- Updated `treasury_service_public_key` in EBPP Docker config.

- Ensured correct public key for signing `request_to_mint_from_ebill`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.toml</strong><dd><code>Update treasury service public key in config.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/ebpp/config.toml

<li>Changed <code>treasury_service_public_key</code> value to a new public key.<br> <li> No other configuration changes made.


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/219/files#diff-48502a787caf5ebdcd9d9f3884b405a0d2adf49a1dfe18b19537e78f855367e4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>