### PR TITLE
fix: cdk-mintd name in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       file: common-services.yml
       service: surrealdb
 
-  cdk_mint:
+  cdk-mintd:
     extends:
       file: common-services.yml
       service: cdk-mintd


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix service name from `cdk_mint` to `cdk-mintd` in docker-compose.yml


___

### **Changes diagram**

```mermaid
flowchart LR
  A["docker-compose.yml"] --> B["Service name correction"]
  B --> C["cdk_mint → cdk-mintd"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Fix service name consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Rename service from <code>cdk_mint</code> to <code>cdk-mintd</code> to match expected naming <br>convention


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/254/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>