### PR TITLE
[docker] docker-compose for local, dev, e2e

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -1,0 +1,218 @@
+services:
+
+  ######################################################################################## ours
+  ebpp:
+    image: wildcat/ebpp
+    ports:
+      - "9090:9090"
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+      electrs:
+        condition: service_started
+    environment:
+      - EBPP_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+    volumes:
+      - ./docker/ebpp/config.toml:/ebpp/config.toml
+      - ./.docker_data/ebpp/:/data/
+
+  key-service:
+    image: wildcat/key-service
+    pull_policy: never
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+    environment:
+      - KEY_SERVICE_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+    volumes:
+      - ./docker/key-service/config.toml:/key-service/config.toml
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+
+  swap-service:
+    image: wildcat/swap-service
+    pull_policy: never
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+      key-service:
+        condition: service_healthy
+    volumes:
+      - ./docker/swap-service/config.toml:/swap-service/config.toml
+
+  treasury-service:
+    image: wildcat/treasury-service
+    pull_policy: never
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+      cdk-mintd:
+        condition: service_started
+    environment:
+      - TREASURY_SERVICE_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+    volumes:
+      - ./docker/treasury-service/config.toml:/treasury-service/config.toml
+      - ./.docker_data/treasury-service/:/data/
+
+  quote-service:
+    image: wildcat/quote-service
+    pull_policy: never
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+      key-service:
+        condition: service_healthy
+      treasury-service:
+        condition: service_started
+    volumes:
+      - ./docker/quote-service/config.toml:/quote-service/config.toml
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 60s
+      start_interval: 3s
+
+  eiou-service:
+    image: wildcat/eiou-service
+    pull_policy: never
+    volumes:
+      - ./docker/eiou-service/config.toml:/eiou-service/config.toml
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+
+  wallet-aggregator:
+    image: wildcat/wallet-aggregator
+    pull_policy: never
+    depends_on:
+      key-service:
+        condition: service_healthy
+      swap-service:
+        condition: service_started # no healthcheck yet
+      cdk-mintd:
+        condition: service_started # no healthcheck yet
+    volumes:
+      - ./docker/wallet-aggregator/config.toml:/wallet-aggregator/config.toml
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3338/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 60s
+      start_interval: 3s
+
+  ebill-service:
+    image: wildcat/ebill-service
+    pull_policy: never
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+    volumes:
+      - ./docker/ebill-service/config.toml:/ebill-service/config.toml
+
+  balance-collector:
+    image: wildcat/balance-collector
+    pull_policy: never
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+      treasury-service:
+        condition: service_started
+      ebpp:
+        condition: service_started
+    volumes:
+      - ./docker/balance-collector/config.toml:/balance-collector/config.toml
+
+  ######################################################################################## 3rd parties
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.2.0
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./docker/keycloak/realm-dev.json:/opt/keycloak/data/import/realm-dev.json:ro
+    healthcheck:
+      test: ['CMD-SHELL', '[ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { java.net.URI uri = java.net.URI.create(args[0]); System.exit(java.net.HttpURLConnection.HTTP_OK == ((java.net.HttpURLConnection)uri.toURL().openConnection()).getResponseCode() ? 0 : 1); } }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:9000/health/live']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    volumes:
+      - ./.docker_data/surrealdb:/data
+    command:
+      - start
+      - --unauthenticated
+      - rocksdb:/data/database.db
+    user: ${UID}:${GID}
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: [ "CMD", "/surreal", "is-ready" ]
+      interval: 5s
+      retries: 5
+
+  bitcoin-core:
+    image: bitcoin/bitcoin:28.1
+    volumes:
+      - ./docker/bitcoin-core/bitcoin.conf:/root/.bitcoin/bitcoin.conf
+      - ./docker/bitcoin-core/bitcoin.conf:/home/bitcoin/bitcoin.conf
+      - ./.docker_data/bitcoin-core/:/home/bitcoin/data
+    environment:
+      BITCOIN_DATA: /home/bitcoin/data
+
+  electrs:
+    image: getumbrel/electrs:v0.10.9
+    depends_on:
+      bitcoin-core:
+        condition: service_healthy
+    volumes:
+      - ./docker/electrs/config.toml:/data/.electrs/config.toml
+
+  cdk-mintd:
+    image: thesimplekid/cdk-mintd:0.9
+    platform: linux/amd64
+    volumes:
+      - ./docker/cdk-mintd/config.toml:/root/.cdk-mintd/config.toml
+    restart: unless-stopped
+    command: ["cdk-mintd"]
+    depends_on:
+      ebpp:
+        condition: service_started
+
+  bff-dashboard-service:
+    image: envoyproxy/envoy:v1.33.0
+    depends_on:
+      - keycloak
+      - quote-service
+      - treasury-service
+      - key-service
+      - ebpp
+    volumes:
+      - ./docker/bff-dashboard-service/envoy.yaml:/etc/envoy/envoy.yaml:ro
+    ports:
+      - "4242:4242"  
+    command: >
+      /usr/local/bin/envoy
+      -c /etc/envoy/envoy.yaml
+      --log-level info
+    networks:
+      - default
+
+  bff-wallet-service:
+    image: nginx:stable-bookworm
+    ports:
+      - "4343:4242"
+    depends_on:
+      - quote-service
+      - wallet-aggregator
+    volumes:
+      - ./docker/bff-wallet-service/nginx.conf:/etc/nginx/nginx.conf
+    restart: unless-stopped

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -1,176 +1,65 @@
 services:
 
   key-service:
