### PR TITLE
[bcr-wdc-treasury-service] fix check who is the substitute

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
@@ -2,7 +2,10 @@
 use std::ops::Deref;
 // ----- extra library imports
 use async_trait::async_trait;
-use bcr_common::{core::signature::serialize_n_schnorr_sign_borsh_msg, wire::keys as wire_keys};
+use bcr_common::{
+    core::signature::serialize_n_schnorr_sign_borsh_msg,
+    wire::{clowder as wire_clowder, keys as wire_keys},
+};
 use bcr_wdc_webapi::exchange as web_exchange;
 use bitcoin::hex::prelude::*;
 use cdk::wallet::MintConnector;
@@ -126,10 +129,16 @@ impl foreign::ClowderClient for ClowderCl {
         });
         let fps_len = fps.len();
         let fps: Vec<clwdr_model::ProofFingerprint> = fps.into_iter().collect();
-        let clwdr_model::IntermintOriginResponse { node_id, mint_url } =
-            self.clwdr.post_fingerprints_origin(fps.clone()).await?;
+        let clwdr_model::IntermintOriginResponse {
+            node_id: origin_id,
+            mint_url: origin_url,
+        } = self.clwdr.post_fingerprints_origin(fps.clone()).await?;
+        let wire_clowder::ConnectedMintResponse {
+            node_id: substitute_id,
+            ..
+        } = self.clwdr.get_substitute(origin_id).await?;
         let myself = self.clwdr.get_id().await?;
-        if node_id != myself.public_key {
+        if substitute_id != myself.public_key {
             return Err(Error::InvalidInput(String::from(
                 "currently not a substitute",
             )));
@@ -137,13 +146,13 @@ impl foreign::ClowderClient for ClowderCl {
         let clwdr_model::ValidFingerprints {
             valid_proofs,
             amount,
-        } = self.clwdr.post_verify_fingerprints(node_id, fps).await?;
+        } = self.clwdr.post_verify_fingerprints(origin_id, fps).await?;
         if valid_proofs.len() != fps_len || amount != input_amount {
             return Err(Error::InvalidInput(String::from(
                 "One or more fingerprints are invalid",
             )));
         }
-        Ok((mint_url, node_id))
+        Ok((origin_url, origin_id))
     }
 
     async fn get_keyset_info(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix substitute verification logic to check correct node ID

- Retrieve substitute node ID from dedicated API endpoint

- Use origin node ID for fingerprint verification instead

- Improve import organization with wire clowder module


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Get fingerprints origin"] -->|origin_id, origin_url| B["Get substitute node ID"]
  B -->|substitute_id| C["Verify substitute is self"]
  C -->|valid| D["Verify fingerprints with origin_id"]
  D -->|valid| E["Return origin_url and origin_id"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clients.rs</strong><dd><code>Fix substitute verification with dedicated API call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/foreign/clients.rs

<ul><li>Added import for <code>wire_clowder</code> module to access substitute response <br>types<br> <li> Renamed destructured variables from <code>node_id</code>/<code>mint_url</code> to <br><code>origin_id</code>/<code>origin_url</code> for clarity<br> <li> Added new API call to <code>get_substitute(origin_id)</code> to retrieve the actual <br>substitute node ID<br> <li> Fixed verification logic to check <code>substitute_id</code> against self instead <br>of <code>origin_id</code><br> <li> Updated fingerprint verification to use <code>origin_id</code> instead of <code>node_id</code><br> <li> Updated return statement to use renamed variables <code>origin_url</code> and <br><code>origin_id</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/435/files#diff-d7e67af976db963bf73a43185080f8284d3876ce2716f5538413f258c9bef848">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

