### PR TITLE
Fix non-admin quote service route

### DIFF
--- a/docker/bff-wallet-service/nginx.conf
+++ b/docker/bff-wallet-service/nginx.conf
@@ -15,7 +15,7 @@ http {
                 return 204;
             }
 
-            proxy_pass http://quote-service:3338/v1/mint/credit;
+            proxy_pass http://quote-service:3338/v1/mint/quote/credit;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
During testing locally, I noticed that the `quote-service` routing in nginx for non-admin routes is not up-to date to the change in routing to `/v1/mint/quote/credit`.

This fixes that.