### PR TITLE
[bcr-wdc-treasury-service] fix minor bug in settle

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
@@ -170,10 +170,12 @@ async fn monitor(
                 continue;
             };
             let mut news = Vec::with_capacity(response.signatures.len());
-            for (premint, signature) in premints.into_iter().zip(response.signatures.into_iter()) {
+            for (signature, premint) in response.signatures.into_iter().zip(premints.iter()) {
                 let amount = signature.amount;
                 let Ok(proof) = bcr_common::core::signature::unblind_ecash_signature(
-                    &keyset, premint, signature,
+                    &keyset,
+                    premint.clone(),
+                    signature,
                 ) else {
                     error!("unblind_ecash_signature failed {}, lost {}", mint.1, amount);
                     continue;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix iterator order in swap response handling loop

- Change from consuming to borrowing premints iterator

- Clone premint before passing to unblind function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["swap response signatures"] -- "zip with" --> B["premints iterator"]
  B -- "changed from into_iter" --> C["iter borrow"]
  D["unblind_ecash_signature"] -- "now receives cloned premint" --> E["signature processing"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settle.rs</strong><dd><code>Fix iterator order and borrowing in swap loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/foreign/settle.rs

<ul><li>Swapped order of tuple unpacking from <code>(premint, signature)</code> to <br><code>(signature, premint)</code> to match iterator order<br> <li> Changed <code>premints.into_iter()</code> to <code>premints.iter()</code> to borrow instead of <br>consume<br> <li> Added <code>.clone()</code> call on <code>premint</code> when passing to <code>unblind_ecash_signature</code> <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/442/files#diff-16b8e795deaa58753acbf96f57dc604503d720a66e90674f4605fd1c7eccde20">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

