### PR TITLE
[bcr_common] adopt new wire::exchange types

### DIFF
--- a/crates/bcr-wdc-treasury-client/src/lib.rs
+++ b/crates/bcr-wdc-treasury-client/src/lib.rs
@@ -1,6 +1,6 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_common::wire::keys as wire_keys;
+use bcr_common::wire::{exchange as wire_exchange, keys as wire_keys};
 use bcr_wdc_webapi::{
     exchange as web_exchange, signatures as web_signatures, wallet as web_wallet,
 };
@@ -148,12 +148,12 @@ impl TreasuryClient {
             .base
             .join(Self::SATEXCHANGEONLINE_EP_V1)
             .expect("sat_exchange_online relative path");
-        let msg = web_exchange::OnlineExchangeRequest {
+        let msg = wire_exchange::OnlineExchangeRequest {
             proofs,
             exchange_path,
         };
         let request = self.cl.post(url).json(&msg);
-        let response: web_exchange::OnlineExchangeResponse = request.send().await?.json().await?;
+        let response: wire_exchange::OnlineExchangeResponse = request.send().await?.json().await?;
         Ok(response.proofs)
     }
 
@@ -167,12 +167,12 @@ impl TreasuryClient {
             .base
             .join(Self::CRSATEXCHANGEONLINE_EP_V1)
             .expect("crsat_exchange_online relative path");
-        let msg = web_exchange::OnlineExchangeRequest {
+        let msg = wire_exchange::OnlineExchangeRequest {
             proofs,
             exchange_path,
         };
         let request = self.cl.post(url).json(&msg);
-        let response: web_exchange::OnlineExchangeResponse = request.send().await?.json().await?;
+        let response: wire_exchange::OnlineExchangeResponse = request.send().await?.json().await?;
         Ok(response.proofs)
     }
 
@@ -188,19 +188,19 @@ impl TreasuryClient {
             .base
             .join(Self::SATEXCHANGEOFFLINE_EP_V1)
             .expect("sat_exchange_offline relative path");
-        let msg = web_exchange::OfflineExchangeRequest {
+        let msg = wire_exchange::OfflineExchangeRequest {
             fingerprints,
             hashes,
             wallet_pk,
         };
         let request = self.cl.post(url).json(&msg);
-        let response: web_exchange::OfflineExchangeResponse = request.send().await?.json().await?;
+        let response: wire_exchange::OfflineExchangeResponse = request.send().await?.json().await?;
         bcr_common::core::signature::schnorr_verify_b64(
             &response.content,
             &response.signature,
             &mint_pk.x_only_public_key().0,
         )?;
-        let payload: web_exchange::OfflineExchangePayload =
+        let payload: wire_exchange::OfflineExchangePayload =
             bcr_common::core::signature::deserialize_borsh_msg(&response.content)?;
         Ok((payload.proofs, response.signature))
     }
@@ -217,19 +217,19 @@ impl TreasuryClient {
             .base
             .join(Self::CRSATEXCHANGEOFFLINE_EP_V1)
             .expect("crsat_exchange_offline relative path");
-        let msg = web_exchange::OfflineExchangeRequest {
+        let msg = wire_exchange::OfflineExchangeRequest {
             fingerprints,
             hashes,
             wallet_pk,
         };
         let request = self.cl.post(url).json(&msg);
-        let response: web_exchange::OfflineExchangeResponse = request.send().await?.json().await?;
+        let response: wire_exchange::OfflineExchangeResponse = request.send().await?.json().await?;
         bcr_common::core::signature::schnorr_verify_b64(
             &response.content,
             &response.signature,
             &mint_pk.x_only_public_key().0,
         )?;
-        let payload: web_exchange::OfflineExchangePayload =
+        let payload: wire_exchange::OfflineExchangePayload =
             bcr_common::core::signature::deserialize_borsh_msg(&response.content)?;
         Ok((payload.proofs, response.signature))
     }

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 // ----- extra library imports
 use axum::extract::{Json, State};
-use bcr_wdc_webapi::exchange as web_exchange;
+use bcr_common::wire::exchange as wire_exchange;
 use bitcoin::base64::prelude::*;
 use cashu::nut03 as cdk03;
 // ----- local imports
@@ -29,8 +29,8 @@ where
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn crsat_online_exchange(
     State(ctrl): State<Arc<foreign::crsat::Service>>,
-    Json(request): Json<web_exchange::OnlineExchangeRequest>,
-) -> Result<Json<web_exchange::OnlineExchangeResponse>> {
+    Json(request): Json<wire_exchange::OnlineExchangeRequest>,
+) -> Result<Json<wire_exchange::OnlineExchangeResponse>> {
     tracing::debug!("Received request to online exchange");
 
     let exchange_path: Vec<cashu::PublicKey> = request
@@ -39,15 +39,15 @@ pub async fn crsat_online_exchange(
         .map(|p| cashu::PublicKey::from(*p))
         .collect();
     let signatures = ctrl.online_exchange(request.proofs, &exchange_path).await?;
-    let response = web_exchange::OnlineExchangeResponse { proofs: signatures };
+    let response = wire_exchange::OnlineExchangeResponse { proofs: signatures };
     Ok(Json(response))
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn sat_online_exchange(
     State(ctrl): State<Arc<foreign::sat::Service>>,
-    Json(request): Json<web_exchange::OnlineExchangeRequest>,
-) -> Result<Json<web_exchange::OnlineExchangeResponse>> {
+    Json(request): Json<wire_exchange::OnlineExchangeRequest>,
+) -> Result<Json<wire_exchange::OnlineExchangeResponse>> {
     tracing::debug!("Received request to online exchange");
 
     let exchange_path: Vec<cashu::PublicKey> = request
@@ -56,44 +56,44 @@ pub async fn sat_online_exchange(
         .map(|p| cashu::PublicKey::from(*p))
         .collect();
     let signatures = ctrl.online_exchange(request.proofs, &exchange_path).await?;
-    let response = web_exchange::OnlineExchangeResponse { proofs: signatures };
+    let response = wire_exchange::OnlineExchangeResponse { proofs: signatures };
     Ok(Json(response))
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn crsat_offline_exchange(
     State(ctrl): State<AppController>,
-    Json(request): Json<web_exchange::OfflineExchangeRequest>,
-) -> Result<Json<web_exchange::OfflineExchangeResponse>> {
+    Json(request): Json<wire_exchange::OfflineExchangeRequest>,
+) -> Result<Json<wire_exchange::OfflineExchangeResponse>> {
     tracing::debug!("Received request to offline exchange");
 
     let proofs = ctrl
         .crsat
         .offline_exchange(request.fingerprints, request.hashes, request.wallet_pk)
         .await?;
-    let payload = web_exchange::OfflineExchangePayload { proofs };
+    let payload = wire_exchange::OfflineExchangePayload { proofs };
     let serialized = borsh::to_vec(&payload)?;
     let signature = ctrl.signer.sign_bytes(&serialized).await?;
     let content = BASE64_STANDARD.encode(&serialized);
-    let response = web_exchange::OfflineExchangeResponse { content, signature };
+    let response = wire_exchange::OfflineExchangeResponse { content, signature };
     Ok(Json(response))
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn sat_offline_exchange(
     State(ctrl): State<AppController>,
-    Json(request): Json<web_exchange::OfflineExchangeRequest>,
-) -> Result<Json<web_exchange::OfflineExchangeResponse>> {
+    Json(request): Json<wire_exchange::OfflineExchangeRequest>,
+) -> Result<Json<wire_exchange::OfflineExchangeResponse>> {
     tracing::debug!("Received request to offline exchange");
 
     let proofs = ctrl
         .sat
         .offline_exchange(request.fingerprints, request.hashes, request.wallet_pk)
         .await?;
-    let payload = web_exchange::OfflineExchangePayload { proofs };
+    let payload = wire_exchange::OfflineExchangePayload { proofs };
     let serialized = borsh::to_vec(&payload)?;
     let signature = ctrl.signer.sign_bytes(&serialized).await?;
     let content = BASE64_STANDARD.encode(&serialized);
-    let response = web_exchange::OfflineExchangeResponse { content, signature };
+    let response = wire_exchange::OfflineExchangeResponse { content, signature };
     Ok(Json(response))
 }

--- a/crates/bcr-wdc-wallet-aggregator/src/web.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/web.rs
@@ -5,10 +5,9 @@ use async_trait::async_trait;
 use axum::extract::{Json, Path, State};
 use bcr_common::{
     client::keys::{Client as KeysClient, Error as KeysError},
-    wire::swap as wire_swap,
+    wire::{exchange as wire_exchange, swap as wire_swap},
 };
 use bcr_wdc_treasury_client::TreasuryClient;
-use bcr_wdc_webapi::exchange as web_exchange;
 use cashu::MintVersion;
 use cdk::wallet::MintConnector;
 use futures::future::JoinAll;
@@ -369,11 +368,10 @@ pub async fn get_clowder_betas(
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl, request))]
-#[allow(dead_code, unused_variables)]
 pub async fn post_exchange(
     State(ctrl): State<AppController>,
-    Json(request): Json<web_exchange::OnlineExchangeRequest>,
-) -> Result<Json<web_exchange::OnlineExchangeResponse>> {
+    Json(request): Json<wire_exchange::OnlineExchangeRequest>,
+) -> Result<Json<wire_exchange::OnlineExchangeResponse>> {
     if request.exchange_path.len() < 3 {
         return Err(Error::Invalid(String::from(
             "minimum exchange path [alpha_pk, this_mint_pk, wallet_pk] not met",
@@ -387,7 +385,7 @@ pub async fn post_exchange(
         pk: request.exchange_path[0],
     };
     let input_type = determine_input_type(&clowder_keys, &request.proofs).await?;
-    let web_exchange::OnlineExchangeRequest {
+    let wire_exchange::OnlineExchangeRequest {
         proofs,
         exchange_path,
     } = request;
@@ -403,7 +401,7 @@ pub async fn post_exchange(
                 .await?
         }
     };
-    let response = web_exchange::OnlineExchangeResponse { proofs };
+    let response = wire_exchange::OnlineExchangeResponse { proofs };
     Ok(Json(response))
 }
 

--- a/crates/bcr-wdc-webapi/src/exchange.rs
+++ b/crates/bcr-wdc-webapi/src/exchange.rs
@@ -1,53 +1,11 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_common::wire::{borsh as wire_borsh, keys as wire_keys};
 use bitcoin::secp256k1;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 // ----- local imports
 
 // ----- end imports
-
-///--------------------------- Online ExchangeRequest
-#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-pub struct OnlineExchangeRequest {
-    pub proofs: Vec<cashu::Proof>,
-    #[schema(value_type = Vec<String>)]
-    pub exchange_path: Vec<secp256k1::PublicKey>,
-}
-
-///--------------------------- Online ExchangeResponse
-#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-pub struct OnlineExchangeResponse {
-    pub proofs: Vec<cashu::Proof>,
-}
-
-///--------------------------- Offline ExchangeRequest
-#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-pub struct OfflineExchangeRequest {
-    pub fingerprints: Vec<wire_keys::ProofFingerprint>,
-    #[schema(value_type = Vec<String>)]
-    pub hashes: Vec<bitcoin::hashes::sha256::Hash>,
-    pub wallet_pk: cashu::PublicKey,
-}
-
-///--------------------------- Offline ExchangePayload
-#[derive(Debug, Clone, borsh::BorshSerialize, borsh::BorshDeserialize)]
-pub struct OfflineExchangePayload {
-    #[borsh(
-        serialize_with = "wire_borsh::serialize_vecof_cdkproof",
-        deserialize_with = "wire_borsh::deserialize_vecof_cdkproof"
-    )]
-    pub proofs: Vec<cashu::Proof>,
-}
-
-///--------------------------- Offline ExchangeResponse
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct OfflineExchangeResponse {
-    pub content: String, // b64 borsh-serialized OfflineExchangePayload
-    #[schema(value_type = String)]
-    pub signature: bitcoin::secp256k1::schnorr::Signature,
-}
 
 ///--------------------------- HtlcSwapAttemptRequest
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Migrate exchange types from `web_exchange` to `wire_exchange`

- Remove duplicate type definitions from webapi crate

- Update all imports and usages across treasury and wallet services

- Consolidate exchange protocol types in bcr_common library


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bcr_common<br/>wire::exchange"] -->|"OnlineExchangeRequest<br/>OnlineExchangeResponse"| B["treasury-client"]
  A -->|"OfflineExchangeRequest<br/>OfflineExchangeResponse"| B
  A -->|"OfflineExchangePayload"| B
  B -->|"uses types"| C["treasury-service"]
  B -->|"uses types"| D["wallet-aggregator"]
  C -->|"web handlers"| E["API endpoints"]
  D -->|"web handlers"| E
  F["webapi<br/>exchange.rs"] -->|"REMOVED"| G["Duplicate types"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Replace web_exchange with wire_exchange types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-client/src/lib.rs

<ul><li>Added import of <code>exchange as wire_exchange</code> from <code>bcr_common::wire</code><br> <li> Replaced all <code>web_exchange::</code> type references with <code>wire_exchange::</code><br> <li> Updated 4 methods: <code>sat_exchange_online</code>, <code>crsat_exchange_online</code>, <br><code>sat_exchange_offline</code>, <code>crsat_exchange_offline</code><br> <li> Changed request/response types for both online and offline exchange <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/372/files#diff-a1ed6e2862956edbaae0bcc2d2035feb1556377205b83a6d249a1cc09e65e3ac">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Switch to wire_exchange types in handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/web.rs

<ul><li>Changed import from <code>bcr_wdc_webapi::exchange</code> to <br><code>bcr_common::wire::exchange</code><br> <li> Updated all function signatures to use <code>wire_exchange</code> types<br> <li> Modified 4 handler functions: <code>crsat_online_exchange</code>, <br><code>sat_online_exchange</code>, <code>crsat_offline_exchange</code>, <code>sat_offline_exchange</code><br> <li> Replaced all type references in request/response handling</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/372/files#diff-ad24c19ee9cc83165c7bac0ca341787f5354bd84be8abc7d35ac197f7350c323">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Migrate to wire_exchange types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-wallet-aggregator/src/web.rs

<ul><li>Added <code>exchange as wire_exchange</code> to bcr_common wire imports<br> <li> Removed import of <code>bcr_wdc_webapi::exchange</code><br> <li> Updated <code>post_exchange</code> function to use <code>wire_exchange</code> types<br> <li> Removed <code>#[allow(dead_code, unused_variables)]</code> attribute<br> <li> Changed all type references from <code>web_exchange</code> to <code>wire_exchange</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/372/files#diff-5558fd821dba3268f729f3ca79eb75aff0edcd3fbf1b9414c170f6fbc18c72a1">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exchange.rs</strong><dd><code>Remove duplicate exchange type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-webapi/src/exchange.rs

<ul><li>Removed all exchange type definitions: <code>OnlineExchangeRequest</code>, <br><code>OnlineExchangeResponse</code>, <code>OfflineExchangeRequest</code>, <br><code>OfflineExchangePayload</code>, <code>OfflineExchangeResponse</code><br> <li> Removed imports of <code>wire_borsh</code> and <code>wire_keys</code> from bcr_common<br> <li> Kept only <code>HtlcSwapAttemptRequest</code> and other non-exchange types<br> <li> File now serves as a placeholder for swap-related types only</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/372/files#diff-60541e4c6a69d2d46f52be9e9eec84e951d12a5581fae2fee50f15b80b95b0b9">+0/-42</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bcr-common</strong><dd><code>Update bcr-common submodule reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bcr-common

<ul><li>Updated submodule commit reference to include new wire::exchange types<br> <li> Moved exchange protocol definitions to bcr_common library</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/372/files#diff-74b63631569e18325f7afcbd4820e8aa24da472795a67c7bfcc57a7308e6f402">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

