### PR TITLE
deployment fix: remove bitcoin-core service from deployment-configuration

### DIFF
--- a/deployment-configuration.yml
+++ b/deployment-configuration.yml
@@ -129,17 +129,6 @@ services:
     environment:
       - CDK_MINTD_MNEMONIC=${MINT_SEED_PHRASE}
 
-  bitcoin-core:
-    volumes:
-      - ./docker/bitcoin-core/bitcoin.conf:/home/bitcoin/bitcoin.conf
-      - ${DATA_PATH}/bitcoin-core/:/home/bitcoin/data
-    command:
-      - -printtoconsole
-      - ${BITCOIN_NETWORK_COMMAND_ARG:--testnet=1}
-      - -conf=/home/bitcoin/bitcoin.conf
-    healthcheck:
-      test: ["CMD", "bitcoin-cli", "${BITCOIN_CLI_NETWORK_ARG:--testnet}", "getconnectioncount"]
-
 networks:
   default:
     external: true


### PR DESCRIPTION
https://github.com/BitcreditProtocol/Wildcat/actions/runs/20234233380/job/58086590650

```
Run docker compose \
  docker compose \
  -f docker-compose.yml \
  -f deployment-configuration.yml \
  config --quiet
  shell: /usr/bin/bash -e {0}

service "bitcoin-core" has neither an image nor a build context specified: invalid compose project
Error: Process completed with exit code 1.

```