-    image: wildcat/key-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-    environment:
-      - KEY_SERVICE_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
-    volumes:
-      - ./docker/key-service/config.toml:/key-service/config.toml
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
+    extends:
+        file: common-services.yml
+        service: key-service
 
   treasury-service:
-    image: wildcat/treasury-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      cdk_mint:
-        condition: service_started
-    environment:
-      - TREASURY_SERVICE_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
-    volumes:
-      - ./docker/treasury-service/config.toml:/treasury-service/config.toml
-      - ./.docker_data/treasury-service/:/data/
+    extends:
+        file: common-services.yml
+        service: treasury-service
 
   swap-service:
-    image: wildcat/swap-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      key-service:
-        condition: service_healthy
-    volumes:
-      - ./docker/swap-service/config.toml:/swap-service/config.toml
+    extends:
+        file: common-services.yml
+        service: swap-service
 
   quote-service:
-    image: wildcat/quote-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      key-service:
-        condition: service_healthy
-      treasury-service:
-        condition: service_started
-    volumes:
-      - ./docker/quote-service/config.toml:/quote-service/config.toml
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
-      start_period: 60s
-      start_interval: 3s
+    extends:
+        file: common-services.yml
+        service: quote-service
 
   wallet-aggregator:
-    image: wildcat/wallet-aggregator
-    pull_policy: never
-    depends_on:
-      key-service:
-        condition: service_healthy
-      swap-service:
-        condition: service_started # no healthcheck yet
-      cdk_mint:
-        condition: service_started # no healthcheck yet
-    volumes:
-      - ./docker/wallet-aggregator/config.toml:/wallet-aggregator/config.toml
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:3338/health"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
-      start_period: 60s
-      start_interval: 3s
+    extends:
+        file: common-services.yml
+        service: wallet-aggregator
+
 
   surrealdb:
-    image: surrealdb/surrealdb:latest
-    volumes:
-      - ./.docker_data/surrealdb:/data
-    command:
-      - start
-      - --unauthenticated
-      - rocksdb:/data/database.db
-    user: ${UID}:${GID}
-    ports:
-      - "8000:8000"
-    healthcheck:
-      test: [ "CMD", "/surreal", "is-ready" ]
-      interval: 5s
-      retries: 5
+    extends:
+        file: common-services.yml
+        service: surrealdb
 
   cdk_mint:
-    image: thesimplekid/cdk-mintd:0.9
-    platform: linux/amd64
-    volumes:
-      - ./docker/cdk-mintd/config.toml:/root/.cdk-mintd/config.toml
-    restart: unless-stopped
-    command: ["cdk-mintd"]
-    depends_on:
-      ebpp:
-        condition: service_started
+    extends:
+        file: common-services.yml
+        service: cdk-mintd
 
   ebpp:
-    image: wildcat/ebpp
-    ports:
-      - "9090:9090"
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      electrs:
-        condition: service_started
-    environment:
-      - EBPP_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
-    volumes:
-      - ./docker/ebpp/config.toml:/ebpp/config.toml
-      - ./.docker_data/ebpp/:/data/
-      - ./.docker_data/ebpp/regtest/:/data/regtest/
+    extends:
+        file: common-services.yml
+        service: ebpp
 
   ebill-service:
