### PR TITLE
[bcr-wdc-treasury-service] free money EP bug fix

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/devmode.rs
+++ b/crates/bcr-wdc-treasury-service/src/devmode.rs
@@ -121,8 +121,10 @@ async fn mint_debit(
     request.sign(sk)?;
     let response = client.post_mint(request).await?;
     let mut proofs = Vec::with_capacity(response.signatures.len());
-    for (sig, pre) in response.signatures.into_iter().zip(premints.into_iter()) {
-        let proof = unblind_ecash_signature(&keys, pre, sig)?;
+    // WARNING: due to a bug in `into_iter()` in cashu 0.13.1 we need to `iter()` and clone the secret
+    // fixed in 0.14.0
+    for (sig, pre) in response.signatures.into_iter().zip(premints.iter()) {
+        let proof = unblind_ecash_signature(&keys, pre.clone(), sig)?;
         proofs.push(proof);
     }
     Ok(Token::new_cashu(mint_url, proofs, None, keys.unit.clone()))


### PR DESCRIPTION
### **User description**
remove the need for a signed mint request to spend proofs generated by the free money endpoint


___

### **PR Type**
Bug fix


___

### **Description**
- Remove signed mint request requirement for free money endpoint

- Set pubkey to None in MintQuoteBolt11Request for devmode

- Eliminate unnecessary keypair public key generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mint_debit function"] -- "Remove pubkey generation" --> B["Set pubkey to None"]
  B -- "Simplify request" --> C["MintQuoteBolt11Request"]
  C -- "Enable unsigned minting" --> D["Free money endpoint"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devmode.rs</strong><dd><code>Remove pubkey requirement from mint quote request</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/devmode.rs

<ul><li>Removed unnecessary keypair public key generation in <code>mint_debit</code> <br>function<br> <li> Changed <code>pubkey</code> field from <code>Some(pubkey)</code> to <code>None</code> in <br><code>MintQuoteBolt11Request</code><br> <li> Eliminated the line that converted keypair public key to cashu <br>PublicKey</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/367/files#diff-53e92f0d7cc04a9eddd7a2e43745aea9da2ac93d86687ca38cb3d238586c088b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

