### PR TITLE
[bcr-wdc-key-service] add response to enable and deactivate

### DIFF
--- a/crates/bcr-wdc-key-client/src/lib.rs
+++ b/crates/bcr-wdc-key-client/src/lib.rs
@@ -157,7 +157,7 @@ impl KeyClient {
         Ok(kid)
     }
 
-    pub async fn enable_keyset(&self, qid: uuid::Uuid) -> Result<()> {
+    pub async fn enable_keyset(&self, qid: uuid::Uuid) -> Result<cdk02::Id> {
         let url = self
             .base
             .join("/v1/admin/keys/enable")
@@ -167,8 +167,8 @@ impl KeyClient {
         if res.status() == reqwest::StatusCode::NOT_FOUND {
             return Err(Error::ResourceFromIdNotFound(qid));
         }
-        res.error_for_status()?;
-        Ok(())
+        let response: web_keys::EnableKeysetResponse = res.json().await?;
+        Ok(response.kid)
     }
 
     pub async fn mint(
@@ -225,8 +225,8 @@ impl KeyClient {
         if res.status() == reqwest::StatusCode::NOT_FOUND {
             return Err(Error::ResourceNotFound(kid));
         }
-        res.json::<cdk02::Id>().await?;
-        Ok(kid)
+        let response: web_keys::DeactivateKeysetResponse = res.json().await?;
+        Ok(response.kid)
     }
 }
 

--- a/crates/bcr-wdc-key-service/src/admin.rs
+++ b/crates/bcr-wdc-key-service/src/admin.rs
@@ -106,7 +106,7 @@ where
     path = "/v1/admin/keys/enable/",
     request_body(content = web_keys::EnableKeysetRequest, content_type = "application/json"),
     responses (
-        (status = 200, description = "Successful response"),
+        (status = 200, description = "Successful response", body = web_keys::EnableKeysetResponse, content_type = "application/json"),
         (status = 404, description = "keyset id not found"),
     )
 )]
@@ -114,13 +114,15 @@ where
 pub async fn enable<QuotesKeysRepo, KeysRepo, SignsRepo>(
     State(ctrl): State<Service<QuotesKeysRepo, KeysRepo, SignsRepo>>,
     Json(request): Json<web_keys::EnableKeysetRequest>,
-) -> Result<()>
+) -> Result<Json<web_keys::EnableKeysetResponse>>
 where
     QuotesKeysRepo: QuoteKeysRepository,
     KeysRepo: KeysRepository,
 {
     tracing::debug!("Received enable request");
-    ctrl.enable(&request.qid).await
+    let kid = ctrl.enable(&request.qid).await?;
+    let response = web_keys::EnableKeysetResponse { kid };
+    Ok(Json(response))
 }
 
 #[utoipa::path(
@@ -128,7 +130,7 @@ where
     path = "/v1/admin/keys/deactivate/",
     request_body(content = web_keys::DeactivateKeysetRequest, content_type = "application/json"),
     responses (
-        (status = 200, description = "Successful response", body = cdk02::Id, content_type = "application/json"),
+        (status = 200, description = "Successful response", body = web_keys::DeactivateKeysetResponse, content_type = "application/json"),
         (status = 404, description = "keyset id not found"),
     )
 )]
@@ -136,12 +138,13 @@ where
 pub async fn deactivate<QuotesKeysRepo, KeysRepo, SignsRepo>(
     State(ctrl): State<Service<QuotesKeysRepo, KeysRepo, SignsRepo>>,
     Json(request): Json<web_keys::DeactivateKeysetRequest>,
-) -> Result<Json<cdk02::Id>>
+) -> Result<Json<web_keys::DeactivateKeysetResponse>>
 where
     QuotesKeysRepo: QuoteKeysRepository,
     KeysRepo: KeysRepository,
 {
     tracing::debug!("Received deactivate request");
     let kid = ctrl.deactivate(request.kid).await?;
-    Ok(Json(kid))
+    let response = web_keys::DeactivateKeysetResponse { kid };
+    Ok(Json(response))
 }

