### PR TITLE
[github] partially disable openapi workflow

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -79,24 +79,24 @@ jobs:
           name: "openapi-${{ steps.branch-names.outputs.ref_branch }}.json"
           path: openapi.json
 
-      - name: compare openapi files
-        id: comparison
-        uses: swimmwatch/openapi-diff-action@v1.0.1
-        with:
-          old-spec: "openapi-${{ steps.branch-names.outputs.ref_branch }}.json"
-          new-spec: openapi.json
-          json: out.json
-          markdown: out.md
-
-      - name: Get issue content
-        id: body
-        run: echo "body=$(cat out.md)" >> $GITHUB_OUTPUT
-
-      - name: open an issue in dashboard repo 
-        if: steps.comparison.outputs.state != 'no_changes'
-        uses: actions-ecosystem/action-create-issue@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          title: "wildcat admin API change in ${{ steps.branch-names.outputs.ref_branch }}: ${{ steps.comparison.outputs.state }} changes"
-          body: ${{ steps.body.outputs.body }}
-          repo: BitcreditProtocol/wildcat-dashboard-ui
+      # - name: compare openapi files
+      #   id: comparison
+      #   uses: swimmwatch/openapi-diff-action@v1.0.1
+      #   with:
+      #     old-spec: "openapi-${{ steps.branch-names.outputs.ref_branch }}.json"
+      #     new-spec: openapi.json
+      #     json: out.json
+      #     markdown: out.md
+      #
+      # - name: Get issue content
+      #   id: body
+      #   run: echo "body=$(cat out.md)" >> $GITHUB_OUTPUT
+      #
+      # - name: open an issue in dashboard repo
+      #   if: steps.comparison.outputs.state != 'no_changes'
+      #   uses: actions-ecosystem/action-create-issue@v1
+      #   with:
+      #     github_token: ${{ steps.app-token.outputs.token }}
+      #     title: "wildcat admin API change in ${{ steps.branch-names.outputs.ref_branch }}: ${{ steps.comparison.outputs.state }} changes"
+      #     body: ${{ steps.body.outputs.body }}
+      #     repo: BitcreditProtocol/wildcat-dashboard-ui


### PR DESCRIPTION
### **User description**
dealing with github actions is never as easy as it looks. It turns out the action used to compare the openapi.json files is expecting files to be in a particular location.
This commit temporarily disables that and all the following steps.


___

### **PR Type**
Other


___

### **Description**
- Temporarily disable OpenAPI comparison workflow steps

- Comment out openapi-diff-action and dependent tasks

- Preserve artifact upload functionality for debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generate openapi.json"] --> B["Upload artifact"]
  B --> C["Compare files<br/>DISABLED"]
  C --> D["Create issue<br/>DISABLED"]
  style C fill:#ffcccc
  style D fill:#ffcccc
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi.yml</strong><dd><code>Disable OpenAPI comparison and issue creation workflow</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/openapi.yml

<ul><li>Commented out the <code>swimmwatch/openapi-diff-action@v1.0.1</code> step that <br>compares OpenAPI specifications<br> <li> Disabled the "Get issue content" step that processes comparison output<br> <li> Disabled the "open an issue in dashboard repo" step that creates <br>GitHub issues<br> <li> Kept the artifact upload step active for manual inspection</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/439/files#diff-3037eb4d8d7d81bdfc122e300300d61f27902de7f07a0177176690cf5aebcc68">+21/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