-    image: wildcat/ebill-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-    volumes:
-      - ./docker/ebill-service/config.toml:/ebill-service/config.toml
+    extends:
+        file: common-services.yml
+        service: ebill-service
 
   bff-wallet-service:
-    image: nginx:stable-bookworm
-    ports:
-      - "4343:4242"
-    depends_on:
-      - quote-service
-      - wallet-aggregator
-    volumes:
-      - ./docker/bff-wallet-service/nginx.conf:/etc/nginx/nginx.conf
-    restart: unless-stopped
+    extends:
+        file: common-services.yml
+        service: bff-wallet-service
 
   bff-dashboard-service:
-    image: envoyproxy/envoy:v1.33.0
-    depends_on:
-      - keycloak
-      - quote-service
-      - treasury-service
-      - key-service
-      - ebpp
-    volumes:
-      - ./docker/bff-dashboard-service/envoy.yaml:/etc/envoy/envoy.yaml:ro
-    ports:
-      - "4242:4242"
-    command: >
-      /usr/local/bin/envoy
-      -c /etc/envoy/envoy.yaml
-      --log-level info
-    networks:
-      - default
+    extends:
+        file: common-services.yml
+        service: bff-dashboard-service
 
   bitcoin-core:
-    image: bitcoin/bitcoin:28.1
-    volumes:
-      - ./docker/bitcoin-core/bitcoin.conf:/root/.bitcoin/bitcoin.conf
-      - ./docker/bitcoin-core/bitcoin.conf:/home/bitcoin/bitcoin.conf
-      - ./.docker_data/bitcoin-core/:/home/bitcoin/data
-    environment:
-      BITCOIN_DATA: /home/bitcoin/data
+    extends:
+        file: common-services.yml
+        service: bitcoin-core
     command:
       -printtoconsole
       -regtest=1
@@ -179,19 +68,18 @@ services:
       test: ["CMD", "bitcoin-cli", "-regtest", "getconnectioncount"]
 
   electrs:
-    image: getumbrel/electrs:v0.10.9
-    depends_on:
-      bitcoin-core:
-        condition: service_healthy
-    volumes:
-      - ./docker/electrs/config.toml:/data/.electrs/config.toml
+    extends:
+        file: common-services.yml
+        service: electrs
     environment:
-      - ELECTRS_NETWORK=regtest
-      - ELECTRS_DAEMON_RPC_ADDR=bitcoin-core:18443
-      - ELECTRS_DAEMON_P2P_ADDR=bitcoin-core:18444
+      - ELECTRS_NETWORK: regtest
+      - ELECTRS_DAEMON_RPC_ADDR: bitcoin-core:18443
+      - ELECTRS_DAEMON_P2P_ADDR: bitcoin-core:18444
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.2.0
+    extends:
+        file: common-services.yml
+        service: keycloak
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
@@ -199,22 +87,12 @@ services:
       KC_HEALTH_ENABLED: true
       KEYCLOAK_BFF_DASHBOARD_SECRET: cute-kitties
       WDC_DASHBOARD_URL: "http://localhost:5173"
