### PR TITLE
Add separator to ebill service for nested config via env

### DIFF
--- a/crates/bcr-wdc-ebill-service/src/main.rs
+++ b/crates/bcr-wdc-ebill-service/src/main.rs
@@ -28,7 +28,7 @@ async fn main() {
     // parse and create config
     let settings = config::Config::builder()
         .add_source(config::File::with_name("config.toml"))
-        .add_source(config::Environment::with_prefix("EBILL"))
+        .add_source(config::Environment::with_prefix("EBILL").separator("__"))
         .build()
         .expect("Failed to build ebill config");
 


### PR DESCRIPTION
### **User description**
* @cleot suggested it would be useful to have the opportunity to set nested config fields via env in `ebill-service` as well


___

### **PR Type**
Enhancement


___

### **Description**
- Add separator to environment variable parsing for nested config

- Enable setting nested configuration fields via environment variables

- Use double underscore separator for nested config path traversal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  env["Environment Variables<br/>with __ separator"]
  config["Config Builder"]
  nested["Nested Config<br/>Fields"]
  env -- "separator(__)" --> config
  config --> nested
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Add nested config separator to environment parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-ebill-service/src/main.rs

<ul><li>Added <code>separator("__")</code> to environment variable configuration builder<br> <li> Enables nested config field access via environment variables using <br>double underscore notation<br> <li> Maintains existing config file and environment variable loading <br>behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/328/files#diff-c5c3ed2056e794256111141fb0aae3454eadb997ce4f32672f76e404d8c19c9e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

