### PR TITLE
Return mint status

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -136,6 +136,7 @@ where
             address: data.address,
             amount: bitcoin::Amount::from_sat(data.amount.into()),
             expiry: data.expiry,
+            state: None,
         })
     }
 }

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -54,6 +54,7 @@ pub struct AppConfig {
     wildcat: debit::WildcatClientConfig,
     monitor_interval_sec: u64,
     quote_expiry_seconds: u64,
+    min_confirmations: u32,
 }
 
 #[derive(Clone, FromRef)]
@@ -66,6 +67,7 @@ pub struct AppController {
     clwdr_rest: Arc<ClowderRestClient>,
     dbmint: cdk::wallet::HttpClient,
     dev: Arc<devmode::Service>,
+    min_confirmations: u32,
 }
 
 impl AppController {
@@ -85,6 +87,7 @@ impl AppController {
             wildcat,
             monitor_interval_sec,
             quote_expiry_seconds,
+            min_confirmations,
         } = cfg;
 
         let wallet = ProdDebitWallet::new(sat_wallet, seed)
@@ -201,6 +204,7 @@ impl AppController {
             clwdr_rest,
             dbmint,
             dev: Arc::new(dev),
+            min_confirmations,
         }
     }
 

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -222,6 +222,7 @@ pub async fn mint_quote_onchain(
         address: address_response.address,
         amount: request.amount,
         expiry,
+        state: Some(cashu::MintQuoteState::Unpaid),
     };
     Ok(Json(wallet_response))
 }
@@ -232,8 +233,38 @@ pub async fn get_mint_quote_onchain(
     Path(quote_id): Path<String>,
 ) -> Result<Json<wire_mint::MintQuoteOnchainResponse>> {
     tracing::debug!("Received get_mint_quote_onchain request");
-    let response = ctrl.debit.get_onchain_mint_quote(&quote_id).await?;
-    Ok(Json(response))
+
+    let cdk_quote = Uuid::parse_str(&quote_id)
+        .map_err(|_| crate::error::Error::InvalidInput(String::from("Invalid quote ID")))?;
+    let data = ctrl.debit.repo.load_onchain_mint(cdk_quote).await?;
+
+    let cdk_status = ctrl.dbmint.get_mint_quote_status(&quote_id).await?;
+
+    // CDK and the payment processor don't know payment status
+    let state = if cdk_status.state == cashu::MintQuoteState::Issued {
+        cashu::MintQuoteState::Issued
+    } else {
+        let dummy_kid = cashu::Id::from_bytes(&[0_u8; 8])
+            .map_err(|_| crate::error::Error::InvalidInput(String::from("Invalid keyset ID")))?;
+        let payment = ctrl
+            .clwdr_rest
+            .verify_mint_payment(data.clowder_quote, dummy_kid, ctrl.min_confirmations)
+            .await?;
+
+        if payment.amount.to_sat() >= data.amount.into() {
+            cashu::MintQuoteState::Paid
+        } else {
+            cashu::MintQuoteState::Unpaid
+        }
+    };
+
+    Ok(Json(wire_mint::MintQuoteOnchainResponse {
+        quote: data.cdk_quote,
+        address: data.address,
+        amount: bitcoin::Amount::from_sat(data.amount.into()),
+        expiry: data.expiry,
+        state: Some(state),
+    }))
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
@@ -263,7 +294,7 @@ pub async fn mint_onchain(
 
     let payment_response = ctrl
         .clwdr_rest
-        .verify_mint_payment(data.clowder_quote, kid, 1)
+        .verify_mint_payment(data.clowder_quote, kid, ctrl.min_confirmations)
         .await?;
 
     tracing::debug!("Clowder payment check {:?} sats", payment_response.amount);

--- a/docker/treasury-service/config.toml
+++ b/docker/treasury-service/config.toml
@@ -10,6 +10,7 @@ clowder_url = "http://clowder-node:3010"
 signer_url = "nats://nats:4222"
 quote_expiry_seconds = 86400
 clwdr_nats_url = "nats://nats:4222"
+min_confirmations = 1
 
 [appcfg.credit_repo]
 connection = "ws://surrealdb:8000"


### PR DESCRIPTION
### **User description**
TODO

- [x] Use master bcr common after merge


___

### **PR Type**
Enhancement


___

### **Description**
- Add mint quote state tracking to onchain mint responses

- Initialize state as Unpaid when creating new mint quotes

- Implement state determination logic in get_mint_quote_onchain endpoint

- Check payment verification and CDK status to determine quote state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mint Quote Creation"] -->|"Set state: Unpaid"| B["MintQuoteOnchainResponse"]
  C["Get Mint Quote"] -->|"Load quote data"| D["Check CDK Status"]
  D -->|"If Issued"| E["State: Issued"]
  D -->|"Else verify payment"| F["Payment Verification"]
  F -->|"Amount >= required"| G["State: Paid"]
  F -->|"Amount < required"| H["State: Unpaid"]
  E --> I["Return Response with State"]
  G --> I
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Add state field to service response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/debit/service.rs

<ul><li>Add <code>state: None</code> field to MintQuoteOnchainResponse in <br>get_onchain_mint_quote method<br> <li> Placeholder state value for onchain mint quote responses</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/447/files#diff-caaa9a1592f0e5ce710ca52d8f651b10978b6986cb1090c391f76ab4bd749b06">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Implement mint quote state determination logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/web.rs

<ul><li>Initialize state as <code>Some(cashu::MintQuoteState::Unpaid)</code> in <br>mint_quote_onchain endpoint<br> <li> Refactor get_mint_quote_onchain to load quote data and determine <br>actual state<br> <li> Implement state determination logic checking CDK status and payment <br>verification<br> <li> Return state based on CDK issued status or payment amount comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/447/files#diff-ad24c19ee9cc83165c7bac0ca341787f5354bd84be8abc7d35ac197f7350c323">+32/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