-      KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS: ${KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS:-*}
-      KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS: ${KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS:-*}
-
+      KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS: "*"
+      KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS: "*"
     command:
       - start-dev
       - --import-realm
       - --http-port=8080
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./docker/keycloak/realm-dev.json:/opt/keycloak/data/import/realm-dev.json:ro
-    healthcheck:
-      test: ['CMD-SHELL', '[ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { java.net.URI uri = java.net.URI.create(args[0]); System.exit(java.net.HttpURLConnection.HTTP_OK == ((java.net.HttpURLConnection)uri.toURL().openConnection()).getResponseCode() ? 0 : 1); } }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:9000/health/live']
-      interval: 5s
-      timeout: 5s
-      retries: 5
 
   e2e-tests:
     image: wildcat/e2e-tests

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,108 @@
+services:
+
+  ######################################################################################## ours
+  ebpp:
+    extends:
+        file: common-services.yml
+        service: ebpp
+
+  key-service:
+    extends:
+        file: common-services.yml
+        service: key-service
+
+  swap-service:
+    extends:
+        file: common-services.yml
+        service: swap-service
+
+  treasury-service:
+    extends:
+        file: common-services.yml
+        service: treasury-service
+
+  quote-service:
+    extends:
+        file: common-services.yml
+        service: quote-service
+
+  eiou-service:
+    extends:
+        file: common-services.yml
+        service: eiou-service
+
+  wallet-aggregator:
+    extends:
+        file: common-services.yml
+        service: wallet-aggregator
+
+  ebill-service:
+    extends:
+        file: common-services.yml
+        service: ebill-service
+
+  balance-collector:
+    extends:
+        file: common-services.yml
+        service: balance-collector
+
+  ######################################################################################## 3rd parties
+  keycloak:
+    extends:
+        file: common-services.yml
+        service: keycloak
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      WDC_DASHBOARD_URL: http://localhost:5173
+      KEYCLOAK_BFF_DASHBOARD_SECRET: cute-kitties
+      KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS: "*"
+      KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS: "*"
+      KC_DB: dev-file
+    command:
+      - start-dev
+      - --import-realm
+      - --http-port=8080
+      - --proxy-headers=xforwarded
+      - --hostname=localhost
+
+
+  surrealdb:
+    extends:
+        file: common-services.yml
+        service: surrealdb
+
+  bitcoin-core:
+    extends:
+        file: common-services.yml
+        service: bitcoin-core
+    command:
+      - -printtoconsole
+      - --regtest=1
+      - -conf=/home/bitcoin/bitcoin.conf
+    healthcheck:
+      test: ["CMD", "bitcoin-cli", "--regtest", "getconnectioncount"]
+
+  electrs:
+    extends:
+        file: common-services.yml
+        service: electrs
+    environment:
+      ELECTRS_NETWORK: regtest
+      ELECTRS_DAEMON_RPC_ADDR: bitcoin-core:18443
+      ELECTRS_DAEMON_P2P_ADDR: bitcoin-core:18444
+
+  cdk-mintd:
+    extends:
+        file: common-services.yml
+        service: cdk-mintd
+
+  bff-dashboard-service:
+    extends:
+        file: common-services.yml
+        service: bff-dashboard-service
+
+  bff-wallet-service:
+    extends:
+        file: common-services.yml
+        service: bff-wallet-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,240 +1,105 @@
 services:
 
   eiou-service:
-    image: wildcat/eiou-service
-    pull_policy: never
-    volumes:
-      - ./docker/eiou-service/config.toml:/eiou-service/config.toml
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
+    extends:
+        file: common-services.yml
+        service: eiou-service
 
   key-service:
-    image: wildcat/key-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-    environment:
-      - KEY_SERVICE_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
-    volumes:
-      - ./docker/key-service/config.toml:/key-service/config.toml
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
+    extends:
+      file: common-services.yml
+      service: key-service
 
   treasury-service:
-    image: wildcat/treasury-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      cdk_mint:
-        condition: service_started
-    environment:
-      - TREASURY_SERVICE_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
-    volumes:
-      - ./docker/treasury-service/config.toml:/treasury-service/config.toml
-      - ./.docker_data/treasury-service/:/data/
+    extends:
+      file: common-services.yml
+      service: treasury-service
 
   swap-service:
-    image: wildcat/swap-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      key-service:
-        condition: service_healthy
-    volumes:
-      - ./docker/swap-service/config.toml:/swap-service/config.toml
+    extends:
+      file: common-services.yml
+      service: swap-service
 
   quote-service:
-    image: wildcat/quote-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      key-service:
-        condition: service_healthy
-      treasury-service:
-        condition: service_started
-    volumes:
-      - ./docker/quote-service/config.toml:/quote-service/config.toml
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:3338/api-docs/openapi.json"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
-      start_period: 60s
-      start_interval: 3s
+    extends:
+      file: common-services.yml
+      service: quote-service
 
   wallet-aggregator:
-    image: wildcat/wallet-aggregator
-    pull_policy: never
-    depends_on:
-      key-service:
-        condition: service_healthy
-      swap-service:
-        condition: service_started # no healthcheck yet
-      cdk_mint:
-        condition: service_started # no healthcheck yet
-    volumes:
-      - ./docker/wallet-aggregator/config.toml:/wallet-aggregator/config.toml
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:3338/health"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
-      start_period: 60s
-      start_interval: 3s
+    extends:
+        file: common-services.yml
+        service: wallet-aggregator
 
   surrealdb:
