### PR TITLE
[bcr-wdc-wallet-aggregator] add commit endpoint

### DIFF
--- a/crates/bcr-wdc-wallet-aggregator/Cargo.toml
+++ b/crates/bcr-wdc-wallet-aggregator/Cargo.toml
@@ -9,20 +9,25 @@ build = "build.rs"
 test-utils = ["axum-test"]
 
 [dependencies]
+anyhow = {workspace = true}
 async-trait.workspace = true
 axum = {workspace = true, features = ["macros"]}
 axum-test = {workspace = true, optional = true}
 bcr-common = {workspace = true, features = ["authorized"]}
 bcr-wdc-ebpp-client = {workspace = true}
-clwdr-client = {workspace = true}
 bcr-wdc-treasury-client = {workspace = true}
+bitcoin = {workspace = true}
+borsh = {workspace = true}
 built = {workspace = true, features = ["semver", "chrono"]}
 cashu.workspace = true
 cdk = {workspace = true, features = ["wallet"]}
+chrono = {workspace = true, features = ["serde"]}
+clwdr-client = {workspace = true}
 config = {workspace = true}
 futures = {workspace = true}
 reqwest = {workspace = true}
 serde.workspace = true
+surrealdb = {workspace = true}
 thiserror.workspace = true
 tokio.workspace = true
 tower-http = { version = "0.6.2" }
@@ -33,8 +38,9 @@ utoipa = {workspace = true, features = ["axum_extras"]}
 utoipa-swagger-ui = {workspace = true, features = ["axum"]}
 
 [dev-dependencies]
-mockall.workspace = true
 bcr-wdc-utils = {workspace = true, features = ["test-utils"]}
+mockall.workspace = true
+surrealdb = {workspace = true, features = ["kv-mem"]}
 
 [build-dependencies]
 built = {workspace = true, features = ["dependency-tree", "chrono"]}

