### PR TITLE
[bcr-wdc-treasury-service] add endpoint to generate free money

### DIFF
--- a/crates/bcr-wdc-ebpp/src/service.rs
+++ b/crates/bcr-wdc-ebpp/src/service.rs
@@ -204,6 +204,14 @@ impl MintPayment for Service {
                 let recipient = self.onchain.add_descriptor(&output).await?;
                 payment::PaymentType::EBill(recipient)
             }
+            ParsedDescription::Dev => {
+                let idx: u32 = rand::random();
+                return Ok(CreateIncomingPaymentResponse {
+                    request_lookup_id: PaymentIdentifier::Label(format!("dev{idx}")),
+                    request: String::new(),
+                    expiry: None,
+                });
+            }
             ParsedDescription::None => {
                 let recipient = self
                     .onchain
@@ -387,6 +395,17 @@ impl MintPayment for Service {
     ) -> PaymentResult<Vec<WaitPaymentResponse>> {
         let _span = tracing::debug_span!("check_incoming_payment_status");
 
+        if let PaymentIdentifier::Label(label) = payment_identifier {
+            if label.starts_with("dev") {
+                return Ok(vec![WaitPaymentResponse {
+                    payment_identifier: payment_identifier.clone(),
+                    payment_amount: cashu::Amount::from(1000),
+                    unit: CurrencyUnit::Sat,
+                    payment_id: label.to_string(),
+                }]);
+            }
+        }
+
         let mut response = Vec::new();
         let foreign = self.payrepo.check_foreign_reqid(payment_identifier).await?;
         if let Some(foreign) = foreign {
@@ -513,6 +532,7 @@ fn parse_to_bip21_uri(input: &str, network: btc::Network) -> Result<bip21::Uri<'
 }
 
 enum ParsedDescription {
+    Dev,
     EbillRequestToPay(wire_signatures::SignedRequestToMintFromEBillDesc),
     ForeignECash(web_exchange::RequestToMintFromForeigneCash),
     None,
@@ -527,6 +547,8 @@ impl ParsedDescription {
             serde_json::from_str::<web_exchange::RequestToMintFromForeigneCash>(input)
         {
             Self::ForeignECash(foreign_ecash_request)
+        } else if input == "it's me, Mario" {
+            Self::Dev
         } else {
             Self::None
         }

--- a/crates/bcr-wdc-treasury-service/Cargo.toml
+++ b/crates/bcr-wdc-treasury-service/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 axum = {workspace = true, features = ["macros"]}
 bcr-common = {workspace = true, features = ["authorized"]}
 bcr-ebill-core = {workspace = true}
+bcr-wallet-lib = {git = "https://github.com/BitcreditProtocol/Wallet-Core.git", branch = "master"}
 bcr-wdc-treasury-client = {workspace = true}
 bcr-wdc-utils = {workspace = true}
 bcr-wdc-webapi = { workspace = true}

--- a/crates/bcr-wdc-treasury-service/src/devmode.rs
+++ b/crates/bcr-wdc-treasury-service/src/devmode.rs
@@ -1,0 +1,129 @@
+// ----- standard library imports
+use std::sync::Arc;
+// ----- extra library imports
+use axum::extract::{Json, State};
+use bcr_common::{
+    client::keys::{Client as KeysClient, Result as KeysResult},
+    core::signature::unblind_ecash_signature,
+};
+use bcr_wallet_lib::wallet::Token;
+use cdk::wallet::{HttpClient, MintConnector};
+use futures::future::JoinAll;
+// ----- local imports
+use crate::error::Result;
+
+// ----- end imports
+
+pub struct Service {
+    pub crkeys: KeysClient,
+    pub dbmint: HttpClient,
+}
+
+#[derive(serde::Deserialize)]
+pub enum IssueType {
+    KeysetId(cashu::Id),
+    Currency(cashu::CurrencyUnit),
+}
+
+#[derive(serde::Deserialize)]
+pub struct MintRequest {
+    pub amount: cashu::Amount,
+    pub issue: IssueType,
+    pub whoami: cashu::MintUrl,
+}
+
+pub async fn free_money(
+    State(cntrl): State<Arc<Service>>,
+    Json(request): Json<MintRequest>,
+) -> Result<Json<String>> {
+    tracing::debug!("Free money request");
+
+    let cashu::KeysetResponse { keysets } = cntrl.dbmint.get_mint_keysets().await?;
+    let kinfos = cntrl.crkeys.list_keyset_info().await?;
+
+    let token = match request.issue {
+        IssueType::KeysetId(kid) => {
+            if let Some(kinfo) = keysets.iter().find(|ks| ks.id == kid && ks.active) {
+                let keys = cntrl.dbmint.get_mint_keyset(kinfo.id).await?;
+                mint_debit(&cntrl.dbmint, request.amount, keys, request.whoami).await?
+            } else if let Some(kinfo) = kinfos.iter().find(|ks| ks.id == kid && ks.active) {
+                let keys = cntrl.crkeys.keys(kinfo.id).await?;
+                mint_credit(&cntrl.crkeys, request.amount, keys, request.whoami).await?
+            } else {
+                return Err(crate::error::Error::InvalidInput(format!(
+                    "Unknown/Invalid keyset: {kid}"
+                )));
+            }
+        }
+        IssueType::Currency(unit) => {
+            if let Some(kinfo) = keysets.iter().find(|k| k.active && k.unit == unit) {
+                let keys = cntrl.dbmint.get_mint_keyset(kinfo.id).await?;
+                mint_debit(&cntrl.dbmint, request.amount, keys, request.whoami).await?
+            } else if let Some(kinfo) = kinfos.iter().find(|k| k.active && k.unit == unit) {
+                let keys = cntrl.crkeys.keys(kinfo.id).await?;
+                mint_credit(&cntrl.crkeys, request.amount, keys, request.whoami).await?
+            } else {
+                return Err(crate::error::Error::InvalidInput(format!(
+                    "Unsupported currency unit: {unit}",
+                )));
+            }
+        }
+    };
+    Ok(Json(token.to_string()))
+}
+
+async fn mint_credit(
+    client: &KeysClient,
+    amount: cashu::Amount,
+    keys: cashu::KeySet,
+    mint_url: cashu::MintUrl,
+) -> Result<Token> {
+    let premints =
+        cashu::PreMintSecrets::random(keys.id, amount, &cashu::amount::SplitTarget::None)?;
+    let blinded_messages = premints.blinded_messages();
+    let joined: JoinAll<_> = blinded_messages
+        .iter()
+        .map(|blind| client.sign(blind))
+        .collect();
+    let signatures: Vec<cashu::BlindSignature> =
+        joined.await.into_iter().collect::<KeysResult<_>>()?;
+    let mut proofs = Vec::with_capacity(signatures.len());
+    for (sig, pre) in signatures.into_iter().zip(premints.into_iter()) {
+        let proof = unblind_ecash_signature(&keys, pre, sig)?;
+        proofs.push(proof);
+    }
+    Ok(Token::new_bitcr(mint_url, proofs, None, keys.unit.clone()))
+}
+
+async fn mint_debit(
+    client: &HttpClient,
+    amount: cashu::Amount,
+    keys: cashu::KeySet,
+    mint_url: cashu::MintUrl,
+) -> Result<Token> {
+    let kp = secp256k1::Keypair::new(secp256k1::global::SECP256K1, &mut rand::thread_rng());
+    let pubkey = cashu::PublicKey::from(kp.public_key());
+    let request = cashu::MintQuoteBolt11Request {
+        amount,
+        unit: keys.unit.clone(),
+        description: Some(String::from("it's me, Mario")),
+        pubkey: Some(pubkey),
+    };
+    let quote = client.post_mint_quote(request).await?;
+    let premints =
+        cashu::PreMintSecrets::random(keys.id, amount, &cashu::amount::SplitTarget::None)?;
+    let mut request = cashu::MintRequest {
+        quote: quote.quote,
+        outputs: premints.blinded_messages(),
+        signature: None,
+    };
+    let sk = cashu::SecretKey::from(kp.secret_key());
+    request.sign(sk)?;
+    let response = client.post_mint(request).await?;
+    let mut proofs = Vec::with_capacity(response.signatures.len());
+    for (sig, pre) in response.signatures.into_iter().zip(premints.into_iter()) {
+        let proof = unblind_ecash_signature(&keys, pre, sig)?;
+        proofs.push(proof);
+    }
+    Ok(Token::new_cashu(mint_url, proofs, None, keys.unit.clone()))
+}

--- a/crates/bcr-wdc-treasury-service/src/error.rs
+++ b/crates/bcr-wdc-treasury-service/src/error.rs
@@ -17,6 +17,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 pub enum Error {
     // external errors wrappers
+    #[error("bcr_common::signature::ecash {0}")]
+    BcrEcash(#[from] bcr_common::core::signature::ECashSignatureError),
     #[error("bcr_common::signature::borsh {0}")]
     BcrBorshSignature(#[from] bcr_common::core::signature::BorshMsgSignatureError),
     #[error("borsh {0}")]
@@ -132,6 +134,7 @@ impl axum::response::IntoResponse for Error {
             Error::Unblind(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::Borsh(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::BcrBorshSignature(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::BcrEcash(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
         };
         resp.into_response()
     }

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -13,6 +13,7 @@ use clwdr_client::SignatoryNatsClient;
 mod admin;
 mod credit;
 mod debit;
+mod devmode;
 mod error;
 mod foreign;
 mod persistence;
@@ -65,6 +66,7 @@ pub struct AppController {
     crsat: Arc<ProdCrsatService>,
     sat: Arc<ProdSatService>,
     signer: Arc<SignatoryNatsClient>,
+    dev: Arc<devmode::Service>,
 }
 
 impl AppController {
@@ -122,7 +124,7 @@ impl AppController {
                 .await
                 .expect("Failed to create crsat offline repository"),
         );
-        let crsatkeys = ProdCrsatKeysClient::new(credit_keys_url);
+        let crsatkeys = ProdCrsatKeysClient::new(credit_keys_url.clone());
         let clowder = Arc::new(ProdClowderClient::new(clowder_url));
         let factory = Arc::new(foreign::clients::MintClientFactory {});
         let interval = std::time::Duration::from_secs(monitor_interval_sec);
@@ -154,7 +156,7 @@ impl AppController {
                 .await
                 .expect("Failed to create sat offline repository"),
         );
-        let satkeys = ProdSatKeysClient::new(cdk_mintd_url, signing_keys);
+        let satkeys = ProdSatKeysClient::new(cdk_mintd_url.clone(), signing_keys);
         let settler = {
             let online: Arc<dyn foreign::OnlineRepository> = satonlinerepo.clone();
             let offline: Arc<dyn foreign::OfflineRepository> = satofflinerepo.clone();
@@ -177,12 +179,17 @@ impl AppController {
             .await
             .expect("Failed to create signer");
 
+        let dev = devmode::Service {
+            crkeys: bcr_common::client::keys::Client::new(credit_keys_url),
+            dbmint: cdk::wallet::HttpClient::new(cdk_mintd_url),
+        };
         Self {
             credit,
             debit,
             crsat,
             sat,
             signer: Arc::new(signer),
+            dev: Arc::new(dev),
         }
     }
 
@@ -207,6 +214,7 @@ pub fn routes(app: AppController) -> Router {
             TreasuryClient::CRSATEXCHANGEOFFLINE_EP_V1,
             post(web::crsat_offline_exchange),
         )
+        .route("/v1/free_money", post(devmode::free_money))
         .route(
             TreasuryClient::SATEXCHANGEOFFLINE_EP_V1,
             post(web::sat_offline_exchange),

--- a/docker/bff-wallet-service/nginx.conf
+++ b/docker/bff-wallet-service/nginx.conf
@@ -70,7 +70,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        location /v1 {
+        location /v1/free_money {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
             add_header 'Access-Control-Allow-Headers' '*' always;


### PR DESCRIPTION
# IMPORTANT
#### Burn into your memory that this API should be removed before going to production

to test this:

freemoney.json
```json
{
    "amount": 1000,
    "whoami": "http://localhost:4343",
    "issue": {
        "Currency": "sat"
    }
}
```

```bash
$ curl -i -X POST -H "Content-Type: application/json" -d @freemoney.json localhost:4343/v1/free_money
```
 