### PR TITLE
[bcr-wdc-quote-service] fee token as a string

### DIFF
--- a/crates/bcr-wdc-quote-service/src/admin.rs
+++ b/crates/bcr-wdc-quote-service/src/admin.rs
@@ -178,14 +178,17 @@ fn convert_to_info_reply(
             discounted,
             tstamp,
         },
-        quotes::Status::MintingEnabled { keyset_id, fee, .. } => wire_quotes::InfoReply::Minting {
+        quotes::Status::MintingEnabled {
+            keyset_id,
+            fee,
+            discounted,
+            ..
+        } => wire_quotes::InfoReply::Minting {
             id: quote.id,
             bill: wire_quotes::BillInfo::from(quote.bill),
             keyset_id,
-            discounted: bitcoin::Amount::from_sat(
-                fee.value().expect("fee token value missing").into(),
-            ),
-            fee: fee.to_string(),
+            discounted,
+            fee,
             minting_status: convert_mint_status(minting_status),
         },
     }

--- a/crates/bcr-wdc-quote-service/src/quotes.rs
+++ b/crates/bcr-wdc-quote-service/src/quotes.rs
@@ -103,7 +103,8 @@ pub enum Status {
     MintingEnabled {
         keyset_id: cashu::Id,
         wallet_pubkey: cashu::PublicKey,
-        fee: bcr_common::wallet::Token,
+        discounted: bitcoin::Amount,
+        fee: String,
     },
 }
 
@@ -256,7 +257,8 @@ impl Quote {
                 self.status = Status::MintingEnabled {
                     keyset_id,
                     wallet_pubkey,
-                    fee,
+                    discounted,
+                    fee: fee.to_string(),
                 }
             }
             _ => {

--- a/crates/bcr-wdc-quote-service/src/web.rs
+++ b/crates/bcr-wdc-quote-service/src/web.rs
@@ -84,12 +84,11 @@ fn convert_to_enquire_reply(
         quotes::Status::MintingEnabled {
             keyset_id,
             wallet_pubkey,
-            fee,
+            discounted,
+            ..
         } => wire_quotes::StatusReply::Accepted {
             keyset_id,
-            discounted: bitcoin::Amount::from_sat(
-                fee.value().expect("fee token to have a value").into(),
-            ),
+            discounted,
             minting_pubkey: wallet_pubkey,
             minting_status: convert_mint_status(minting_status),
         },


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Convert fee token from object to string representation

- Store discounted amount directly in MintingEnabled status

- Simplify fee value extraction by removing token parsing logic

- Update submodule reference to latest bcr-common commit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fee Token Object"] -- "Convert to String" --> B["Fee as String"]
  C["Fee Value Extraction"] -- "Remove Parsing Logic" --> D["Direct Amount Usage"]
  E["MintingEnabled Status"] -- "Add discounted field" --> F["Simplified Structure"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>quotes.rs</strong><dd><code>Fee token type conversion and status restructuring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/quotes.rs

<ul><li>Changed <code>fee</code> field type from <code>bcr_common::wallet::Token</code> to <code>String</code><br> <li> Added <code>discounted: bitcoin::Amount</code> field to <code>MintingEnabled</code> status <br>variant<br> <li> Updated status assignment to convert fee token to string and use <br>discounted amount directly</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/438/files#diff-03545ff0e2dffaef5dbb0e2990ee74cf84c03a3c10f8f0f069b28ac5734f1ef8">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin.rs</strong><dd><code>Simplify fee handling in admin reply conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/admin.rs

<ul><li>Destructured <code>discounted</code> from <code>MintingEnabled</code> status<br> <li> Removed fee value extraction and conversion logic<br> <li> Simplified assignment by using <code>discounted</code> directly instead of parsing <br>fee token</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/438/files#diff-0ac7a81b04baaf01768d8526f8dceb0754d20adf93d53808f189a4b810752acb">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Simplify fee handling in web reply conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-quote-service/src/web.rs

<ul><li>Removed <code>fee</code> field from pattern matching in <code>MintingEnabled</code> status<br> <li> Added <code>discounted</code> field to pattern matching<br> <li> Eliminated fee token value extraction and conversion logic<br> <li> Use <code>discounted</code> amount directly in reply</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/438/files#diff-1bd0e6958ea77d8d30de256aa68ee557a88bc615c71586889a98edca3ea18e30">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bcr-common</strong><dd><code>Update bcr-common submodule reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bcr-common

<ul><li>Updated submodule commit reference from <br><code>d4f814c7e53c7f56d3508fa2a544e2f9f520351a</code> to <br><code>7e9d1ac75d1f905b5e01315cb13dfd865d7a9983</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/438/files#diff-74b63631569e18325f7afcbd4820e8aa24da472795a67c7bfcc57a7308e6f402">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