--- a/crates/bcr-wdc-wallet-aggregator/src/commitment.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/commitment.rs
@@ -1,0 +1,174 @@
+// ----- standard library imports
+use std::collections::HashMap;
+// ----- extra library imports
+use async_trait::async_trait;
+use bcr_common::{
+    client::{keys::Client as KeysClient, swap::Client as SwapClient},
+    core::signature::deserialize_borsh_msg,
+    wire::{keys as wire_keys, swap as wire_swap},
+};
+use bitcoin::secp256k1::schnorr;
+use cashu::nut07 as cdk07;
+use cdk::wallet::MintConnector;
+// ----- local imports
+use crate::{
+    error::{Error, Result},
+    TStamp,
+};
+
+// ----- end imports
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait Repository: Send + Sync {
+    async fn clean_expired(&self, now: TStamp) -> Result<()>;
+    /// check if any of the proof fingerprints appear in an existing commitment
+    /// returns true if any of the proofs is committed
+    async fn check_committed_inputs(&self, ys: &[cashu::PublicKey]) -> Result<bool>;
+    /// check if any of the blinded Messages appear in an existing commitment
+    /// returns true if any of the secrets is committed
+    async fn check_committed_outputs(&self, secrets: &[cashu::PublicKey]) -> Result<bool>;
+
+    async fn store(
+        &self,
+        inputs: Vec<cashu::PublicKey>,
+        outputs: Vec<cashu::PublicKey>,
+        expiration: TStamp,
+        commitment: schnorr::Signature,
+    ) -> Result<()>;
+    async fn find(
+        &self,
+        inputs: &[cashu::PublicKey],
+        outputs: &[cashu::PublicKey],
+    ) -> Result<Option<schnorr::Signature>>;
+    async fn delete(&self, commitment: schnorr::Signature) -> Result<()>;
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait Signer: Send + Sync {
+    async fn sign(&self, content: &[u8]) -> Result<bitcoin::secp256k1::schnorr::Signature>;
+}
+
+pub struct Service {
+    pub repo: Box<dyn Repository>,
+    pub signer: Box<dyn Signer>,
+}
+
+impl Service {
+    pub const MIN_EXPIRATION: chrono::Duration = chrono::Duration::seconds(90);
+    pub async fn commit(
+        &self,
+        now: TStamp,
+        request: wire_swap::CommitmentRequest,
+        swap_cl: &SwapClient,
+        keys_cl: &KeysClient,
+        cdk_mint_cl: &cdk::wallet::HttpClient,
+    ) -> Result<wire_swap::CommitmentResponse> {
+        let payload: wire_swap::CommitmentContent = deserialize_borsh_msg(&request.content)?;
+        // expiration check
+        if payload.expiration < now + Self::MIN_EXPIRATION {
+            return Err(Error::InvalidInput(String::from("expiration too soon")));
+        }
+        validate_commitment_inputs(keys_cl, swap_cl, cdk_mint_cl, &payload.inputs).await?;
+        // crsat
+        let signatures = keys_cl.restore(payload.outputs.clone()).await?;
+        if !signatures.is_empty() {
+            return Err(Error::InvalidInput(String::from("crsat blinds seen")));
+        }
+        // sat
+        let restore_request = cashu::RestoreRequest {
+            outputs: payload.outputs.clone(),
+        };
+        let restore_response = cdk_mint_cl.post_restore(restore_request).await?;
+        if !restore_response.signatures.is_empty() {
+            return Err(Error::InvalidInput(String::from("sat blinds seen")));
+        }
+        // committed
+        let ys: Vec<cashu::PublicKey> = payload.inputs.iter().map(|p| p.y).collect();
+        self.repo.clean_expired(now).await?;
+        let any_committed = self.repo.check_committed_inputs(&ys).await?;
+        if any_committed {
+            return Err(Error::InvalidInput(String::from("proofs committed")));
+        }
+        let secrets: Vec<_> = payload.outputs.iter().map(|b| b.blinded_secret).collect();
+        let any_committed = self.repo.check_committed_outputs(&secrets).await?;
+        if any_committed {
+            return Err(Error::InvalidInput(String::from(
+                "blinded messages committed",
+            )));
+        }
+        // signing
+        let serialized = borsh::to_vec(&payload)?;
+        let signature = self.signer.sign(&serialized).await?;
+        self.repo
+            .store(ys, secrets, payload.expiration, signature)
+            .await?;
+        let response = wire_swap::CommitmentResponse {
+            commitment: signature,
+        };
+        Ok(response)
+    }
+
+    // check if a swap request is ok to go ahead
+    // a request can be either made of unseen inputs and outputs
+    // or committed inputs and outputs
+    pub async fn check_swap(&self, now: TStamp, request: cashu::SwapRequest) -> Result<bool> {
+        self.repo.clean_expired(now).await?;
+        let inputs = request
+            .inputs()
+            .iter()
+            .map(|p| p.y())
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let outputs: Vec<_> = request.outputs().iter().map(|b| b.blinded_secret).collect();
+        // committed swap
+        let commitment = self.repo.find(&inputs, &outputs).await?;
+        if let Some(commitment) = commitment {
+            self.repo.delete(commitment).await?;
+            return Ok(true);
+        }
+
+        let any_committed_proofs = self.repo.check_committed_inputs(&inputs).await?;
+        let any_committed_blinds = self.repo.check_committed_outputs(&outputs).await?;
+        Ok(!any_committed_proofs && !any_committed_blinds)
+    }
+}
+
+async fn validate_commitment_inputs(
+    key_cl: &KeysClient,
+    swap_cl: &SwapClient,
+    cdk_mint_cl: &cdk::wallet::HttpClient,
+    inputs: &[wire_keys::ProofFingerprint],
+) -> Result<()> {
+    //crsat hypothesis
+    let ys: Vec<cashu::PublicKey> = inputs.iter().map(|p| p.y).collect();
+    let state = swap_cl.check_state(ys.clone()).await?;
+    let any_spent = state
+        .into_iter()
+        .any(|state| matches!(state.state, cdk07::State::Spent));
+    if any_spent {
+        return Err(Error::InvalidInput(String::from("crsat proofs spent")));
+    }
+    let mut by_kids: HashMap<cashu::Id, Vec<&wire_keys::ProofFingerprint>> = HashMap::new();
+    for fp in inputs {
+        by_kids.entry(fp.keyset_id).or_default().push(fp);
+    }
+    for (kid, fps) in by_kids {
+        if key_cl.keyset_info(kid).await.is_ok() {
+            for fp in fps {
+                key_cl.verify_fingerprint(fp).await?;
+            }
+        }
+    }
+    // sat hypothesis
+    let state_request = cashu::CheckStateRequest { ys: ys.clone() };
+    let state_response = cdk_mint_cl.post_check_state(state_request).await?;
+    let any_spent = state_response
+        .states
+        .into_iter()
+        .any(|state| matches!(state.state, cdk07::State::Spent));
+    if any_spent {
+        return Err(Error::InvalidInput(String::from("sat proofs spent")));
+    }
+    Ok(())
+}

--- a/crates/bcr-wdc-wallet-aggregator/src/error.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/error.rs
@@ -15,6 +15,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("DB: {0}")]
+    DB(anyhow::Error),
+    #[error("cashu::nut00:: {0}")]
+    Cdk00(#[from] cashu::nut00::Error),
+    #[error("borsh:: {0}")]
+    Borsh(#[from] borsh::io::Error),
+    #[error("bcr_common::borsh:: {0}")]
+    BcrCommonBorsh(#[from] bcr_common::core::signature::BorshMsgSignatureError),
     #[error("CDK Client error: {0}")]
     Cdk(#[from] CDKError),
     #[error("Keyset Client: {0}")]
@@ -32,12 +40,15 @@ pub enum Error {
 
     #[error("not yet implemented: {0}")]
     NotYet(String),
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 }
 
 impl axum::response::IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         tracing::error!("Error: {}", self);
         let response = match self {
+            Error::InvalidInput(e) => (StatusCode::BAD_REQUEST, e.to_string()),
             Error::NotYet(msg) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("{msg} not yet implemented"),
@@ -58,6 +69,10 @@ impl axum::response::IntoResponse for Error {
             Error::Keys(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
 
             Error::Cdk(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::BcrCommonBorsh(_) => (StatusCode::BAD_REQUEST, String::new()),
+            Error::Borsh(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::Cdk00(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::DB(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
         };
 
         response.into_response()

--- a/crates/bcr-wdc-wallet-aggregator/src/lib.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/lib.rs
@@ -14,12 +14,17 @@ pub mod built_info {
     // The file has been placed there by the build script.
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
+mod commitment;
 mod error;
+mod persistence;
+mod signer;
 mod web;
 // ----- local imports
 use error::Result;
 
 // ----- end imports
+
+pub type TStamp = chrono::DateTime<chrono::Utc>;
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct AppConfig {
@@ -30,6 +35,7 @@ pub struct AppConfig {
     ebpp_client_url: bcr_wdc_ebpp_client::Url,
     clwdr_nats_url: Option<reqwest::Url>,
     clwdr_rest_url: Option<reqwest::Url>,
+    commit_repo_cfg: persistence::surreal::DBCommitmentsConnectionConfig,
 }
 
 #[derive(Clone, FromRef)]
@@ -41,6 +47,7 @@ pub struct AppController {
     ebpp_client: bcr_wdc_ebpp_client::EBPPClient,
     clwdr_stream_client: Option<Arc<clwdr_client::ClowderNatsClient>>,
     clwdr_rest_client: Option<Arc<clwdr_client::ClowderRestClient>>,
+    commit_srv: Arc<commitment::Service>,
 }
 
 impl AppController {
@@ -53,6 +60,7 @@ impl AppController {
             ebpp_client_url,
             clwdr_nats_url,
             clwdr_rest_url,
+            commit_repo_cfg,
         } = cfg;
 
         let cdk_client = HttpClient::new(cdk_mint_url, None);
@@ -72,6 +80,15 @@ impl AppController {
         let clwdr_rest_client =
             clwdr_rest_url.map(|url| Arc::new(clwdr_client::ClowderRestClient::new(url)));
 
+        let commit_repo = persistence::surreal::DBCommitments::new(commit_repo_cfg)
+            .await
+            .expect("failed to init commitment repo");
+        let dummy = signer::DummySigner::default();
+        let commit_srv = Arc::new(commitment::Service {
+            repo: Box::new(commit_repo),
+            signer: Box::new(dummy),
+        });
+
         Ok(Self {
             cdk_client,
             keys_client,
@@ -80,6 +97,7 @@ impl AppController {
             ebpp_client,
             clwdr_stream_client,
             clwdr_rest_client,
+            commit_srv,
         })
     }
 }
@@ -119,6 +137,7 @@ pub async fn routes(app: AppController) -> Result<Router> {
         .route("/v1/swap", post(web::post_swap))
         .route("/v1/checkstate", post(web::post_check_state))
         .route("/v1/restore", post(web::post_restore))
+        .route("/v1/commitment", post(web::post_commit))
         // Clowder Endpoints
         .route("/v1/id", get(web::get_clowder_id))
         .route("/v1/path", post(web::post_clowder_path))

--- a/crates/bcr-wdc-wallet-aggregator/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/persistence/inmemory.rs
@@ -1,0 +1,90 @@
+// ----- standard library imports
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+// ----- extra library imports
+use async_trait::async_trait;
+use bitcoin::secp256k1::schnorr::Signature;
+// ----- local imports
+use crate::{commitment, error::Result, TStamp};
+
+// ----- end imports
+
+type Value = (Vec<cashu::PublicKey>, Vec<cashu::PublicKey>, TStamp);
+#[allow(dead_code)]
+#[derive(Clone, Default)]
+pub struct InMemoryCommitmentMap {
+    commitments: Arc<RwLock<HashMap<Signature, Value>>>,
+}
+
+#[async_trait]
+impl commitment::Repository for InMemoryCommitmentMap {
+    async fn clean_expired(&self, now: TStamp) -> Result<()> {
+        let mut commitments = self.commitments.write().unwrap();
+        commitments.retain(|_, (_, _, expiration)| *expiration > now);
+        Ok(())
+    }
+
+    async fn check_committed_inputs(&self, ys: &[cashu::PublicKey]) -> Result<bool> {
+        let commitments = self.commitments.read().unwrap();
+        for (_, (inputs, _, _)) in commitments.iter() {
+            for y in ys {
+                if inputs.contains(y) {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    async fn check_committed_outputs(&self, secrets: &[cashu::PublicKey]) -> Result<bool> {
+        let commitments = self.commitments.read().unwrap();
+        for (_, (_, outputs, _)) in commitments.iter() {
+            for secret in secrets {
+                if outputs.contains(secret) {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    async fn store(
+        &self,
+        mut inputs: Vec<cashu::PublicKey>,
+        mut outputs: Vec<cashu::PublicKey>,
+        expiration: TStamp,
+        signature: Signature,
+    ) -> Result<()> {
+        let mut commitments = self.commitments.write().unwrap();
+        inputs.sort();
+        outputs.sort();
+        commitments.insert(signature, (inputs, outputs, expiration));
+        Ok(())
+    }
+
+    async fn find(
+        &self,
+        inputs: &[cashu::PublicKey],
+        outputs: &[cashu::PublicKey],
+    ) -> Result<Option<Signature>> {
+        let mut inputs = inputs.to_vec();
+        inputs.sort();
+        let mut outputs = outputs.to_vec();
+        outputs.sort();
+        let commitments = self.commitments.read().unwrap();
+        for (signature, (committed_inputs, committed_outputs, _)) in commitments.iter() {
+            if *committed_inputs == inputs && *committed_outputs == outputs {
+                return Ok(Some(*signature));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn delete(&self, commitment: Signature) -> Result<()> {
+        let mut commitments = self.commitments.write().unwrap();
+        commitments.remove(&commitment);
+        Ok(())
+    }
+}

--- a/crates/bcr-wdc-wallet-aggregator/src/persistence/mod.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/persistence/mod.rs
@@ -1,0 +1,7 @@
+// ----- standard library imports
+// ----- extra library imports
+// ----- local modules
+pub mod inmemory;
+pub mod surreal;
+
+// ----- end imports

--- a/crates/bcr-wdc-wallet-aggregator/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/persistence/surreal.rs
@@ -1,0 +1,267 @@
+// ----- standard library imports
+use std::str::FromStr;
+// ----- extra library imports
+use anyhow::anyhow;
+use async_trait::async_trait;
+use bitcoin::secp256k1::schnorr::Signature;
+use surrealdb::{engine::any::Any, RecordId, Result as SurrealResult, Surreal};
+// ----- local imports
+use crate::{
+    commitment,
+    error::{Error, Result},
+    TStamp,
+};
+
+// ----- end imports
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct CommitmentDBEntry {
+    id: RecordId,
+    inputs: Vec<cashu::PublicKey>,
+    outputs: Vec<cashu::PublicKey>,
+    expiration: TStamp,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct DBCommitmentsConnectionConfig {
+    pub connection: String,
+    pub namespace: String,
+    pub database: String,
+    pub table: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DBCommitments {
+    db: Surreal<Any>,
+    table: String,
+}
+
+impl DBCommitments {
+    pub async fn new(cfg: DBCommitmentsConnectionConfig) -> SurrealResult<Self> {
+        let db_connection = Surreal::<Any>::init();
+        db_connection.connect(cfg.connection).await?;
+        db_connection.use_ns(cfg.namespace).await?;
+        db_connection.use_db(cfg.database).await?;
+        Ok(Self {
+            db: db_connection,
+            table: cfg.table,
+        })
+    }
+}
+
+#[async_trait]
+impl commitment::Repository for DBCommitments {
+    async fn clean_expired(&self, now: TStamp) -> Result<()> {
+        self.db
+            .query("DELETE FROM type::table($table) WHERE expiration < $now")
+            .bind(("table", self.table.clone()))
+            .bind(("now", now))
+            .await
+            .map_err(|e| Error::DB(anyhow!("SurrealDB error: {}", e)))?;
+        Ok(())
+    }
+
+    async fn check_committed_inputs(&self, ys: &[cashu::PublicKey]) -> Result<bool> {
+        let commitment: Option<CommitmentDBEntry> = self
+            .db
+            .query("SELECT * FROM type::table($table) WHERE array::is_empty(array::intersect(inputs, $ys)) = false LIMIT 1")
+            .bind(("table", self.table.clone()))
+            .bind(("ys", ys.to_vec()))
+            .await
+            .map_err(|e| Error::DB(anyhow!("SurrealDB error: {}", e)))?
+            .take(0)
+            .map_err(|e| Error::DB(anyhow!("SurrealDB error: {}", e)))?;
+        Ok(commitment.is_some())
+    }
+    async fn check_committed_outputs(&self, secrets: &[cashu::PublicKey]) -> Result<bool> {
+        let commitment: Option<CommitmentDBEntry> = self
+            .db
+            .query("SELECT * FROM type::table($table) WHERE array::is_empty(array::intersect(outputs, $secrets)) = false LIMIT 1")
+            .bind(("table", self.table.clone()))
+            .bind(("secrets", secrets.to_vec()))
+            .await
+            .map_err(|e| Error::DB(anyhow!("SurrealDB error: {}", e)))?
+            .take(0)
+            .map_err(|e| Error::DB(anyhow!("SurrealDB error: {}", e)))?;
+        Ok(commitment.is_some())
+    }
+
+    async fn store(
+        &self,
+        inputs: Vec<cashu::PublicKey>,
+        outputs: Vec<cashu::PublicKey>,
+        expiration: TStamp,
+        signature: Signature,
+    ) -> Result<()> {
+        let rid = RecordId::from_table_key(&self.table, signature.to_string());
+        let entry = CommitmentDBEntry {
+            id: rid.clone(),
+            inputs,
+            outputs,
+            expiration,
+        };
+        let _: Option<CommitmentDBEntry> =
+            self.db.insert(rid).content(entry).await.map_err(|e| {
+                Error::DB(anyhow!("SurrealDB error while storing commitment: {}", e))
+            })?;
+        Ok(())
+    }
+
+    async fn find(
+        &self,
+        inputs: &[cashu::PublicKey],
+        outputs: &[cashu::PublicKey],
+    ) -> Result<Option<Signature>> {
+        let commitment: Option<CommitmentDBEntry> = self
+            .db
+            .query(
+                "SELECT * FROM type::table($table)
+    WHERE 
+        array::is_empty(array::difference(inputs, $inputs)) 
+    AND 
+        array::is_empty(array::difference(outputs, $outputs))
+    LIMIT 1",
+            )
+            .bind(("table", self.table.clone()))
+            .bind(("inputs", inputs.to_vec()))
+            .bind(("outputs", outputs.to_vec()))
+            .await
+            .map_err(|e| Error::DB(anyhow!("SurrealDB error: {}", e)))?
+            .take(0)
+            .map_err(|e| Error::DB(anyhow!("SurrealDB error: {}", e)))?;
+        let Some(entry) = commitment else {
+            return Ok(None);
+        };
+        let key = entry.id.key().to_string();
+        let commitment = Signature::from_str(&key).expect("signature from recordId");
+        Ok(Some(commitment))
+    }
+
+    async fn delete(&self, commitment: Signature) -> Result<()> {
+        let rid = RecordId::from_table_key(&self.table, commitment.to_string());
+        let _: Option<CommitmentDBEntry> =
+            self.db.delete(rid).await.map_err(|e| {
+                Error::DB(anyhow!("SurrealDB error while deleting commitment: {}", e))
+            })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::{key::rand, secp256k1 as secp};
+    use commitment::Repository;
+    use rand::Rng;
+
+    async fn init_mem_db() -> DBCommitments {
+        let sdb = Surreal::<Any>::init();
+        sdb.connect("mem://").await.unwrap();
+        sdb.use_ns("test").await.unwrap();
+        sdb.use_db("test").await.unwrap();
+        DBCommitments {
+            db: sdb,
+            table: String::from("test"),
+        }
+    }
+
+    fn random_cdk_pks(sz: usize) -> Vec<cashu::PublicKey> {
+        std::iter::repeat_with(|| {
+            let pk = secp::generate_keypair(&mut rand::thread_rng()).1;
+            cashu::PublicKey::from(pk)
+        })
+        .take(sz)
+        .collect()
+    }
+
+    fn random_signature() -> Signature {
+        let mut sl = [0; secp::constants::SCHNORR_SIGNATURE_SIZE];
+        rand::thread_rng().fill(&mut sl[..]);
+        Signature::from_slice(&sl).unwrap()
+    }
+
+    #[tokio::test]
+    async fn store() {
+        let db = init_mem_db().await;
+        let inputs = random_cdk_pks(5);
+        let outputs = random_cdk_pks(3);
+        let tstamp = TStamp::from_timestamp(100000, 0).unwrap();
+        let signature = random_signature();
+        db.store(inputs, outputs, tstamp, signature).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_committed_inputs() {
+        let db = init_mem_db().await;
+        let inputs = random_cdk_pks(5);
+        let outputs = random_cdk_pks(3);
+        let tstamp = TStamp::from_timestamp(100000, 0).unwrap();
+        let signature = random_signature();
+        db.store(inputs.clone(), outputs.clone(), tstamp, signature)
+            .await
+            .unwrap();
+
+        let mut tester = random_cdk_pks(2);
+        let result = db.check_committed_inputs(&tester).await;
+        assert!(!result.unwrap());
+        tester.push(inputs[0]);
+        let result = db.check_committed_inputs(&tester).await;
+        assert!(result.unwrap());
+        let result = db.check_committed_inputs(&inputs).await;
+        assert!(result.unwrap());
+        let result = db.check_committed_inputs(&outputs).await;
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn check_committed_outputs() {
+        let db = init_mem_db().await;
+        let inputs = random_cdk_pks(5);
+        let outputs = random_cdk_pks(3);
+        let tstamp = TStamp::from_timestamp(100000, 0).unwrap();
+        let signature = random_signature();
+        db.store(inputs.clone(), outputs.clone(), tstamp, signature)
+            .await
+            .unwrap();
+
+        let mut tester = random_cdk_pks(2);
+        let result = db.check_committed_outputs(&tester).await;
+        assert!(!result.unwrap());
+        tester.push(outputs[0]);
+        let result = db.check_committed_outputs(&tester).await;
+        assert!(result.unwrap());
+        let result = db.check_committed_outputs(&outputs).await;
+        assert!(result.unwrap());
+        let result = db.check_committed_outputs(&inputs).await;
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn search() {
+        let db = init_mem_db().await;
+        let inputs = random_cdk_pks(5);
+        let outputs = random_cdk_pks(3);
+        let tstamp = TStamp::from_timestamp(100000, 0).unwrap();
+        let signature = random_signature();
+        db.store(inputs.clone(), outputs.clone(), tstamp, signature)
+            .await
+            .unwrap();
+
+        let tester = random_cdk_pks(2);
+        let result = db.find(&tester, &outputs).await.unwrap();
+        assert!(result.is_none());
+        let result = db.find(&inputs, &tester).await.unwrap();
+        assert!(result.is_none());
+        let mut tester = random_cdk_pks(4);
+        tester.push(inputs[0]);
+        let result = db.find(&tester, &outputs).await.unwrap();
+        assert!(result.is_none());
+        let mut tester = random_cdk_pks(2);
+        tester.push(outputs[0]);
+        let result = db.find(&inputs, &tester).await.unwrap();
+        assert!(result.is_none());
+        let result = db.find(&inputs, &outputs).await.unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), signature);
+    }
+}

--- a/crates/bcr-wdc-wallet-aggregator/src/signer.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/signer.rs
@@ -1,0 +1,22 @@
+// ----- standard library imports
+// ----- extra library imports
+use async_trait::async_trait;
+// ----- local imports
+use crate::{
+    commitment,
+    error::{Error, Result},
+};
+
+// ----- end imports
+
+#[derive(Default)]
+pub struct DummySigner {}
+
+#[async_trait]
+impl commitment::Signer for DummySigner {
+    async fn sign(&self, _content: &[u8]) -> Result<bitcoin::secp256k1::schnorr::Signature> {
+        Err(Error::NotYet(
+            "DummySigner does not implement signing".to_string(),
+        ))
+    }
+}

--- a/crates/bcr-wdc-wallet-aggregator/src/web.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/web.rs
@@ -4,10 +4,8 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use axum::extract::{Json, Path, State};
 use bcr_common::client::keys::{Client as KeysClient, Error as KeysError};
-use cashu::{
-    nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut03 as cdk03, nut06 as cdk06, nut07 as cdk07,
-    nut09 as cdk09, MintVersion,
-};
+use bcr_common::wire::swap as wire_swap;
+use cashu::MintVersion;
 use cdk::wallet::MintConnector;
 use clwdr_client::model::{ExchangeRequest, ExchangeResponse};
 use futures::future::JoinAll;
@@ -35,7 +33,7 @@ pub async fn health() -> Result<&'static str> {
         (status = 200, description = "Successful response", content_type = "application/json"),
     )
 )]
-pub async fn get_mint_info(State(ctrl): State<AppController>) -> Result<Json<cdk06::MintInfo>> {
+pub async fn get_mint_info(State(ctrl): State<AppController>) -> Result<Json<cashu::MintInfo>> {
     tracing::debug!("Requested /v1/info");
     let network = ctrl.ebpp_client.network().await?;
     let info = ctrl.cdk_client.get_mint_info().await?;
@@ -81,13 +79,13 @@ cdk-mintd = {cdk_mintd}"#,
         (status = 200, description = "Successful response", content_type = "application/json"),
     )
 )]
-pub async fn get_mint_keys(State(ctrl): State<AppController>) -> Result<Json<cdk01::KeysResponse>> {
+pub async fn get_mint_keys(State(ctrl): State<AppController>) -> Result<Json<cashu::KeysResponse>> {
     tracing::debug!("Requested /v1/keys");
 
     let mut keys = ctrl.cdk_client.get_mint_keys().await?;
     let mut bcr_keys = ctrl.keys_client.list_keys().await.unwrap_or_default();
     keys.append(&mut bcr_keys);
-    let response = cdk01::KeysResponse { keysets: keys };
+    let response = cashu::KeysResponse { keysets: keys };
     Ok(Json(response))
 }
 
@@ -100,7 +98,7 @@ pub async fn get_mint_keys(State(ctrl): State<AppController>) -> Result<Json<cdk
 )]
 pub async fn get_mint_keysets(
     State(ctrl): State<AppController>,
-) -> Result<Json<cdk02::KeysetResponse>> {
+) -> Result<Json<cashu::KeysetResponse>> {
     tracing::debug!("Requested /v1/keysets");
 
     let mut infos = ctrl.cdk_client.get_mint_keysets().await?;
@@ -117,7 +115,7 @@ pub async fn get_mint_keysets(
     get,
     path = "/v1/keys/{kid}",
     params(
-        ("kid" = cdk02::Id, Path, description = "The keyset id")
+        ("kid" = cashu::Id, Path, description = "The keyset id")
     ),
     responses (
         (status = 200, description = "Successful response", content_type = "application/json"),
@@ -126,19 +124,19 @@ pub async fn get_mint_keysets(
 )]
 pub async fn get_mint_keyset(
     State(ctrl): State<AppController>,
-    Path(kid): Path<cdk02::Id>,
-) -> Result<Json<cdk01::KeysResponse>> {
+    Path(kid): Path<cashu::Id>,
+) -> Result<Json<cashu::KeysResponse>> {
     tracing::debug!("Requested /v1/keys/{}", kid);
 
     let bcr_response = ctrl.keys_client.keys(kid).await;
     if let Ok(keys) = bcr_response {
-        let response = cdk01::KeysResponse {
+        let response = cashu::KeysResponse {
             keysets: vec![keys],
         };
         return Ok(Json(response));
     }
     let keys = ctrl.cdk_client.get_mint_keyset(kid).await?;
-    let response = cdk01::KeysResponse {
+    let response = cashu::KeysResponse {
         keysets: vec![keys],
     };
     Ok(Json(response))
@@ -148,7 +146,7 @@ pub async fn get_mint_keyset(
     get,
     path = "/v1/keysets/{kid}",
     params(
-        ("kid" = cdk02::Id, Path, description = "The keyset id")
+        ("kid" = cashu::Id, Path, description = "The keyset id")
     ),
     responses (
         (status = 200, description = "Successful response", content_type = "application/json"),
@@ -157,8 +155,8 @@ pub async fn get_mint_keyset(
 )]
 pub async fn get_keyset_info(
     State(ctrl): State<AppController>,
-    Path(kid): Path<cdk02::Id>,
-) -> Result<Json<cdk02::KeySetInfo>> {
+    Path(kid): Path<cashu::Id>,
+) -> Result<Json<cashu::KeySetInfo>> {
     tracing::debug!("Requested /v1/keysets/{}", kid);
 
     if let Ok(info) = ctrl.keys_client.keyset_info(kid).await {
@@ -173,7 +171,7 @@ pub async fn get_keyset_info(
         }
         // if there are no keys, then it doesn't exist, otherwise its inactive
         let keys = ctrl.cdk_client.get_mint_keyset(kid).await?;
-        Ok(Json(cdk02::KeySetInfo {
+        Ok(Json(cashu::KeySetInfo {
             id: kid,
             active: false,
             unit: keys.unit,
@@ -194,10 +192,17 @@ pub async fn get_keyset_info(
 )]
 pub async fn post_swap(
     State(ctrl): State<AppController>,
-    Json(request): Json<cdk03::SwapRequest>,
-) -> Result<Json<cdk03::SwapResponse>> {
+    Json(request): Json<cashu::SwapRequest>,
+) -> Result<Json<cashu::SwapResponse>> {
     tracing::debug!("Requested /v1/swap");
 
+    let now = chrono::Utc::now();
+    let is_ok = ctrl.commit_srv.check_swap(now, request.clone()).await?;
+    if !is_ok {
+        return Err(Error::InvalidInput(String::from(
+            "Swap request rejected due to commitment",
+        )));
+    }
     let swap_type = determine_swap_type(
         &ctrl.keys_client,
         request.inputs().as_slice(),
@@ -228,7 +233,7 @@ pub async fn post_swap(
         clwdr_client.mint_swap(proofs, signatures.clone()).await?;
     }
 
-    let response = cdk03::SwapResponse { signatures };
+    let response = cashu::SwapResponse { signatures };
 
     Ok(Json(response))
 }
@@ -242,8 +247,8 @@ pub async fn post_swap(
 )]
 pub async fn post_check_state(
     State(ctrl): State<AppController>,
-    Json(request): Json<cdk07::CheckStateRequest>,
-) -> Result<Json<cdk07::CheckStateResponse>> {
+    Json(request): Json<cashu::CheckStateRequest>,
+) -> Result<Json<cashu::CheckStateResponse>> {
     tracing::debug!("Requested /v1/checkstate");
 
     let n = request.ys.len();
@@ -269,7 +274,7 @@ pub async fn post_check_state(
             merged.push(credit.clone());
         }
     }
-    Ok(Json(cdk07::CheckStateResponse { states: merged }))
+    Ok(Json(cashu::CheckStateResponse { states: merged }))
 }
 
 #[utoipa::path(
@@ -281,8 +286,8 @@ pub async fn post_check_state(
 )]
 pub async fn post_restore(
     State(ctrl): State<AppController>,
-    Json(request): Json<cdk09::RestoreRequest>,
-) -> Result<Json<cdk09::RestoreResponse>> {
+    Json(request): Json<cashu::RestoreRequest>,
+) -> Result<Json<cashu::RestoreResponse>> {
     tracing::debug!("Requested /v1/restore");
 
     let outputs = request.outputs.clone();
@@ -294,7 +299,7 @@ pub async fn post_restore(
         .zip(restore_resp.signatures.into_iter())
         .collect::<Vec<_>>();
 
-    let mut response = cdk09::RestoreResponse {
+    let mut response = cashu::RestoreResponse {
         outputs: Default::default(),
         signatures: Default::default(),
         promises: Default::default(),
@@ -367,6 +372,25 @@ pub async fn post_exchange(
     todo!("Intermint Exchange not yet implemented");
 }
 
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl, request))]
+pub async fn post_commit(
+    State(ctrl): State<AppController>,
+    Json(request): Json<wire_swap::CommitmentRequest>,
+) -> Result<Json<wire_swap::CommitmentResponse>> {
+    let now = chrono::Utc::now();
+    let response = ctrl
+        .commit_srv
+        .commit(
+            now,
+            request,
+            &ctrl.swap_client,
+            &ctrl.keys_client,
+            &ctrl.cdk_client,
+        )
+        .await?;
+    Ok(Json(response))
+}
+
 #[allow(clippy::enum_variant_names)]
 enum SwapType {
     CrSat2CrSat,
@@ -387,23 +411,23 @@ enum SwapType {
 trait KeyClientT {
     async fn keyset_info(
         &self,
-        keyset_id: cdk02::Id,
-    ) -> std::result::Result<cdk02::KeySetInfo, KeysError>;
+        keyset_id: cashu::Id,
+    ) -> std::result::Result<cashu::KeySetInfo, KeysError>;
 }
 #[async_trait]
 impl KeyClientT for KeysClient {
     async fn keyset_info(
         &self,
-        keyset_id: cdk02::Id,
-    ) -> std::result::Result<cdk02::KeySetInfo, KeysError> {
+        keyset_id: cashu::Id,
+    ) -> std::result::Result<cashu::KeySetInfo, KeysError> {
         self.keyset_info(keyset_id).await
     }
 }
 
 async fn determine_swap_type(
     key_cl: &impl KeyClientT,
-    inputs: &[cdk00::Proof],
-    outputs: &[cdk00::BlindedMessage],
+    inputs: &[cashu::Proof],
+    outputs: &[cashu::BlindedMessage],
 ) -> Result<SwapType> {
     let input_kids = inputs.iter().map(|p| p.keyset_id).collect::<HashSet<_>>();
     let input_responses: JoinAll<_> = input_kids
@@ -448,7 +472,7 @@ mod tests {
             signatures_test::generate_proofs(&crsat_keyset, &amounts[1..])[0].clone(),
             signatures_test::generate_proofs(&sat_keyset, &amounts[..1])[0].clone(),
         ];
-        let outputs: Vec<cdk00::BlindedMessage> =
+        let outputs: Vec<cashu::BlindedMessage> =
             signatures_test::generate_blinds(sat_keyset.id, &amounts)
                 .into_iter()
                 .map(|(b, _, _)| b)
@@ -478,7 +502,7 @@ mod tests {
         let (info, keyset) = keys_test::generate_random_keyset();
         let amounts = [cashu::Amount::from(4u64), cashu::Amount::from(8u64)];
         let inputs = signatures_test::generate_proofs(&keyset, &amounts);
-        let outputs: Vec<cdk00::BlindedMessage> =
+        let outputs: Vec<cashu::BlindedMessage> =
             signatures_test::generate_blinds(keyset.id, &amounts)
                 .into_iter()
                 .map(|(b, _, _)| b)
@@ -500,7 +524,7 @@ mod tests {
         let (crsat_info, crsat_keyset) = keys_test::generate_random_keyset();
         let amounts = [cashu::Amount::from(4u64), cashu::Amount::from(4u64)];
         let inputs = signatures_test::generate_proofs(&crsat_keyset, &amounts);
-        let outputs: Vec<cdk00::BlindedMessage> =
+        let outputs: Vec<cashu::BlindedMessage> =
             signatures_test::generate_blinds(sat_keyset.id, &amounts)
                 .into_iter()
                 .map(|(b, _, _)| b)


### PR DESCRIPTION
same-mint swap protocol allows wallets to ask for a commitment from the mint before doing the actual swap request.
This way if the mint acts maliciously, wallets can recourse and protest to clowder betas nodes using the commitment as proof.