-    image: surrealdb/surrealdb:latest
-    volumes:
-      - ./.docker_data/surrealdb:/data
-    command:
-      - start
-      - --unauthenticated
-      - rocksdb:/data/database.db
-    user: ${UID}:${GID}
-    ports:
-      - "8000:8000"
-    healthcheck:
-      test: [ "CMD", "/surreal", "is-ready" ]
-      interval: 5s
-      retries: 5
+    extends:
+      file: common-services.yml
+      service: surrealdb
 
   cdk_mint:
-    image: thesimplekid/cdk-mintd:0.9
-    platform: linux/amd64
-    volumes:
-      - ./docker/cdk-mintd/config.toml:/root/.cdk-mintd/config.toml
-    restart: unless-stopped
-    command: ["cdk-mintd"]
-    depends_on:
-      ebpp:
-        condition: service_started
+    extends:
+      file: common-services.yml
+      service: cdk-mintd
 
   ebpp:
-    image: wildcat/ebpp
-    ports:
-      - "9090:9090"
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      electrs:
-        condition: service_started
-    environment:
-      - EBPP_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
-    volumes:
-      - ./docker/ebpp/config.toml:/ebpp/config.toml
-      - ./.docker_data/ebpp/:/data/
+    extends:
+      file: common-services.yml
+      service: ebpp
 
   ebill-service:
-    image: wildcat/ebill-service
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-    volumes:
-      - ./docker/ebill-service/config.toml:/ebill-service/config.toml
+    extends:
+      file: common-services.yml
+      service: ebill-service
 
   bff-wallet-service:
-    image: nginx:stable-bookworm
-    ports:
-      - "4343:4242"
-    depends_on:
-      - quote-service
-      - wallet-aggregator
-    volumes:
-      - ./docker/bff-wallet-service/nginx.conf:/etc/nginx/nginx.conf
-    restart: unless-stopped
+    extends:
+        file: common-services.yml
+        service: bff-wallet-service
 
   bff-dashboard-service:
-    image: envoyproxy/envoy:v1.33.0
-    depends_on:
-      - keycloak
-      - quote-service
-      - treasury-service
-      - key-service
-      - ebpp
-    volumes:
-      - ./docker/bff-dashboard-service/envoy.yaml:/etc/envoy/envoy.yaml:ro
-    ports:
-      - "4242:4242"  
-    command: >
-      /usr/local/bin/envoy
-      -c /etc/envoy/envoy.yaml
-      --log-level info
-    networks:
-      - default
+    extends:
+        file: common-services.yml
+        service: bff-dashboard-service
 
   bitcoin-core:
-    image: bitcoin/bitcoin:28.1
-    volumes:
-      - ./docker/bitcoin-core/bitcoin.conf:/root/.bitcoin/bitcoin.conf
-      - ./docker/bitcoin-core/bitcoin.conf:/home/bitcoin/bitcoin.conf
-      - ./.docker_data/bitcoin-core/:/home/bitcoin/data
-    environment:
-      BITCOIN_DATA: /home/bitcoin/data
+    extends:
+      file: common-services.yml
+      service: bitcoin-core
     command:
       - -printtoconsole
-      - ${BITCOIN_NETWORK_COMMAND_ARG:--regtest=1}
+      - --testnet=1
       - -conf=/home/bitcoin/bitcoin.conf
     healthcheck:
-      test: ["CMD", "bitcoin-cli", "${BITCOIN_CLI_NETWORK_ARG:--regtest}", "getconnectioncount"]
+      test: ["CMD", "bitcoin-cli", "--testnet", "getconnectioncount"]
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.2.0
+    extends:
+        file: common-services.yml
+        service: keycloak
     environment:
-      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN_USER:-admin}
-      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_SECRET:-admin}
-      WDC_DASHBOARD_URL: ${WDC_DASHBOARD_URL:-http://localhost:5173}
-      KEYCLOAK_BFF_DASHBOARD_SECRET: ${KEYCLOAK_BFF_DASHBOARD_SECRET:-cute-kitties}
-      KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS: ${KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS:-*}
-      KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS: ${KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS:-*}
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN_USER}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_SECRET}
+      WDC_DASHBOARD_URL: ${WDC_DASHBOARD_URL}
+      KEYCLOAK_BFF_DASHBOARD_SECRET: ${KEYCLOAK_BFF_DASHBOARD_SECRET}
+      KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS: ${KEYCLOAK_BFF_DASHBOARD_ALLOWED_ORIGINS}
+      KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS: ${KEYCLOAK_BFF_DASHBOARD_ALLOWED_REDIRECT_URIS}
       KC_DB: dev-file
     command:
       - start-dev
       - --import-realm
       - --http-port=8080
       - --proxy-headers=xforwarded
