### PR TITLE
[github] fix openapi workflow

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -76,14 +76,14 @@ jobs:
       - name: upload new openapi.json file
         uses: actions/upload-artifact@v6
         with:
-          name: "openapi-${{ github.refname }}.json"
+          name: "openapi-${{ steps.branch-names.outputs.ref_branch }}.json"
           path: openapi.json
 
       - name: compare openapi files
         id: comparison
         uses: swimmwatch/openapi-diff-action@v1.0.1
         with:
-          old-spec: "openapi-${{ env.GITHUB_REF }}.json"
+          old-spec: "openapi-${{ steps.branch-names.outputs.ref_branch }}.json"
           new-spec: openapi.json
           json: out.json
           markdown: out.md
@@ -97,6 +97,6 @@ jobs:
         uses: actions-ecosystem/action-create-issue@v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          title: "wildcat admin API change in ${{ github.refname }}: ${{ steps.comparison.outputs.state }} changes"
+          title: "wildcat admin API change in ${{ steps.branch-names.outputs.ref_branch }}: ${{ steps.comparison.outputs.state }} changes"
           body: ${{ steps.body.outputs.body }}
           repo: BitcreditProtocol/wildcat-dashboard-ui


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace inconsistent GitHub variable references with standardized branch name output

- Use `steps.branch-names.outputs.ref_branch` consistently across workflow steps

- Fix artifact naming and comparison logic to use correct branch reference variable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Variables"] -->|"Replace with"| B["steps.branch-names.outputs.ref_branch"]
  B -->|"Applied to"| C["Artifact Upload"]
  B -->|"Applied to"| D["OpenAPI Comparison"]
  B -->|"Applied to"| E["Issue Creation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi.yml</strong><dd><code>Standardize branch reference variable in workflow steps</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/openapi.yml

<ul><li>Replace <code>github.refname</code> with <code>steps.branch-names.outputs.ref_branch</code> in <br>artifact upload step<br> <li> Replace <code>env.GITHUB_REF</code> with <code>steps.branch-names.outputs.ref_branch</code> in <br>comparison step<br> <li> Replace <code>github.refname</code> with <code>steps.branch-names.outputs.ref_branch</code> in <br>issue creation title<br> <li> Ensures consistent and correct branch reference across all workflow <br>steps</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/423/files#diff-3037eb4d8d7d81bdfc122e300300d61f27902de7f07a0177176690cf5aebcc68">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

