### PR TITLE
[bcr-wdc-key-service] minor improvements to infos_for_expiration_date

### DIFF
--- a/crates/bcr-wdc-key-service/src/admin.rs
+++ b/crates/bcr-wdc-key-service/src/admin.rs
@@ -80,8 +80,7 @@ pub async fn get_keyset_for_date(
 ) -> Result<Json<cashu::Id>> {
     tracing::debug!("Received get_keyset_for_date request");
 
-    let tstamp = date.and_time(chrono::NaiveTime::default()).and_utc();
-    let kid = ctrl.get_keyset_id_for_date(tstamp).await?;
+    let kid = ctrl.get_keyset_id_for_date(date).await?;
     Ok(Json(kid))
 }
 

--- a/crates/bcr-wdc-key-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-key-service/src/persistence/inmemory.rs
@@ -12,7 +12,6 @@ use uuid::Uuid;
 use crate::{
     error::{Error, Result},
     service::{KeysRepository, MintOperation, SignaturesRepository},
-    TStamp,
 };
 
 // ----- end imports
@@ -66,13 +65,12 @@ impl KeysRepository for InMemoryKeyMap {
         *info = new;
         Ok(())
     }
-    async fn infos_for_expiration_date(&self, expire: TStamp) -> Result<Vec<MintKeySetInfo>> {
+    async fn infos_for_expiration_date(&self, expire: u64) -> Result<Vec<MintKeySetInfo>> {
         let rlocked = self.keys.read().unwrap();
-        let tstamp = expire.timestamp() as u64;
         let infos = rlocked
             .values()
             .filter_map(|(info, _)| {
-                if info.final_expiry.unwrap_or_default() > tstamp {
+                if info.final_expiry.unwrap_or_default() >= expire {
                     Some(info)
                 } else {
                     None

--- a/crates/bcr-wdc-key-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-key-service/src/persistence/surreal.rs
@@ -16,7 +16,6 @@ use uuid::Uuid;
 use crate::{
     error::{Error, Result},
     service::{KeysRepository, MintOperation, SignaturesRepository},
-    TStamp,
 };
 
 // ----- end imports
@@ -91,7 +90,7 @@ fn convert_to_keysdbentry(entry: KeysetEntry, table: &str) -> KeysDBEntry {
 }
 impl std::convert::From<KeysDBEntry> for KeysetEntry {
     fn from(dbk: KeysDBEntry) -> Self {
-        let KeysDBEntry { info, keys, .. } = dbk;
+        let KeysDBEntry { info, keys, id: _ } = dbk;
         let info = MintKeySetInfo::from(info);
         let mut keysmap: BTreeMap<Amount, cdk01::MintKeyPair> = BTreeMap::default();
         for (val, keypair) in keys.into_iter() {
@@ -262,15 +261,14 @@ impl KeysRepository for DBKeys {
             Err(Error::KeysetNotFound(kid))
         }
     }
-    async fn infos_for_expiration_date(&self, expire: TStamp) -> Result<Vec<MintKeySetInfo>> {
-        let tstamp = expire.timestamp();
+    async fn infos_for_expiration_date(&self, expire: u64) -> Result<Vec<MintKeySetInfo>> {
         let infos: Vec<KeysInfoDBEntry> = self
             .db
             // WARNING: https://github.com/surrealdb/surrealdb/issues/6405
             // .query("SELECT info FROM type::table($table) WHERE info.final_expiry > $tstamp ORDER BY info.final_expiry ASC")
-            .query("SELECT VALUE info FROM type::table($table) WHERE info.final_expiry >= $tstamp")
+            .query("SELECT VALUE info FROM type::table($table) WHERE info.final_expiry >= $expire")
             .bind(("table", self.keys_table.clone()))
-            .bind(("tstamp", tstamp))
+            .bind(("expire", expire))
             .await
             .map_err(|e| Error::KeysRepository(anyhow!(e)))?
             .take(0)
@@ -536,17 +534,11 @@ mod tests {
         keys1.1.final_expiry = keys1.0.final_expiry;
         db.store(keys1).await.unwrap();
 
-        let res = db
-            .infos_for_expiration_date(TStamp::from_timestamp(10, 0).unwrap())
-            .await
-            .unwrap();
+        let res = db.infos_for_expiration_date(10).await.unwrap();
         assert_eq!(res.len(), 2);
         assert_eq!(res[0].final_expiry, Some(10));
         assert_eq!(res[1].final_expiry, Some(30));
-        let res = db
-            .infos_for_expiration_date(TStamp::from_timestamp(20, 0).unwrap())
-            .await
-            .unwrap();
+        let res = db.infos_for_expiration_date(20).await.unwrap();
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].final_expiry, Some(30));
     }

--- a/crates/bcr-wdc-key-service/src/service.rs
+++ b/crates/bcr-wdc-key-service/src/service.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 use crate::{
     error::{Error, Result},
     factory::Factory,
-    TStamp,
 };
 
 // ----- end imports
@@ -35,7 +34,7 @@ pub trait KeysRepository: Send + Sync {
     async fn list_info(&self) -> Result<Vec<MintKeySetInfo>>;
     async fn list_keyset(&self) -> Result<Vec<cashu::MintKeySet>>;
     async fn update_info(&self, info: MintKeySetInfo) -> Result<()>;
-    async fn infos_for_expiration_date(&self, expire: TStamp) -> Result<Vec<MintKeySetInfo>>;
+    async fn infos_for_expiration_date(&self, expire: u64) -> Result<Vec<MintKeySetInfo>>;
     async fn store_mintop(&self, mint_operation: MintOperation) -> Result<()>;
     async fn load_mintop(&self, uid: Uuid) -> Result<MintOperation>;
     async fn list_mintops(&self, kid: cashu::Id) -> Result<Vec<MintOperation>>;
@@ -70,15 +69,20 @@ pub struct Service {
 }
 
 impl Service {
-    pub async fn get_keyset_id_for_date(&self, date: TStamp) -> Result<cashu::Id> {
-        let mut infos = self.keys.infos_for_expiration_date(date).await?;
-        let tstamp = std::cmp::max(date.timestamp() as u64, 0);
-        infos.retain(|info| info.final_expiry.unwrap_or_default() > tstamp);
-        infos.sort_by_key(|info| info.final_expiry.expect("none is filtered out"));
-        if !infos.is_empty() {
-            return Ok(infos.first().expect("infos not empty").id);
+    pub async fn get_keyset_id_for_date(&self, date: chrono::NaiveDate) -> Result<cashu::Id> {
+        let datetime = date
+            .and_hms_opt(0, 0, 0)
+            .expect("get_keyset_id_for_date with 00:00:00 time")
+            .and_utc();
+        let tstamp = std::cmp::max(datetime.timestamp(), 0) as u64;
+        let infos = self.keys.infos_for_expiration_date(tstamp).await?;
+        let info = infos
+            .iter()
+            .find(|info| info.final_expiry.unwrap_or_default() == tstamp);
+        if let Some(info) = info {
+            return Ok(info.id);
         }
-        let new_keyset = self.keygen.generate(date);
+        let new_keyset = self.keygen.generate(datetime);
         let kid = new_keyset.0.id;
         let kset = new_keyset.1.clone();
         self.keys.store(new_keyset).await?;
@@ -247,9 +251,6 @@ mod tests {
         let seed = bip39::Mnemonic::from_str("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
             .unwrap()
             .to_seed("");
-        let maturity = chrono::DateTime::parse_from_rfc3339("2029-01-01T00:00:00Z")
-            .unwrap()
-            .to_utc();
         let factory = Factory::new(&seed, DerivationPath::default());
 
         let service = TestKeysService {
@@ -258,9 +259,10 @@ mod tests {
             keygen: factory,
             clowder: Arc::new(crate::clowder::DummyClowderClient),
         };
-        let qid = Uuid::new_v4();
-        let kp = bcr_wdc_utils::keys::test_utils::generate_random_keypair();
+        let maturity = chrono::NaiveDate::from_ymd_opt(2029, 1, 1).unwrap();
         let kid = service.get_keyset_id_for_date(maturity).await.unwrap();
+        let qid = Uuid::new_v4();
+        let kp = bcr_common::core_tests::generate_random_keypair();
         service
             .new_minting_operation(qid, kid, kp.public_key().into(), amount)
             .await
@@ -333,5 +335,17 @@ mod tests {
         };
         request.sign(kp.secret_key().into()).unwrap();
         service.mint(&request).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn infos_for_expiration_date() {
+        let (service, _, _, _) = setup_test_service(cashu::Amount::from(1000)).await;
+        let mut keys = bcr_common::core_tests::generate_random_ecash_keyset();
+        let date = chrono::NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
+        keys.0.final_expiry = Some(1767139200);
+        keys.1.final_expiry = Some(1767139200);
+        service.keys.store(keys.clone()).await.unwrap();
+        let kid = service.get_keyset_id_for_date(date).await.unwrap();
+        assert_eq!(kid, keys.0.id);
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplify `infos_for_expiration_date` API by accepting `u64` timestamps instead of `TStamp` objects

- Update `get_keyset_id_for_date` to accept `NaiveDate` and handle conversion internally

- Refactor keyset lookup logic to find exact expiry match instead of filtering and sorting

- Add test coverage for `infos_for_expiration_date` functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NaiveDate input"] -->|convert to u64 timestamp| B["get_keyset_id_for_date"]
  B -->|pass u64| C["infos_for_expiration_date"]
  C -->|find exact match| D["Return keyset ID"]
  E["Remove TStamp type"] -->|simplify API| F["Direct u64 parameters"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Remove redundant timestamp conversion in admin handler</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/admin.rs

<ul><li>Simplify <code>get_keyset_for_date</code> by removing intermediate timestamp <br>conversion<br> <li> Pass <code>NaiveDate</code> directly to <code>get_keyset_id_for_date</code> instead of <br>converting to UTC datetime</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/362/files#diff-f366824ed4999514276e404ad0b38b03fbb4c1768345ebce12638f7be6bfad1f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Update in-memory repository to use u64 timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/persistence/inmemory.rs

<ul><li>Change <code>infos_for_expiration_date</code> parameter from <code>TStamp</code> to <code>u64</code><br> <li> Remove <code>TStamp</code> import<br> <li> Update filter logic to use <code>>=</code> comparison with direct u64 value instead <br>of converting timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/362/files#diff-3f12dfeeadb01ce475140bd0f334bac22948a837c7d6f5ce31a4120e1a8ef560">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>surreal.rs</strong><dd><code>Update SurrealDB repository to use u64 timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-key-service/src/persistence/surreal.rs

<ul><li>Change <code>infos_for_expiration_date</code> parameter from <code>TStamp</code> to <code>u64</code><br> <li> Remove <code>TStamp</code> import<br> <li> Update database query binding to use <code>expire</code> parameter directly instead <br>of <code>tstamp</code><br> <li> Replace pattern match <code>..</code> with explicit <code>id: _</code> in <code>KeysDBEntry</code> conversion<br> <li> Add debug print statement for expire parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/362/files#diff-ba8ade7df8f929ce375f54a312f93f59224a2beafd836727aa2108c57d32ca26">+7/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Refactor service API to use simplified timestamp parameters</code></dd></summary>
<hr>

crates/bcr-wdc-key-service/src/service.rs

<ul><li>Change <code>infos_for_expiration_date</code> trait method signature to accept <code>u64</code> <br>instead of <code>TStamp</code><br> <li> Refactor <code>get_keyset_id_for_date</code> to accept <code>NaiveDate</code> and convert to u64 <br>timestamp internally<br> <li> Simplify keyset lookup to find exact expiry match instead of filtering <br>and sorting<br> <li> Remove unused <code>maturity</code> variable from test setup<br> <li> Update test to use <code>NaiveDate</code> and correct import path for test <br>utilities<br> <li> Add new test <code>infos_for_expiration_date</code> to verify keyset retrieval by <br>expiration date</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/362/files#diff-0bf63ca2bfa682f3961784061646602648f6450798339852bae9daf95e784e52">+29/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

