### PR TITLE
bcr-common v0.2.1 integration continues

### DIFF
--- a/crates/bcr-wdc-ebill-client/src/lib.rs
+++ b/crates/bcr-wdc-ebill-client/src/lib.rs
@@ -1,9 +1,9 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_common::wire::identity as wire_identity;
+use bcr_common::wire::{bill as wire_bill, identity as wire_identity};
 use bcr_wdc_webapi::{
     bill::{
-        BillCombinedBitcoinKey, BillId, BillsResponse, BitcreditBill, Endorsement,
+        BillCombinedBitcoinKey, BillId, BillsResponse, BitcreditBill,
         RequestToPayBitcreditBillPayload,
     },
     quotes::{BillInfo, SharedBill},
@@ -178,7 +178,10 @@ impl EbillClient {
     }
 
     #[cfg(feature = "authorized")]
-    pub async fn get_bill_endorsements(&self, bill_id: &BillId) -> Result<Vec<Endorsement>> {
+    pub async fn get_bill_endorsements(
+        &self,
+        bill_id: &BillId,
+    ) -> Result<Vec<wire_bill::Endorsement>> {
         let url = self
             .base
             .join(&format!("/v1/admin/bill/endorsements/{bill_id}"))
@@ -188,7 +191,7 @@ impl EbillClient {
         if res.status() == reqwest::StatusCode::NOT_FOUND {
             return Err(Error::ResourceNotFound(bill_id.to_string()));
         }
-        let endorsements = res.json::<Vec<Endorsement>>().await?;
+        let endorsements = res.json::<Vec<wire_bill::Endorsement>>().await?;
         Ok(endorsements)
     }
 

--- a/crates/bcr-wdc-ebill-service/src/web.rs
+++ b/crates/bcr-wdc-ebill-service/src/web.rs
@@ -7,7 +7,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use bcr_common::wire::identity as wire_identity;
+use bcr_common::wire::{bill as wire_bill, identity as wire_identity};
 use bcr_ebill_api::{
     constants::MAX_DOCUMENT_FILE_SIZE_BYTES,
     data::{bill, contact, identity},
@@ -27,7 +27,7 @@ use bcr_wdc_utils::convert;
 use bcr_wdc_webapi::{
     bill::{
         BillCombinedBitcoinKey, BillId, BillPaymentStatus, BillWaitingForPaymentState,
-        BillsResponse, BitcreditBill, Endorsement, RequestToPayBitcreditBillPayload,
+        BillsResponse, BitcreditBill, RequestToPayBitcreditBillPayload,
     },
     quotes::RequestEncryptedFileUrlPayload,
 };
@@ -319,14 +319,19 @@ pub async fn get_bill_payment_status(
 pub async fn get_bill_endorsements(
     State(ctrl): State<AppController>,
     Path(bill_id): Path<BillId>,
-) -> Result<Json<Vec<Endorsement>>> {
+) -> Result<Json<Vec<wire_bill::Endorsement>>> {
     tracing::debug!("Received get bill detail request");
     let identity = ctrl.identity_service.get_identity().await?;
     let endorsements = ctrl
         .bill_service
         .get_endorsements(&bill_id, &identity.node_id)
         .await?;
-    Ok(Json(endorsements.into_iter().map(|e| e.into()).collect()))
+    Ok(Json(
+        endorsements
+            .into_iter()
+            .map(convert::endorsement_ebill2wire)
+            .collect(),
+    ))
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]

--- a/crates/bcr-wdc-utils/src/convert.rs
+++ b/crates/bcr-wdc-utils/src/convert.rs
@@ -127,7 +127,7 @@ pub fn identity_ebill2wire(input: ebill_identity::Identity) -> Result<wire_ident
     Ok(output)
 }
 
-pub fn lightbillidentparticipantwithaddress_ebill2wire(
+fn lightbillidentparticipantwithaddress_ebill2wire(
     input: ebill_contact::LightBillIdentParticipantWithAddress,
 ) -> wire_bill::LightBillIdentParticipantWithAddress {
     wire_bill::LightBillIdentParticipantWithAddress {
@@ -138,7 +138,7 @@ pub fn lightbillidentparticipantwithaddress_ebill2wire(
     }
 }
 
-pub fn lightbillidentparticipant_ebill2wire(
+fn lightbillidentparticipant_ebill2wire(
     input: ebill_contact::LightBillIdentParticipant,
 ) -> wire_bill::LightBillIdentParticipant {
     wire_bill::LightBillIdentParticipant {
@@ -156,7 +156,7 @@ fn lightbillanonparticipant_ebill2wire(
     }
 }
 
-pub fn lightbillparticipant_ebill2wire(
+fn lightbillparticipant_ebill2wire(
     input: ebill_contact::LightBillParticipant,
 ) -> wire_bill::LightBillParticipant {
     match input {
@@ -169,7 +169,7 @@ pub fn lightbillparticipant_ebill2wire(
     }
 }
 
-pub fn lightsignedby_ebill2wire(input: ebill_bill::LightSignedBy) -> wire_bill::LightSignedBy {
+fn lightsignedby_ebill2wire(input: ebill_bill::LightSignedBy) -> wire_bill::LightSignedBy {
     wire_bill::LightSignedBy {
         data: lightbillparticipant_ebill2wire(input.data),
         signatory: input.signatory.map(lightbillidentparticipant_ebill2wire),

--- a/crates/bcr-wdc-utils/src/convert.rs
+++ b/crates/bcr-wdc-utils/src/convert.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 // ----- extra library imports
 use bcr_common::{
     core,
-    wire::{contact as wire_contact, identity as wire_identity},
+    wire::{bill as wire_bill, contact as wire_contact, identity as wire_identity},
 };
 use bcr_ebill_core::{self as ebill_core, contact as ebill_contact, identity as ebill_identity};
 use thiserror::Error;
@@ -123,4 +123,15 @@ pub fn identity_ebill2wire(input: ebill_identity::Identity) -> Result<wire_ident
         nostr_relays,
     };
     Ok(output)
+}
+
+pub fn lightbillidentparticipantwithaddress_ebill2wire(
+    input: ebill_contact::LightBillIdentParticipantWithAddress,
+) -> wire_bill::LightBillIdentParticipantWithAddress {
+    wire_bill::LightBillIdentParticipantWithAddress {
+        t: contacttype_ebill2wire(input.t),
+        name: input.name,
+        node_id: nodeid_ebill2wire(input.node_id),
+        postal_address: postaladdress_ebill2wire(input.postal_address),
+    }
 }

--- a/crates/bcr-wdc-utils/src/convert.rs
+++ b/crates/bcr-wdc-utils/src/convert.rs
@@ -135,3 +135,13 @@ pub fn lightbillidentparticipantwithaddress_ebill2wire(
         postal_address: postaladdress_ebill2wire(input.postal_address),
     }
 }
+
+pub fn lightbillidentparticipant_ebill2wire(
+    input: ebill_contact::LightBillIdentParticipant,
+) -> wire_bill::LightBillIdentParticipant {
+    wire_bill::LightBillIdentParticipant {
+        t: contacttype_ebill2wire(input.t),
+        name: input.name,
+        node_id: nodeid_ebill2wire(input.node_id),
+    }
+}

--- a/crates/bcr-wdc-utils/src/convert.rs
+++ b/crates/bcr-wdc-utils/src/convert.rs
@@ -5,7 +5,9 @@ use bcr_common::{
     core,
     wire::{bill as wire_bill, contact as wire_contact, identity as wire_identity},
 };
-use bcr_ebill_core::{self as ebill_core, contact as ebill_contact, identity as ebill_identity};
+use bcr_ebill_core::{
+    self as ebill_core, bill as ebill_bill, contact as ebill_contact, identity as ebill_identity,
+};
 use thiserror::Error;
 // ----- local imports
 
@@ -164,5 +166,12 @@ pub fn lightbillparticipant_ebill2wire(
         ebill_contact::LightBillParticipant::Anon(data) => {
             wire_bill::LightBillParticipant::Anon(lightbillanonparticipant_ebill2wire(data))
         }
+    }
+}
+
+pub fn lightsignedby_ebill2wire(input: ebill_bill::LightSignedBy) -> wire_bill::LightSignedBy {
+    wire_bill::LightSignedBy {
+        data: lightbillparticipant_ebill2wire(input.data),
+        signatory: input.signatory.map(lightbillidentparticipant_ebill2wire),
     }
 }

--- a/crates/bcr-wdc-utils/src/convert.rs
+++ b/crates/bcr-wdc-utils/src/convert.rs
@@ -145,3 +145,11 @@ pub fn lightbillidentparticipant_ebill2wire(
         node_id: nodeid_ebill2wire(input.node_id),
     }
 }
+
+pub fn lightbillanonparticipant_ebill2wire(
+    input: ebill_contact::LightBillAnonParticipant,
+) -> wire_bill::LightBillAnonParticipant {
+    wire_bill::LightBillAnonParticipant {
+        node_id: nodeid_ebill2wire(input.node_id),
+    }
+}

--- a/crates/bcr-wdc-utils/src/convert.rs
+++ b/crates/bcr-wdc-utils/src/convert.rs
@@ -146,10 +146,23 @@ pub fn lightbillidentparticipant_ebill2wire(
     }
 }
 
-pub fn lightbillanonparticipant_ebill2wire(
+fn lightbillanonparticipant_ebill2wire(
     input: ebill_contact::LightBillAnonParticipant,
 ) -> wire_bill::LightBillAnonParticipant {
     wire_bill::LightBillAnonParticipant {
         node_id: nodeid_ebill2wire(input.node_id),
+    }
+}
+
+pub fn lightbillparticipant_ebill2wire(
+    input: ebill_contact::LightBillParticipant,
+) -> wire_bill::LightBillParticipant {
+    match input {
+        ebill_contact::LightBillParticipant::Ident(data) => wire_bill::LightBillParticipant::Ident(
+            lightbillidentparticipantwithaddress_ebill2wire(data),
+        ),
+        ebill_contact::LightBillParticipant::Anon(data) => {
+            wire_bill::LightBillParticipant::Anon(lightbillanonparticipant_ebill2wire(data))
+        }
     }
 }

--- a/crates/bcr-wdc-utils/src/convert.rs
+++ b/crates/bcr-wdc-utils/src/convert.rs
@@ -175,3 +175,14 @@ pub fn lightsignedby_ebill2wire(input: ebill_bill::LightSignedBy) -> wire_bill::
         signatory: input.signatory.map(lightbillidentparticipant_ebill2wire),
     }
 }
+
+pub fn endorsement_ebill2wire(input: ebill_bill::Endorsement) -> wire_bill::Endorsement {
+    wire_bill::Endorsement {
+        pay_to_the_order_of: lightbillidentparticipantwithaddress_ebill2wire(
+            input.pay_to_the_order_of,
+        ),
+        signed: lightsignedby_ebill2wire(input.signed),
+        signing_timestamp: input.signing_timestamp,
+        signing_address: input.signing_address.map(postaladdress_ebill2wire),
+    }
+}

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -506,14 +506,16 @@ impl From<bill::Endorsement> for Endorsement {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LightSignedBy {
     pub data: LightBillParticipant,
-    pub signatory: Option<LightBillIdentParticipant>,
+    pub signatory: Option<wire_bill::LightBillIdentParticipant>,
 }
 
 impl From<bill::LightSignedBy> for LightSignedBy {
     fn from(val: bill::LightSignedBy) -> Self {
         LightSignedBy {
             data: val.data.into(),
-            signatory: val.signatory.map(|s| s.into()),
+            signatory: val
+                .signatory
+                .map(convert::lightbillidentparticipant_ebill2wire),
         }
     }
 }
@@ -543,23 +545,6 @@ pub struct LightBillAnonParticipant {
 impl From<contact::LightBillAnonParticipant> for LightBillAnonParticipant {
     fn from(val: contact::LightBillAnonParticipant) -> Self {
         LightBillAnonParticipant {
-            node_id: val.node_id,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct LightBillIdentParticipant {
-    #[serde(rename = "type")]
-    pub t: wire_contact::ContactType,
-    pub name: String,
-    pub node_id: NodeId,
-}
-impl From<contact::LightBillIdentParticipant> for LightBillIdentParticipant {
-    fn from(val: contact::LightBillIdentParticipant) -> Self {
-        LightBillIdentParticipant {
-            t: convert::contacttype_ebill2wire(val.t),
-            name: val.name,
             node_id: val.node_id,
         }
     }

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -485,7 +485,7 @@ impl From<bill::BillCombinedBitcoinKey> for BillCombinedBitcoinKey {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Endorsement {
     pub pay_to_the_order_of: wire_bill::LightBillIdentParticipantWithAddress,
-    pub signed: LightSignedBy,
+    pub signed: wire_bill::LightSignedBy,
     pub signing_timestamp: u64,
     pub signing_address: Option<wire_identity::PostalAddress>,
 }
@@ -496,26 +496,9 @@ impl From<bill::Endorsement> for Endorsement {
             pay_to_the_order_of: convert::lightbillidentparticipantwithaddress_ebill2wire(
                 val.pay_to_the_order_of,
             ),
-            signed: val.signed.into(),
+            signed: convert::lightsignedby_ebill2wire(val.signed),
             signing_timestamp: val.signing_timestamp,
             signing_address: val.signing_address.map(convert::postaladdress_ebill2wire),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct LightSignedBy {
-    pub data: wire_bill::LightBillParticipant,
-    pub signatory: Option<wire_bill::LightBillIdentParticipant>,
-}
-
-impl From<bill::LightSignedBy> for LightSignedBy {
-    fn from(val: bill::LightSignedBy) -> Self {
-        LightSignedBy {
-            data: convert::lightbillparticipant_ebill2wire(val.data),
-            signatory: val
-                .signatory
-                .map(convert::lightbillidentparticipant_ebill2wire),
         }
     }
 }

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -1,6 +1,6 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_common::wire::{contact as wire_contact, identity as wire_identity};
+use bcr_common::wire::{bill as wire_bill, contact as wire_contact, identity as wire_identity};
 pub use bcr_ebill_core::bill::BillId;
 pub use bcr_ebill_core::NodeId;
 use bcr_ebill_core::{
@@ -484,7 +484,7 @@ impl From<bill::BillCombinedBitcoinKey> for BillCombinedBitcoinKey {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Endorsement {
-    pub pay_to_the_order_of: LightBillIdentParticipantWithAddress,
+    pub pay_to_the_order_of: wire_bill::LightBillIdentParticipantWithAddress,
     pub signed: LightSignedBy,
     pub signing_timestamp: u64,
     pub signing_address: Option<wire_identity::PostalAddress>,
@@ -493,7 +493,9 @@ pub struct Endorsement {
 impl From<bill::Endorsement> for Endorsement {
     fn from(val: bill::Endorsement) -> Self {
         Endorsement {
-            pay_to_the_order_of: val.pay_to_the_order_of.into(),
+            pay_to_the_order_of: convert::lightbillidentparticipantwithaddress_ebill2wire(
+                val.pay_to_the_order_of,
+            ),
             signed: val.signed.into(),
             signing_timestamp: val.signing_timestamp,
             signing_address: val.signing_address.map(convert::postaladdress_ebill2wire),
@@ -519,13 +521,15 @@ impl From<bill::LightSignedBy> for LightSignedBy {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum LightBillParticipant {
     Anon(LightBillAnonParticipant),
-    Ident(LightBillIdentParticipantWithAddress),
+    Ident(wire_bill::LightBillIdentParticipantWithAddress),
 }
 
 impl From<contact::LightBillParticipant> for LightBillParticipant {
     fn from(val: contact::LightBillParticipant) -> Self {
         match val {
-            contact::LightBillParticipant::Ident(data) => LightBillParticipant::Ident(data.into()),
+            contact::LightBillParticipant::Ident(data) => LightBillParticipant::Ident(
+                convert::lightbillidentparticipantwithaddress_ebill2wire(data),
+            ),
             contact::LightBillParticipant::Anon(data) => LightBillParticipant::Anon(data.into()),
         }
     }
@@ -557,27 +561,6 @@ impl From<contact::LightBillIdentParticipant> for LightBillIdentParticipant {
             t: convert::contacttype_ebill2wire(val.t),
             name: val.name,
             node_id: val.node_id,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct LightBillIdentParticipantWithAddress {
-    #[serde(rename = "type")]
-    pub t: wire_contact::ContactType,
-    pub name: String,
-    pub node_id: NodeId,
-    #[serde(flatten)]
-    pub postal_address: wire_identity::PostalAddress,
-}
-
-impl From<contact::LightBillIdentParticipantWithAddress> for LightBillIdentParticipantWithAddress {
-    fn from(val: contact::LightBillIdentParticipantWithAddress) -> Self {
-        LightBillIdentParticipantWithAddress {
-            t: convert::contacttype_ebill2wire(val.t),
-            name: val.name,
-            node_id: val.node_id,
-            postal_address: convert::postaladdress_ebill2wire(val.postal_address),
         }
     }
 }

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -522,7 +522,7 @@ impl From<bill::LightSignedBy> for LightSignedBy {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum LightBillParticipant {
-    Anon(LightBillAnonParticipant),
+    Anon(wire_bill::LightBillAnonParticipant),
     Ident(wire_bill::LightBillIdentParticipantWithAddress),
 }
 
@@ -532,20 +532,9 @@ impl From<contact::LightBillParticipant> for LightBillParticipant {
             contact::LightBillParticipant::Ident(data) => LightBillParticipant::Ident(
                 convert::lightbillidentparticipantwithaddress_ebill2wire(data),
             ),
-            contact::LightBillParticipant::Anon(data) => LightBillParticipant::Anon(data.into()),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct LightBillAnonParticipant {
-    pub node_id: NodeId,
-}
-
-impl From<contact::LightBillAnonParticipant> for LightBillAnonParticipant {
-    fn from(val: contact::LightBillAnonParticipant) -> Self {
-        LightBillAnonParticipant {
-            node_id: val.node_id,
+            contact::LightBillParticipant::Anon(data) => {
+                LightBillParticipant::Anon(convert::lightbillanonparticipant_ebill2wire(data))
+            }
         }
     }
 }

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -505,36 +505,17 @@ impl From<bill::Endorsement> for Endorsement {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LightSignedBy {
-    pub data: LightBillParticipant,
+    pub data: wire_bill::LightBillParticipant,
     pub signatory: Option<wire_bill::LightBillIdentParticipant>,
 }
 
 impl From<bill::LightSignedBy> for LightSignedBy {
     fn from(val: bill::LightSignedBy) -> Self {
         LightSignedBy {
-            data: val.data.into(),
+            data: convert::lightbillparticipant_ebill2wire(val.data),
             signatory: val
                 .signatory
                 .map(convert::lightbillidentparticipant_ebill2wire),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum LightBillParticipant {
-    Anon(wire_bill::LightBillAnonParticipant),
-    Ident(wire_bill::LightBillIdentParticipantWithAddress),
-}
-
-impl From<contact::LightBillParticipant> for LightBillParticipant {
-    fn from(val: contact::LightBillParticipant) -> Self {
-        match val {
-            contact::LightBillParticipant::Ident(data) => LightBillParticipant::Ident(
-                convert::lightbillidentparticipantwithaddress_ebill2wire(data),
-            ),
-            contact::LightBillParticipant::Anon(data) => {
-                LightBillParticipant::Anon(convert::lightbillanonparticipant_ebill2wire(data))
-            }
         }
     }
 }

--- a/crates/bcr-wdc-webapi/src/bill.rs
+++ b/crates/bcr-wdc-webapi/src/bill.rs
@@ -1,6 +1,6 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_common::wire::{bill as wire_bill, contact as wire_contact, identity as wire_identity};
+use bcr_common::wire::{contact as wire_contact, identity as wire_identity};
 pub use bcr_ebill_core::bill::BillId;
 pub use bcr_ebill_core::NodeId;
 use bcr_ebill_core::{
@@ -478,27 +478,6 @@ impl From<bill::BillCombinedBitcoinKey> for BillCombinedBitcoinKey {
     fn from(val: bill::BillCombinedBitcoinKey) -> Self {
         BillCombinedBitcoinKey {
             private_descriptor: val.private_descriptor,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Endorsement {
-    pub pay_to_the_order_of: wire_bill::LightBillIdentParticipantWithAddress,
-    pub signed: wire_bill::LightSignedBy,
-    pub signing_timestamp: u64,
-    pub signing_address: Option<wire_identity::PostalAddress>,
-}
-
-impl From<bill::Endorsement> for Endorsement {
-    fn from(val: bill::Endorsement) -> Self {
-        Endorsement {
-            pay_to_the_order_of: convert::lightbillidentparticipantwithaddress_ebill2wire(
-                val.pay_to_the_order_of,
-            ),
-            signed: convert::lightsignedby_ebill2wire(val.signed),
-            signing_timestamp: val.signing_timestamp,
-            signing_address: val.signing_address.map(convert::postaladdress_ebill2wire),
         }
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
**Major Architectural Changes:**

- Integrated `bcr-common` library across all services, replacing individual client implementations with unified clients (`KeysClient`, `QuoteClient`, `SwapClient`, `EbillClient`, `TreasuryClient`)

- Refactored database persistence layer to separate keyset information from mint operations tracking

- Replaced `MintCondition` with `MintOperation` structure for better mint operation management

- Migrated all services to use wire protocol types from `bcr-common::wire` for consistency

- Removed `QuoteKeysRepository` trait and merged functionality into `KeysRepository`

**Service Layer Updates:**

- Restructured services to use `Arc<dyn Trait>` for repository dependencies

- Split quote offering and minting enablement into separate flows

- Added Clowder client integration for keyset notifications and synchronization

- Refactored keyset generation to use timestamp-based derivation instead of UUID-based

- Updated all API endpoints to use `/v1/admin/` prefix for administrative operations

**Data Model Changes:**

- Renamed `public_key` to `minting_pubkey` throughout quote status tracking

- Added `MintOpDBEntry` structure for mint operations persistence

- Split `KeysDBEntry` into `KeysInfoDBEntry` and `KeysDBEntry` for better separation of concerns

- Enhanced quote status model with minting pubkey tracking across all states

**Client and API Updates:**

- Added authentication support to ebill client with OAuth-style flow

- Expanded quote client API with granular methods: `deny`, `offer`, `accept_offer`, `reject_offer`, `cancel_enquiry`, `enable_minting`

- Simplified treasury and wallet client APIs by removing expiration parameters

- Updated swap service to use standardized endpoint constants from `bcr-common`

**Testing and Utilities:**

- Updated all tests to use new client APIs and wire protocol types

- Added conversion utilities between `bcr_common::wire` and `bcr_ebill_core` types

- Refactored test utilities with structured return types and updated signatures

- Simplified e2e tests for new minting and quote acceptance flows

**Error Handling:**

- Migrated error types to use `bcr-common` equivalents (`KeysError`, `SwapError`)

- Added new error variants: `ClowderClient`, `Internal`, `IdentityType`, `InvalidQuoteStatus`

- Enhanced error handling with status discriminants for better debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Individual Clients"] -- "replaced by" --> B["bcr-common Unified Clients"]
  C["MintCondition"] -- "replaced by" --> D["MintOperation"]
  E["KeysDBEntry"] -- "split into" --> F["KeysInfoDBEntry + KeysDBEntry"]
  G["UUID-based Keyset"] -- "refactored to" --> H["Timestamp-based Keyset"]
  I["Quote Offering"] -- "separated into" --> J["Offer + Enable Minting"]
  K["Services"] -- "integrated with" --> L["Clowder Client"]
  M["Custom Types"] -- "migrated to" --> N["bcr-common Wire Types"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>31 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>surreal.rs</strong><dd><code>Refactor database persistence layer to separate keyset info and mint </code><br><code>operations</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/persistence/surreal.rs

<ul><li>Refactored database schema by splitting <code>KeysDBEntry</code> into separate <br><code>KeysInfoDBEntry</code> and <code>KeysDBEntry</code> structures<br> <li> Added new <code>MintOpDBEntry</code> structure and conversion functions for mint <br>operations tracking<br> <li> Replaced <code>QuoteKeysRepository</code> with mint operation methods in <br><code>KeysRepository</code> trait<br> <li> Updated <code>DBKeys</code> to manage two tables: <code>keys_table</code> and <code>mints_table</code><br> <li> Added methods for storing, loading, listing, and updating mint <br>operations<br> <li> Implemented <code>infos_for_expiration_date</code> method for querying keysets by <br>expiration<br> <li> Removed <code>condition</code> and <code>mark_as_minted</code> methods, replaced with mint <br>operation tracking<br> <li> Updated configuration structures to support multiple tables</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-ba8ade7df8f929ce375f54a312f93f59224a2beafd836727aa2108c57d32ca26">+403/-362</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Restructure service layer with mint operations and trait-based </code><br><code>dependencies</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/service.rs

<ul><li>Replaced <code>MintCondition</code> with <code>MintOperation</code> structure containing uid, <br>kid, pub_key, target, and minted amounts<br> <li> Removed <code>QuoteKeysRepository</code> trait and merged functionality into <br><code>KeysRepository</code><br> <li> Added <code>ClowderClient</code> trait for external service communication<br> <li> Refactored <code>Service</code> to use <code>Arc<dyn Trait></code> for repository dependencies<br> <li> Implemented <code>get_keyset_id_for_date</code> method for automatic keyset <br>generation<br> <li> Updated <code>mint</code> method to accept <code>MintRequest</code> and verify signatures<br> <li> Added <code>new_minting_operation</code> method for creating mint operations<br> <li> Removed <code>generate_keyset</code>, <code>pre_sign</code>, and <code>enable</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-0bf63ca2bfa682f3961784061646602648f6450798339852bae9daf95e784e52">+176/-211</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Update quote service with separated offer and minting enablement flows</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/service.rs

<ul><li>Updated <code>KeysHandler</code> trait methods: replaced <code>generate</code> with <br><code>get_keyset_with_redemption_date</code> and <code>add_new_mint_operation</code><br> <li> Modified <code>Wallet</code> trait to remove <code>expire</code> parameter from <code>store_signatures</code><br> <li> Refactored <code>Service</code> to use <code>Arc<dyn Trait></code> for all dependencies<br> <li> Split <code>offer</code> method functionality: separated minting enablement into <br><code>enable_minting</code> method<br> <li> Updated quote status handling to use <code>minting_pubkey</code> instead of <br><code>public_key</code><br> <li> Modified test setup to use Arc-wrapped mock implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-186f7e8fe93bbc7070dc420fa5c734f262aa91e2cc4a5585eecc838222112f36">+104/-86</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Refactor in-memory persistence to support mint operations tracking</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/persistence/inmemory.rs

<ul><li>Restructured <code>InMemoryKeyMap</code> to separate keys and mint operations <br>storage<br> <li> Added <code>MintOperationsReferences</code> type for tracking mint operations by <br>uid and kid<br> <li> Implemented mint operation methods: <code>store_mintop</code>, <code>load_mintop</code>, <br><code>list_mintops</code>, <code>update_mintop</code><br> <li> Removed <code>QuoteKeysRepository</code> implementation (<code>InMemoryQuoteKeyMap</code>)<br> <li> Updated <code>KeysRepository</code> implementation with new mint operation tracking<br> <li> Added <code>infos_for_expiration_date</code> method for filtering keysets by <br>expiration timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-3f12dfeeadb01ce475140bd0f334bac22948a837c7d6f5ce31a4120e1a8ef560">+117/-156</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add authentication support and update API endpoints to admin routes</code></dd></summary>
<hr>

crates/bcr-wdc-ebill-client/src/lib.rs

<ul><li>Added optional <code>authorized</code> feature with authentication support<br> <li> Implemented <code>authenticate</code> method for OAuth-style authentication<br> <li> Updated all API methods to use <code>/v1/admin/</code> prefix instead of <code>/v1/</code><br> <li> Added authorization plugin for authenticated requests<br> <li> Updated imports to use <code>bcr_common::wire</code> types for bill and identity<br> <li> Modified method signatures to use wire protocol types</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-a16ec5eb3940ebaff1e6279b5b37f628510942532a0e1720c6b5617e0ad787dd">+86/-38</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Integration of bcr-common library and service architecture refactoring</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/lib.rs

<ul><li>Integrated <code>bcr_common</code> library for wire types and <code>KeysClient</code><br> <li> Removed <code>QuoteKeysRepository</code> dependency and simplified service <br>architecture<br> <li> Added <code>clowder</code> module and client configuration<br> <li> Updated route endpoints to use constants from <code>KeysClient</code><br> <li> Refactored <code>AppController</code> to use <code>Arc</code> for shared state<br> <li> Updated OpenAPI schema imports to use <code>bcr_common::wire</code> types</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-3f8809d40f9e828f899b297d0eed35852796e26fa96f3c629ac0f4a6dc079589">+61/-77</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Simplification of web handlers and type consolidation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/web.rs

<ul><li>Simplified handler signatures by removing generic type parameters<br> <li> Updated imports to use consolidated <code>cashu</code> types<br> <li> Modified <code>lookup_keys</code> to return <code>KeysResponse</code> instead of <code>KeySet</code><br> <li> Removed signature verification logic from <code>mint_ebill</code> handler</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-02c5aa52715b6e2c505a69f778d2d2ae101cfa3e43d41b471c321b11a362be35">+43/-78</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clients.rs</strong><dd><code>Client architecture refactoring with bcr-common integration</code></dd></summary>
<hr>

crates/bcr-wdc-e2e-tests/src/clients.rs

<ul><li>Replaced multiple client implementations with unified clients from <br><code>bcr_common</code><br> <li> Added new client instances (<code>EbillClient</code>, <code>KeysClient</code>, <code>QuoteClient</code>, <br><code>SwapClient</code>, <code>TreasuryClient</code>)<br> <li> Refactored service methods to use new client APIs<br> <li> Added <code>admin_ebill_identity_details</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-e590f662f5fd8bbe6a53eebe1a3fc173fd9192bab5fe99d9f23caecf0540ebd1">+105/-70</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Wire types integration and BillId compatibility updates</code>&nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-ebpp/src/service.rs

<ul><li>Updated imports to use <code>bcr_common::wire::signatures</code><br> <li> Modified <code>request_to_pay</code> to accept <code>bcr_ebill_core::bill::BillId</code><br> <li> Added conversion logic for <code>BillId</code> compatibility<br> <li> Changed <code>Duration</code> import to use <code>std::time::Duration</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-b5acbddaada54279fd8bdaa1fd26b270a4cd28251ced566869426ee85da7c965">+21/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Admin API refactoring with new keyset and mint operation endpoints</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/admin.rs

<ul><li>Removed <code>generate</code>, <code>pre_sign</code>, and <code>enable</code> endpoints<br> <li> Added <code>get_keyset_for_date</code> endpoint for keyset lookup by expiration <br>date<br> <li> Added <code>new_mintop</code> endpoint for creating new mint operations<br> <li> Simplified handler signatures by removing generic type parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-f366824ed4999514276e404ad0b38b03fbb4c1768345ebce12638f7be6bfad1f">+58/-92</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>factory.rs</strong><dd><code>Keyset generation refactored to use timestamp-based derivation</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/factory.rs

<ul><li>Refactored <code>generate</code> method to derive keysets from expiration timestamp <br>instead of quote UUID<br> <li> Changed derivation path calculation to use timestamp components<br> <li> Updated to use <code>cashu::MintKeySet::generate</code> for keyset creation<br> <li> Removed custom <code>generate_mintkeyset</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-0936b33fd56c8a54b5936db31eea011621bb1d417e92c43b5751a1bac4ed393a">+42/-68</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Admin handlers simplification and minting enablement feature</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/admin.rs

<ul><li>Simplified handler signatures by removing generic type parameters<br> <li> Added <code>enable_minting</code> endpoint for enabling minting on quotes<br> <li> Renamed <code>admin_lookup_quote</code> to <code>lookup_quote</code> and <code>admin_update_quote</code> to <br><code>update_quote</code><br> <li> Updated <code>convert_into_list_params</code> and <code>convert_to_info_reply</code> to handle <br>new status fields</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-0ac7a81b04baaf01768d8526f8dceb0754d20adf93d53808f189a4b810752acb">+44/-40</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>convert.rs</strong><dd><code>New conversion utilities for wire and ebill core types</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-utils/src/convert.rs

<ul><li>New file implementing conversion functions between <code>bcr_common::wire</code> <br>and <code>bcr_ebill_core</code> types<br> <li> Added converters for identity, contact, postal address, and bill <br>participant types<br> <li> Includes bidirectional conversion support (wire2ebill and ebill2wire)</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-52321ba996233054c565727cc2472f705539d2c40e36fbed7f02fcbda1a2cf3a">+188/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Web handlers updated to use wire types and conversion utilities</code></dd></summary>
<hr>

crates/bcr-wdc-ebill-service/src/web.rs

<ul><li>Updated imports to use <code>bcr_common::wire</code> types<br> <li> Modified handlers to use conversion utilities from <br><code>bcr_wdc_utils::convert</code><br> <li> Changed <code>get_seed_phrase</code>, <code>get_identity</code>, and <code>create_identity</code> to use wire <br>types<br> <li> Updated <code>get_bill_endorsements</code> to convert endorsements using new <br>utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-d8457ecbd57dbb19b898ff61af1dcc6112b91759fc270f19d2a05fa479c5ebcc">+27/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>quotes.rs</strong><dd><code>Quote status model enhanced with minting pubkey tracking</code>&nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/quotes.rs

<ul><li>Renamed <code>public_key</code> field to <code>minting_pubkey</code> in <code>Status::Pending</code><br> <li> Added <code>minting_pubkey</code> field to <code>Status::Offered</code> and <code>Status::Accepted</code><br> <li> Converted <code>TryFrom</code> implementation to standalone <code>convert_to_billinfo</code> <br>function<br> <li> Enhanced error handling with <code>InvalidQuoteStatus</code> errors<br> <li> Added <code>Display</code> derive for <code>StatusDiscriminants</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-03545ff0e2dffaef5dbb0e2990ee74cf84c03a3c10f8f0f069b28ac5734f1ef8">+60/-42</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Quote service architecture simplification and bcr-common integration</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/lib.rs

<ul><li>Simplified service architecture by removing generic type parameters<br> <li> Updated <code>AppController</code> to use <code>Arc</code> for shared state<br> <li> Consolidated <code>cashu</code> imports from multiple <code>nut</code> modules<br> <li> Updated OpenAPI schema to include new wire types<br> <li> Modified routes function signature to remove generic constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-165657972ffc04299a11d483cafb1e6a8590ee69e9f7a7170b74a4d93b04b628">+30/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bill.rs</strong><dd><code>Bill types updated to use wire types and conversion utilities</code></dd></summary>
<hr>

crates/bcr-wdc-webapi/src/bill.rs

<ul><li>Updated imports to use <code>bcr_common::wire</code> types for contact and identity<br> <li> Modified <code>BillData</code> and <code>BillIdentParticipant</code> to use wire types<br> <li> Updated conversion implementations to use <code>bcr_wdc_utils::convert</code> <br>utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-6a495b86b4d732551ef6dad860fb79491bf2762aa3037122a4a84cebe72c0e03">+15/-112</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keys.rs</strong><dd><code>Keys handler refactored with new keyset management methods</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/keys.rs

<ul><li>Replaced <code>bcr_wdc_key_client::KeyClient</code> with <code>bcr_common::KeysClient</code><br> <li> Refactored <code>KeysHandler</code> trait methods: removed <code>generate</code>, added <br><code>get_keyset_with_redemption_date</code> and <code>add_new_mint_operation</code><br> <li> Updated <code>sign</code> method signature to remove <code>qid</code> parameter<br> <li> Enhanced test utilities with redemption date-based keyset lookup</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-d24b03325dacb5f2241120b3f10ef53990566604d941fe8a1dfd7a4ee08098ed">+55/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Web handlers simplified with minting pubkey terminology</code>&nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/web.rs

<ul><li>Simplified handler signatures by removing generic type parameters<br> <li> Updated <code>enquire_quote</code> to use <code>convert_to_billinfo</code> function<br> <li> Renamed <code>public_key</code> to <code>minting_pubkey</code> throughout<br> <li> Updated <code>convert_to_enquire_reply</code> to include <code>minting_pubkey</code> in <br>responses</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-1bd0e6958ea77d8d30de256aa68ee557a88bc615c71586889a98edca3ea18e30">+23/-45</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Wallet aggregator enhanced with clowder client integration</code></dd></summary>
<hr>

crates/bcr-wdc-wallet-aggregator/src/lib.rs

<ul><li>Added <code>clowder_client</code> integration with optional NATS connection<br> <li> Updated client types to use <code>bcr_common</code> clients<br> <li> Modified <code>AppController::new</code> to be async and return <code>Result</code><br> <li> Added keyset synchronization with clowder on startup<br> <li> Changed <code>routes</code> function to be async and handle clowder initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-8479e17ae2f35c019c884788163137e22c66a8955874a28a3ebbe30754be3c1c">+49/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Quote client API expanded with granular quote management methods</code></dd></summary>
<hr>

crates/bcr-wdc-quote-client/src/lib.rs

<ul><li>Renamed <code>mint_pubkey</code> parameter to <code>minting_pubkey</code> in <code>enquire</code> method<br> <li> Added new methods: <code>deny</code>, <code>offer</code>, <code>accept_offer</code>, <code>reject_offer</code>, <br><code>cancel_enquiry</code>, <code>enable_minting</code><br> <li> Renamed <code>resolve</code> to more specific action methods<br> <li> Renamed <code>cancel</code> to <code>cancel_enquiry</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-fa0779382859a62530dd708ed21f321792e966dee691bb62cb62946804e28a43">+70/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Swap endpoint enhanced with clowder notifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-wallet-aggregator/src/web.rs

<ul><li>Updated <code>KeyClient</code> to <code>KeysClient</code> from <code>bcr_common</code><br> <li> Added clowder client integration for mint swap notifications<br> <li> Modified <code>post_swap</code> to notify clowder of swap operations<br> <li> Updated error handling for <code>KeysError</code> type</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-5558fd821dba3268f729f3ca79eb75aff0edcd3fbf1b9414c170f6fbc18c72a1">+17/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Treasury debit service updated for wire types and core integration</code></dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/debit/service.rs

<ul><li>Updated imports to use <code>bcr_common::wire::signatures</code> and <br><code>bcr_common::core</code><br> <li> Modified <code>mint_quote</code> to use wire signature types<br> <li> Added <code>BillId</code> conversion for compatibility with bcr-common<br> <li> Changed <code>Duration</code> import to <code>std::time::Duration</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-caaa9a1592f0e5ce710ca52d8f651b10978b6986cb1090c391f76ab4bd749b06">+13/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.rs</strong><dd><code>Add DummyClient implementation for key service testing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/client.rs

<ul><li>Added new <code>DummyClient</code> struct with methods for keyset operations, <br>signing, verification, minting, and restoration<br> <li> Implemented async methods that wrap <code>InMemoryRepository</code> operations with <br>error handling<br> <li> Includes placeholder <code>todo!()</code> implementations for <code>mint</code> and <code>restore</code> <br>methods</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-8b5dd0c09ffad825927b2e33578a23b31c031f59fb0de8ca030e1d9fad8b42c2">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clowder.rs</strong><dd><code>Add Clowder client integration for keyset notifications</code>&nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/clowder.rs

<ul><li>Added new Clowder client integration with <code>DummyClowderClient</code> and <br><code>ClowderCl</code> implementations<br> <li> Implemented <code>ClowderClient</code> trait with <code>new_keyset</code> and <code>keyset_deactivated</code> <br>methods<br> <li> Added configuration enum supporting Dummy and ClowderNats variants</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-fc0c842c1cf4200d2e041471e6d532b58d204a12e2ad7cb5fb2082d4f2e7de96">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Simplify treasury client API and update cashu imports</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-client/src/lib.rs

<ul><li>Replaced <code>cashu::nut00/nut02/nut03</code> imports with direct <code>cashu</code> types<br> <li> Removed <code>expiration</code> parameter from <code>store_signatures</code> method<br> <li> Updated <code>redeem</code> method to use <code>cashu::SwapRequest</code> and <br><code>cashu::SwapResponse</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-a1ed6e2862956edbaae0bcc2d2035feb1556377205b83a6d249a1cc09e65e3ac">+10/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Restructure ebill service routes with admin prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-ebill-service/src/lib.rs

<ul><li>Updated all route paths to include <code>/v1/admin/</code> prefix for <br>administrative endpoints<br> <li> Reorganized routes for identity, bill operations, and validation</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-bca71cbba9ed5622ab5e4c3fa1910a48a033a88332b9531db05bd4869694b8ce">+18/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.rs</strong><dd><code>Simplify wallet service interface by removing expiration parameter</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/wallet.rs

<ul><li>Removed <code>expiration</code> parameter from <code>get_blinds</code> and <code>store_signatures</code> <br>methods<br> <li> Updated imports to use direct <code>cashu</code> types instead of <br><code>cashu::nuts::nut00/nut02</code><br> <li> Simplified method signatures in both <code>Client</code> and <code>DummyWallet</code> <br>implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-82a31ebeb1d1b6f5737bc38f6056c3ca659b8a68cd6e6374a8768e9dec0f776a">+7/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Standardize swap service endpoints using bcr-common constants</code></dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/lib.rs

<ul><li>Added <code>bcr_common::SwapClient</code> import and used its endpoint constants<br> <li> Updated route definitions to use <code>SwapClient::SWAP_EP_V1</code>, <code>BURN_EP_V1</code>, <br><code>CHECKSTATE_EP_V1</code>, and <code>RECOVER_EP_V1</code><br> <li> Changed test utilities to use <code>bcr_wdc_key_service::client::DummyClient</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-d6043a0bd0e59231f714995c9050c95248343410c6e4944cd2d027c37ded0b06">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>quotes.rs</strong><dd><code>Add minting public key tracking to quote API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-webapi/src/quotes.rs

<ul><li>Renamed <code>public_key</code> field to <code>minting_pubkey</code> in <code>EnquireRequest</code><br> <li> Added <code>minting_pubkey</code> field to <code>OfferAccepted</code> and <code>Minting</code> status <br>variants<br> <li> Added new <code>EnableMintingRequest</code> and <code>EnableMintingResponse</code> structs</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-42911c9e24e041418ffc2f1e92de4be1171ef724642b15b4228d37b60499f496">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Make wallet aggregator initialization asynchronous</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-wallet-aggregator/src/main.rs

<ul><li>Added <code>await</code> to <code>AppController::new</code> initialization<br> <li> Added <code>await</code> to <code>routes</code> function call<br> <li> Added error handling with <code>expect</code> for both operations</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-73d577198abfe1bf64974aee26b323e62e076c9efd3370effe47ace48acda76d">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_utils.rs</strong><dd><code>Refactor test utilities to use wire protocol types and updated </code><br><code>signatures</code></dd></summary>
<hr>

crates/bcr-wdc-webapi/src/test_utils.rs

<ul><li>Updated imports to use <code>bcr_common::wire</code> for contact and identity types<br> <li> Modified <code>generate_random_bill_enquire_request</code> signature to accept <br><code>receiver_pk</code>, optional <code>payee_kp</code>, and optional <code>amount</code><br> <li> Changed <code>EnquireRequest</code> field from <code>public_key</code> to <code>minting_pubkey</code><br> <li> Renamed <code>random_date</code> function to <code>random_datetime</code><br> <li> Updated identity structures to use wire protocol types</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-e1f74ab6df7fe46ff507cbce007fc16efe9c4c63181b4f6025bea28d976819f3">+46/-49</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Update end-to-end tests for new minting and quote acceptance flow</code></dd></summary>
<hr>

crates/bcr-wdc-e2e-tests/src/main.rs

<ul><li>Simplified authentication tests by removing unnecessary authorization <br>checks<br> <li> Updated <code>can_mint_ebill</code> test to use new minting flow with <br><code>enable_minting_for_quote_id</code><br> <li> Removed <code>EnableKeysetRequest</code> and keyset activation logic<br> <li> Updated mint request flow to use <code>accept_quote</code> and <code>enable_minting</code> <br>methods<br> <li> Simplified keyset verification and proof generation logic<br> <li> Updated swap test to use new service methods</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-7dfaf4fa6e45c9464ca129bab5799f4ef75cb2e6e8bb38769a49b510506f6a86">+39/-80</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>identity.rs</strong><dd><code>Update identity tests to use wire protocol types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-ebill-client/tests/identity.rs

<ul><li>Updated imports to use <code>bcr_common::wire::identity</code> types<br> <li> Changed test to use <code>wire_identity::SeedPhrase</code> and <br><code>wire_identity::NewIdentityPayload</code><br> <li> Updated <code>OptionalPostalAddress</code> reference to wire protocol type</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-f4454dcd8fbe2d58d2e152cd8a3b9bd59cb037978a2b0dde55906c4146154aad">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>surreal.rs</strong><dd><code>Test data updated for minting pubkey field changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/persistence/surreal.rs

<ul><li>Updated test data to use <code>minting_pubkey</code> instead of <code>public_key</code><br> <li> Added <code>minting_pubkey</code> field to <code>Status::Offered</code> and <code>Status::Accepted</code> in <br>tests</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-e0caddd16b02b3646a69fca2fb0c9f351fcb57dcd7d613a1c750a4e1bd051a0b">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_utils.rs</strong><dd><code>Refactor e2e test utilities with structured return types</code>&nbsp; </dd></summary>
<hr>

crates/bcr-wdc-e2e-tests/src/test_utils.rs

<ul><li>Refactored <code>random_ebill_request</code> to return <code>EbillRequestComponents</code> <br>struct instead of tuple<br> <li> Removed <code>get_amounts</code> function (moved to cashu implementation)<br> <li> Updated function signature to accept <code>receiver</code> and <code>amount</code> parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-22f15da9c72f8af83a1e2828f15e27fc283744d8f8a21d03cdbab3d9d82f75ce">+14/-38</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list.rs</strong><dd><code>Update quote client tests for new request generation API</code>&nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-client/tests/list.rs

<ul><li>Updated <code>generate_random_bill_enquire_request</code> calls with new signature <br>including <code>receiver</code>, <code>holder_key_pair</code>, and <code>amount</code> parameters<br> <li> Changed from using <code>owner_key</code> to <code>owner_key.public_key().into()</code> for <br>receiver parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-03e6c0af2a4326a20b8eabba92723a19a6b632f06a408607af0c7a1d1d8c3058">+17/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>swap.rs</strong><dd><code>Simplify swap tests by removing mint conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/tests/swap.rs

<ul><li>Replaced <code>bcr_wdc_key_client</code> with <code>bcr_common::SwapClient</code><br> <li> Removed <code>MintCondition</code> usage and simplified keyset storage<br> <li> Updated <code>store</code> method call to remove condition parameter and add <code>await</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-f23e21524e8649a23d6f8943f93c1899e8234159e65c12b72b73713ca0508ad5">+6/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enquire.rs</strong><dd><code>Update enquire test with new request generation pattern</code>&nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-client/tests/enquire.rs

<ul><li>Updated test to use <code>receiver_pk</code> instead of <code>owner_key</code><br> <li> Changed <code>generate_random_bill_enquire_request</code> call to pass <br><code>receiver_pk.into()</code>, <code>holder_kp</code>, and <code>None</code> for amount<br> <li> Updated <code>enquire</code> call to use <code>keys_test::publics()[0]</code> instead of <br><code>owner_key.public_key().into()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-c1aa452a491e88b5931fae2864857a2a86487522824636ca1e8ca0c8cbe1ffd6">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>checkstate.rs</strong><dd><code>Simplify checkstate test by removing mint conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/tests/checkstate.rs

<ul><li>Replaced <code>bcr_wdc_key_service::MintCondition</code> with <br><code>bcr_wdc_key_service::KeysRepository</code><br> <li> Removed <code>MintCondition</code> initialization and simplified <code>store</code> call<br> <li> Added <code>await</code> to <code>store</code> method call</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-d6f615157c6972f07e64509cf49836b3ec416e71b2cb84a7f3a5dd8ed44cb675">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keys.rs</strong><dd><code>Update keys tests for bcr-common migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/tests/keys.rs

<ul><li>Replaced <code>bcr_wdc_key_client</code> with <code>bcr_common::KeysClient</code> and <code>KeysError</code><br> <li> Updated test server initialization to use <code>await</code><br> <li> Changed error assertion to match <code>KeysError::ResourceNotFound</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-cdbe87b79fcb89e679508d17263220ad0c4c5fe6849cf54a3485779c266b4788">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keyset_info.rs</strong><dd><code>Update keyset info tests for bcr-common migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/tests/keyset_info.rs

<ul><li>Replaced <code>bcr_wdc_key_client</code> with <code>bcr_common::KeysClient</code> and <code>KeysError</code><br> <li> Updated test server initialization to use <code>await</code><br> <li> Changed error assertion to match <code>KeysError::ResourceNotFound</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-a2e73de7c98e5bc21edda9e3af565f55e425344589e8d32b5d1c0929358e0d26">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lookup.rs</strong><dd><code>Update lookup test with new request generation API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-client/tests/lookup.rs

<ul><li>Updated <code>generate_random_bill_enquire_request</code> call with new parameters<br> <li> Changed <code>enquire</code> call to use <code>signing_key.public_key().into()</code> instead of <br><code>owner_key.public_key().into()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-d1f56eaa033a97db8a88e1fcc6320a8fce933dcbb21105719396a0f567f32082">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>restore.rs</strong><dd><code>Update restore test for bcr-common migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/tests/restore.rs

<ul><li>Replaced <code>bcr_wdc_key_client::KeyClient</code> with <code>bcr_common::KeysClient</code><br> <li> Updated test server initialization to use <code>await</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-341dd45df3eef513f9edbed9320703ab5fde6adb1bd8a8ad15f5c5b41281c4aa">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_keyset_info.rs</strong><dd><code>Update list keyset info test for bcr-common migration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/tests/list_keyset_info.rs

<ul><li>Replaced <code>bcr_wdc_key_client::KeyClient</code> with <code>bcr_common::KeysClient</code><br> <li> Updated test server initialization to use <code>await</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-0be850109b92666253ef2ebbaa20947be0121f86c4168565dffad60f00bd1b77">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>keys.rs</strong><dd><code>Removed UUID-based derivation path extension utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-utils/src/keys.rs

<ul><li>Removed <code>extend_path_from_uuid</code> function<br> <li> Removed <code>uuid::Uuid</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-88918b1bb74f41ff3324615d303d1c32ed912a92eeefe25d47604cf2b3a362c8">+1/-33</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>devtool.rs</strong><dd><code>Update devtool for new request generation API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-webapi/src/bin/devtool.rs

<ul><li>Updated <code>generate_random_bill_enquire_request</code> call to pass <code>owner_pk</code>, <br><code>None</code>, and <code>None</code> parameters<br> <li> Changed from using <code>owner_key</code> directly to <br><code>bitcoin::PublicKey::new(owner_key.public_key())</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-df21ec837a02726f23714c89a58bfc9afeb0f0e568a977a8907f7bed7f32c477">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ebill.rs</strong><dd><code>Rename date utility function for clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/ebill.rs

- Renamed `random_date` to `random_datetime` in test utilities


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-8f49a9e1d88ad9c59e7ebeb22dd015f30ef99d14528d174bdbe643e56161c81d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>New error variant for identity type validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-ebill-service/src/error.rs

<ul><li>Added <code>IdentityType</code> error variant<br> <li> Updated <code>IntoResponse</code> implementation to handle <code>IdentityType</code> error</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-b935147390b93205af89a3d7114a4cb905a2615eb1ef9cc7604d599ec4c2bcfd">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Extend error handling with Clowder and internal errors</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/error.rs

<ul><li>Added <code>ClowderClient</code> error variant<br> <li> Added <code>Internal</code> error variant for internal server errors<br> <li> Updated error messages for repository errors<br> <li> Enhanced <code>IntoResponse</code> implementation with new error mappings</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-1ddc03038fa2a6c659a03a250ed71bf55253dabf322d0caad60ec76a7e73da7c">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Enhance quote service error handling with status tracking</code></dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/error.rs

<ul><li>Replaced <code>bcr_wdc_key_client::Error</code> with <code>bcr_common::KeysError</code><br> <li> Changed <code>QuoteAlreadyResolved</code> error to <code>InvalidQuoteStatus</code> with status <br>discriminants<br> <li> Updated error response mappings for new error variants</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-ba4223300771963ac9bac2c3a6d4859b9e260cff57010253b4ef8f8d51f641ef">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>keys.rs</strong><dd><code>Migrate swap service keys to bcr-common library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/keys.rs

<ul><li>Replaced <code>bcr_wdc_key_client</code> with <code>bcr_common</code> for <code>KeysClient</code> and <br><code>KeysError</code><br> <li> Updated import paths from <code>cashu::nuts::nut00/nut02</code> to direct <code>cashu</code> <br>types<br> <li> Changed <code>KeyClient</code> to <code>KeysClient</code> and updated URL type to <code>reqwest::Url</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-ee737c4d0352b0fcb329c16d410f63ab5f29e139ec20200c8440f4ca763052b4">+12/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Migrate wallet aggregator errors to bcr-common library</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-wallet-aggregator/src/error.rs

<ul><li>Replaced <code>bcr_wdc_key_client</code> and <code>bcr_wdc_swap_client</code> with <code>bcr_common</code> <br>equivalents<br> <li> Added <code>ClowderClient</code> error variant<br> <li> Updated error type references to use <code>bcr_common::KeysError</code> and <br><code>bcr_common::SwapError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-83abe012df823c2cf0711368e006172e98a578f9226eebceba77a51cdecbd7d6">+12/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Migrate treasury admin to bcr-common wire types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/admin.rs

<ul><li>Replaced <code>bcr_wdc_webapi::signatures</code> with <code>bcr_common::wire::signatures</code><br> <li> Removed <code>expiration</code> parameter from <code>store_signatures</code> call<br> <li> Updated <code>request_mint_from_ebill</code> to use wire types and convert <code>ebill_id</code> <br>format</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-1a696476126e3290a8fea9f62843118cdb79f77c324ead24a867267d7dacaff3">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wildcat.rs</strong><dd><code>Migrate wildcat client to bcr-common library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/debit/wildcat.rs

<ul><li>Replaced <code>bcr_wdc_key_client</code> and <code>bcr_wdc_swap_client</code> with <code>bcr_common</code> <br>equivalents<br> <li> Updated client initialization to use <code>KeysClient</code> and <code>SwapClient</code> from <br><code>bcr_common</code><br> <li> Changed error handling to use <code>KeysError</code> from <code>bcr_common</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-b00e7a42e7f7d62211a82197682b868526c0e095d5488b58a77be62a99abf922">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keys.rs</strong><dd><code>Migrate credit keys service to bcr-common library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/credit/keys.rs

<ul><li>Replaced <code>bcr_wdc_key_client</code> with <code>bcr_common::KeysClient</code><br> <li> Updated <code>KeyClient</code> references to <code>KeysClient</code><br> <li> Changed error handling to use <code>KeysError</code> from <code>bcr_common</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-9add08abfe7f7f8e016f41d9db0813e65951b9f1db294c4229e7e29e5a78fa78">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Migrate swap client to bcr-common wire types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-client/src/lib.rs

<ul><li>Replaced <code>bcr_wdc_webapi::swap</code> with <code>bcr_common::wire::swap</code><br> <li> Updated <code>BurnRequest</code>, <code>BurnResponse</code>, <code>RecoverRequest</code>, and <code>RecoverResponse</code> <br>to use wire types</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-0b8fd88c2d32cd810d4400a2765b0520b17e5cf352474d41f79b80bf6054e956">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Migrate swap web handlers to bcr-common wire types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/web.rs

<ul><li>Replaced <code>bcr_wdc_webapi::swap</code> with <code>bcr_common::wire::swap</code><br> <li> Updated <code>BurnRequest</code> and <code>BurnResponse</code> to use wire types</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-a962c0b71f7450d6ddbac912eb54cf75d94eab7bf3740e33406f1704975762de">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Migrate swap admin handlers to bcr-common wire types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/admin.rs

<ul><li>Replaced <code>bcr_wdc_webapi::swap</code> with <code>bcr_common::wire::swap</code><br> <li> Updated <code>RecoverRequest</code> and <code>RecoverResponse</code> to use wire types</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-345dfa30c5943a03863c97927531ac09287e9d7c20a757afa5164335977f37ce">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.rs</strong><dd><code>Migrate debit wallet to bcr-common wire types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/debit/wallet.rs

<ul><li>Replaced <code>bcr_wdc_webapi</code> with <code>bcr_common::wire::signatures</code><br> <li> Updated <code>mint_quote</code> method to use <br><code>wire_signatures::SignedRequestToMintFromEBillDesc</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-ab70a3c30b817240c79e6db77038f6efecb7530eb01f06331c389f4440f08440">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Migrate swap service errors to bcr-common library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-swap-service/src/error.rs

<ul><li>Replaced <code>bcr_wdc_key_client::Error</code> with <code>bcr_common::KeysError</code><br> <li> Updated <code>KeysClient</code> error variant to use <code>bcr_common::KeysError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-1efd0eb1b6134bb669567aad1c0684679f39c90daef1e35a29c11cb82bf63433">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Migrate treasury service errors to bcr-common library</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/error.rs

<ul><li>Replaced <code>bcr_wdc_key_client::Error</code> with <code>bcr_common::KeysError</code><br> <li> Replaced <code>bcr_wdc_swap_client::Error</code> with <code>bcr_common::SwapError</code><br> <li> Updated error messages for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-ab2c84ccec5c1e98a9c43fc0ab1e435af80833007aa3e33f25260f5397da2214">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>49 files</summary><table>
<tr>
  <td><strong>build.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+33/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>e2e-test.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2">+31/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nightly.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6">+32/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rust.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d">+29/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88">+36/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>common-services.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-feef9361dee340026246ae79275bc3b63be23a97aef0579ef9042376439c4137">+7/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-5aa2b35cb73a0e4968d3853eed4415b5acef0c7382b97804d16eff5e024e1955">+14/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-eca02ddaff04e57fc896ad2ec840dbf27c58b1e0e4318e4fc35913dc519fcc9c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bills.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-f0b2fa0e421864cafc40b00b275d3c6eb89f6f2b24063000b3f1eca1721c655c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-c45ccc113f9d74c3e2a7e7ee453eb21e783d71bd6fde8b8f75d7142386aa255b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-fbb36d8aa1db230a56172e02eeb7630c6b0ff44f9c10f92d56ad92668e9fdbeb">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-f0d2d228315ef718f33c9cc1fc49a4002ccd011ae5e7aaae8415d0f7d11f0f32">+0/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-a8c55995b2dad28ce9375fabcc6c909015b3419a52b5fa6a1c7a4205f25dbf89">+0/-357</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pre_sign.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-2b05713a9668b140f4313ba736cbd54d1582040fb1d71de4cd356c0a0b3d0a7f">+0/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-3fe552818ead67e1b09da15ad6b91494204ec912c55ff6335bf7fe4d30675c9d">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-34b7cf60e8e8ea099119b79812adae9f6944c4c0a4bb8996feb9fd78da184710">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-4e256eed7ead076418f608369ce678e64c1a2ee653ee3518b1f27a22b3c502b0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cancel.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-8d894fc4076b3af42631c49af8068695d9d222436fffbc73a3ac5058a8d7b3de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-7953f8a4c41812869b8fde0f8bf44078cf538d9bc28115d3d37e77e77124cdfe">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-005921f385b693f0588048aa036916664ede39230056df53e5e9ec123eab0f02">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-20c6ff9bd3580bd8e784733a5efaf2ff4f8df9492cf1e5691f1b35857c4a9f2b">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-b0811ad016d852658854b109291d33acdb64a223f7d8a3c2abbbd2938f28d6c7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-6df636339e3a8a42ba9e410dd9560703ec90157f097e903f0e733f8b4d18f4cc">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-fb8e907942c08710bc61e846f07cd964a3a620ff03e6df23ec32a299dc7a6558">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-244fb9160ddcbeadb2c1faa1830722c935612662a349aa529b15589c440f4e6b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-ccfd2dab4d161c5afe534c946f0ef8bb51ee58f286c1082c25e2c01d0c2e46b6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>signatures.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-3a6b632ae0793c851aa4bac969ce483cc94c1bdc2954c1af74d159ae2de91e8f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-245d40508bcd3a2d2446ceb2a51102995a7dab7aeabdd2b68e1de9528a4e4d1d">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.config.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-81a7796c6ff4a2bd591d31a916457943093d168beeb7e561e8e62eb992e04be5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-1deda28f2b11c4bb4eb4ec44a221db20268322c9ac0950126d25f9fdcc7b759a">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>contact.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-6d0d709b67b2215b63010adce496623ac6a089ae8b46e7fea1f52696f004c537">+0/-57</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identity.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-c134b0cc8e64e29425da6c7770c28bce8112a857878c57428d211f59e491cfe2">+0/-221</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>keys.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-188353c6638ec833337a71f3ccf5522a22bb02a6fbfa233224a455a5c7bc1e85">+0/-49</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-473e41768fe06fcab3f4959ac515fddce85e8e9ba438483c691d79c270d558bb">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>signatures.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-56eeabfa487aff0407262229cab0d9d44a5bb537e1a40ff0e41410dc1b9ceac9">+0/-29</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>swap.rs</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-a82098daf15fa6b647caac6a978912a0ba392619a26fe2764342c81d5b42091f">+0/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deployment-configuration-local.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-9ad168432396c0f9612e58281fab2ef4c6d06aa914f4609dd419cec25cbfdc03">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deployment-configuration.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-13bce7a18666c010bbcaca59df63da5c5227816089d43dcca3386faed460c8dc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose-e2e.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-a7288a5d1665494bd3e308cf33c299712053eb89448da79918583891af8b2a23">+5/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose-local.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-aed91aa2667654a05077a027349bdccf0caa1bfefddc15a397fc00f1ee8385d3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-274e5507bb3f753802cf591bf0b8ac308096c5a1c11bb9c0c7713aeef6bf29f1">+14/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>envoy.yaml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-42eb1a6f496726d980f9f5be9b9b7e5213440f12b3ee73b5a3d98907903a9b7c">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-775038e10f5fc84247e6a1f33f3b457b7d139df3d4e8e691d864e49caafb008a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.toml</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-ad1172e87dd1b09e7745ee6029056d0ced2d5322feea8e908065d0d1774f726a">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>justfile</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>recipe.json</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-449afccfc3c61c500a03380a6c5244190e2dd9e53ac8f257436b5aa23eae2b4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cargo_git_auth.sh</strong></td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/313/files#diff-bc60d0a18ce135cef9ab6f7ba6ac475565a6ae04d1d51a9f604ee2d28e879805">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

