### PR TITLE
[bcr-wdc-e2e-tests] Fix minor typo

### DIFF
--- a/crates/bcr-wdc-e2e-tests/src/clients.rs
+++ b/crates/bcr-wdc-e2e-tests/src/clients.rs
@@ -130,11 +130,11 @@ impl Service<UserService> {
     pub async fn mint_credit_quote(
         &self,
         bill: web_quotes::SharedBill,
-        miniting_pubkey: cashu::PublicKey,
+        minting_pubkey: cashu::PublicKey,
         signing_key: &bitcoin::key::Keypair,
     ) -> Uuid {
         self.quote_cl
-            .enquire(bill, miniting_pubkey, signing_key)
+            .enquire(bill, minting_pubkey, signing_key)
             .await
             .unwrap()
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed typo in parameter name from `miniting_pubkey` to `minting_pubkey`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clients.rs</strong><dd><code>Fix parameter name typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-e2e-tests/src/clients.rs

<ul><li>Fixed typo in parameter name <code>miniting_pubkey</code> to <code>minting_pubkey</code><br> <li> Updated function call to use corrected parameter name</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/308/files#diff-e590f662f5fd8bbe6a53eebe1a3fc173fd9192bab5fe99d9f23caecf0540ebd1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

