### PR TITLE
[docker] remove bitcoin-core and electrs from common-services

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -304,13 +304,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-    depends_on:
-      signatory:
-        condition: service_started
-      nats:
-        condition: service_started
-      electrs:
-        condition: service_started
     ports:
       - "3010:3010"
       - 5001:5001/udp

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -127,6 +127,13 @@ services:
     extends:
       file: common-services.yml
       service: clowder-node
+    depends_on:
+      signatory:
+        condition: service_started
+      nats:
+        condition: service_started
+      electrs:
+        condition: service_started
 
   eic-service:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,17 +72,6 @@ services:
     ports:
       - "4242:4242"
 
-  bitcoin-core:
-    extends:
-      file: common-services.yml
-      service: bitcoin-core
-    command:
-      - -printtoconsole
-      - --testnet=1
-      - -conf=/home/bitcoin/bitcoin.conf
-    healthcheck:
-      test: ["CMD", "bitcoin-cli", "--testnet", "getconnectioncount"]
-
   keycloak:
     extends:
       file: common-services.yml
@@ -104,15 +93,6 @@ services:
     ports:
       - "8080:8080"
 
-  electrs:
-    extends:
-      file: common-services.yml
-      service: electrs
-    environment:
-      ELECTRS_NETWORK: testnet
-      ELECTRS_DAEMON_RPC_ADDR: bitcoin-core:18332
-      ELECTRS_DAEMON_P2P_ADDR: bitcoin-core:18333
-
   ######################################################################################## clowder
 
   signatory:
@@ -129,9 +109,11 @@ services:
     extends:
       file: common-services.yml
       service: clowder-node
-    environment:
-      CLWDR__ELECTRUM_CONFIG__RPC_URL: tcp://electrs:50001
-      CLWDR__ELECTRUM_CONFIG__NETWORK: testnet
+    depends_on:
+      signatory:
+        condition: service_started
+      nats:
+        condition: service_started
 
   ######################################################################################## wildcat-auxiliary
 


### PR DESCRIPTION
official docker-compose deployment leverages an external electrum server