--- a/crates/bcr-wdc-key-service/src/lib.rs
+++ b/crates/bcr-wdc-key-service/src/lib.rs
@@ -104,7 +104,9 @@ where
 #[openapi(
     components(schemas(
         bcr_wdc_webapi::keys::DeactivateKeysetRequest,
+        bcr_wdc_webapi::keys::DeactivateKeysetResponse,
         bcr_wdc_webapi::keys::EnableKeysetRequest,
+        bcr_wdc_webapi::keys::EnableKeysetResponse,
         bcr_wdc_webapi::keys::GenerateKeysetRequest,
         bcr_wdc_webapi::keys::KeysetMintCondition,
         bcr_wdc_webapi::keys::PreSignRequest,

--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -250,13 +250,14 @@ where
     QuoteKeysRepo: QuoteKeysRepository,
     KeysRepo: KeysRepository,
 {
-    pub async fn enable(&self, qid: &uuid::Uuid) -> Result<()> {
+    pub async fn enable(&self, qid: &uuid::Uuid) -> Result<cdk02::Id> {
         let mut entry = self
             .quote_keys
             .entry(qid)
             .await?
             .ok_or(Error::UnknownKeysetFromId(*qid))?;
         entry.0.active = true;
+        let kid = entry.0.id;
         let condition = self
             .quote_keys
             .condition(qid)
@@ -264,7 +265,7 @@ where
             .ok_or(Error::UnknownKeysetFromId(*qid))?;
 
         self.keys.store(entry, condition).await?;
-        Ok(())
+        Ok(kid)
     }
 }
 

--- a/crates/bcr-wdc-webapi/src/keys.rs
+++ b/crates/bcr-wdc-webapi/src/keys.rs
@@ -32,8 +32,18 @@ pub struct EnableKeysetRequest {
     pub qid: uuid::Uuid,
 }
 
+#[derive(Serialize, Deserialize, ToSchema, Debug)]
+pub struct EnableKeysetResponse {
+    pub kid: cdk02::Id,
+}
+
 ///--------------------------- Deactivate keyset
 #[derive(Serialize, Deserialize, ToSchema, Debug)]
 pub struct DeactivateKeysetRequest {
+    pub kid: cdk02::Id,
+}
+
+#[derive(Serialize, Deserialize, ToSchema, Debug)]
+pub struct DeactivateKeysetResponse {
     pub kid: cdk02::Id,
 }


### PR DESCRIPTION
### **User description**
simple json responses containing the keyset ID


___

### **PR Type**
Enhancement


___

### **Description**
• Add JSON response structures for enable/deactivate keyset endpoints
• Return keyset ID in enable operation response
• Update OpenAPI documentation with proper response schemas
• Standardize API response format across endpoints


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Update admin endpoints with structured responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/admin.rs

• Update enable endpoint to return <code>EnableKeysetResponse</code> instead of <br>empty response<br> • Update deactivate endpoint to return <br><code>DeactivateKeysetResponse</code> instead of raw ID<br> • Modify OpenAPI <br>documentation to specify proper response body types<br> • Add JSON <br>response wrapping for both endpoints


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/225/files#diff-f366824ed4999514276e404ad0b38b03fbb4c1768345ebce12638f7be6bfad1f">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Return keyset ID from enable service method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/service.rs

• Modify enable method to return keyset ID instead of unit type<br> • <br>Extract and return the keyset ID from the entry


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/225/files#diff-0bf63ca2bfa682f3961784061646602648f6450798339852bae9daf95e784e52">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keys.rs</strong><dd><code>Define response structures for keyset operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-webapi/src/keys.rs

• Add <code>EnableKeysetResponse</code> struct with keyset ID field<br> • Add <br><code>DeactivateKeysetResponse</code> struct with keyset ID field<br> • Include <br>Serialize, Deserialize, ToSchema, and Debug derives


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/225/files#diff-188353c6638ec833337a71f3ccf5522a22bb02a6fbfa233224a455a5c7bc1e85">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Register new response schemas in OpenAPI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/lib.rs

• Add <code>DeactivateKeysetResponse</code> and <code>EnableKeysetResponse</code> to OpenAPI <br>schema components


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/225/files#diff-3f8809d40f9e828f899b297d0eed35852796e26fa96f3c629ac0f4a6dc079589">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>