### PR TITLE
[docker] minor fixes

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -296,6 +296,3 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-    ports:
-      - "3010:3010"
-      - 5001:5001/udp

--- a/deployment-configuration.yml
+++ b/deployment-configuration.yml
@@ -45,6 +45,10 @@ services:
     image: europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/bcr-wdc-wallet-aggregator:${IMAGE_TAG:-latest}
     pull_policy: always
 
+  admin-aggregator:
+    image: europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/bcr-wdc-admin-aggregator:${IMAGE_TAG:-latest}
+    pull_policy: always
+
   ebill-service:
     image: europe-west1-docker.pkg.dev/bitcr-shared/bitcr-wildcat-dev/bcr-wdc-ebill-service:${IMAGE_TAG:-latest}
     pull_policy: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,16 @@ services:
     extends:
       file: common-services.yml
       service: signatory
+    volumes:
+      - ./docker/clowder-signatory/settings.toml:/clowder/settings.toml
+
+  # Signatory for Beta node
+  signatory-beta:
+    extends:
+      file: common-services.yml
+      service: signatory
+    volumes:
+      - ./docker/clowder-signatory/settings_beta.toml:/clowder/settings.toml
 
   nats:
     extends:
@@ -109,11 +119,27 @@ services:
         condition: service_started
       nats:
         condition: service_started
+    volumes:
+      - ./docker/clowder-node/settings.toml:/clowder/settings.toml
     ports:
       - "3010:3010"
       - 5001:5001/udp
+
+  # Beta node for mint
+  clowder-beta:
+    extends:
+      file: common-services.yml
+      service: clowder-node
+    depends_on:
+      signatory-beta:
+        condition: service_started
+      nats:
+        condition: service_started
     volumes:
-      - ./docker/clowder-node/settings.toml:/clowder/settings.toml
+      - ./docker/clowder-node/settings_beta.toml:/clowder/settings.toml
+    ports:
+      - "3011:3011"
+      - 5002:5002/udp
 
   ######################################################################################## wildcat-auxiliary
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove port mappings from clowder-node base service definition

- Add admin-aggregator service to deployment configuration

- Introduce signatory-beta and clowder-beta services for beta node support

- Add explicit volume mounts to signatory and clowder-node services


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["common-services.yml<br/>Base definitions"] -->|extends| B["signatory"]
  A -->|extends| C["signatory-beta"]
  A -->|extends| D["clowder-node"]
  A -->|extends| E["clowder-beta"]
  B -->|depends on| F["nats"]
  C -->|depends on| F
  D -->|depends on| B
  D -->|depends on| F
  E -->|depends on| C
  E -->|depends on| F
  G["deployment-configuration.yml"] -->|adds| H["admin-aggregator"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common-services.yml</strong><dd><code>Remove port mappings from base service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common-services.yml

<ul><li>Removed port mappings (3010:3010 and 5001:5001/udp) from clowder-node <br>service<br> <li> Kept healthcheck configuration intact</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/409/files#diff-feef9361dee340026246ae79275bc3b63be23a97aef0579ef9042376439c4137">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment-configuration.yml</strong><dd><code>Add admin-aggregator service configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployment-configuration.yml

<ul><li>Added new <code>admin-aggregator</code> service with image reference and <br>pull_policy<br> <li> Service configured to pull from bitcr-wildcat-dev registry</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/409/files#diff-13bce7a18666c010bbcaca59df63da5c5227816089d43dcca3386faed460c8dc">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add beta node services and volume mounts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Added explicit volume mount to <code>signatory</code> service for settings.toml<br> <li> Created new <code>signatory-beta</code> service extending common-services with beta <br>settings<br> <li> Added explicit volume mount to <code>clowder-node</code> service<br> <li> Created new <code>clowder-beta</code> service with separate port mappings <br>(3011:3011, 5002:5002/udp)<br> <li> Beta node depends on signatory-beta instead of signatory</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/409/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+27/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