-      - --hostname=${KEYCLOAK_HOSTNAME:-localhost}
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./docker/keycloak/realm-dev.json:/opt/keycloak/data/import/realm-dev.json:ro
-    healthcheck:
-      test: ['CMD-SHELL', '[ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { java.net.URI uri = java.net.URI.create(args[0]); System.exit(java.net.HttpURLConnection.HTTP_OK == ((java.net.HttpURLConnection)uri.toURL().openConnection()).getResponseCode() ? 0 : 1); } }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:9000/health/live']
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      - --hostname=${KEYCLOAK_HOSTNAME}
 
   electrs:
-    image: getumbrel/electrs:v0.10.9
-    depends_on:
-      bitcoin-core:
-        condition: service_healthy
-    volumes:
-      - ./docker/electrs/config.toml:/data/.electrs/config.toml
+    extends:
+      file: common-services.yml
+      service: electrs
     environment:
-      ELECTRS_NETWORK: ${ELECTRS_NETWORK:-regtest}
-      ELECTRS_DAEMON_RPC_ADDR: ${ELECTRS_DAEMON_RPC_ADDR:-bitcoin-core:18443}
-      ELECTRS_DAEMON_P2P_ADDR: ${ELECTRS_DAEMON_P2P_ADDR:-bitcoin-core:18444}
+      ELECTRS_NETWORK: testnet
+      ELECTRS_DAEMON_RPC_ADDR: bitcoin-core:18332
+      ELECTRS_DAEMON_P2P_ADDR: bitcoin-core:18333
 
   balance-collector:
-    image: wildcat/balance-collector
-    pull_policy: never
-    depends_on:
-      surrealdb:
-        condition: service_healthy
-      treasury-service:
-        condition: service_started
-      ebpp:
-        condition: service_started
-    volumes:
-      - ./docker/balance-collector/config.toml:/balance-collector/config.toml
+    extends:
+        file: common-services.yml
+        service: balance-collector


### PR DESCRIPTION
### **User description**
introduce common-services.yml docker compose file to describe common configuration for services


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `common-services.yml` for shared Docker service configurations

- Refactor existing compose files to use service extension pattern

- Consolidate duplicate service definitions across environments

- Standardize service configurations for local, dev, and e2e environments


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common-services.yml</strong><dd><code>Add centralized Docker services configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common-services.yml

<li>Define comprehensive service configurations for all application <br>services<br> <li> Include custom services (ebpp, key-service, swap-service, etc.) with <br>dependencies and health checks<br> <li> Add third-party services (keycloak, surrealdb, bitcoin-core, electrs, <br>cdk-mintd)<br> <li> Configure BFF services with proper networking and proxy settings


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/239/files#diff-feef9361dee340026246ae79275bc3b63be23a97aef0579ef9042376439c4137">+218/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-e2e.yml</strong><dd><code>Refactor e2e compose to use common services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose-e2e.yml

<li>Replace inline service definitions with <code>extends</code> references to <br><code>common-services.yml</code><br> <li> Add environment-specific overrides for regtest Bitcoin network<br> <li> Maintain e2e-specific configurations while reducing duplication<br> <li> Fix service name reference from <code>cdk_mint</code> to <code>cdk-mintd</code>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/239/files#diff-a7288a5d1665494bd3e308cf33c299712053eb89448da79918583891af8b2a23">+48/-170</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-local.yml</strong><dd><code>Add local development Docker compose configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose-local.yml

<li>Create new local development compose file using service extensions<br> <li> Configure regtest Bitcoin network for local development<br> <li> Set up Keycloak with local-specific environment variables<br> <li> Include all necessary services for local development workflow


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/239/files#diff-aed91aa2667654a05077a027349bdccf0caa1bfefddc15a397fc00f1ee8385d3">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Refactor main compose to use service extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Refactor main compose file to use <code>extends</code> pattern from <br><code>common-services.yml</code><br> <li> Switch from regtest to testnet Bitcoin network configuration<br> <li> Remove hardcoded defaults in favor of environment variable references<br> <li> Maintain production-ready service configurations


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/239/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+60/-195</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>