### PR TITLE
[docker] keycloak helth check not working

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -118,14 +118,11 @@ services:
     volumes:
       - ./docker/keycloak/realm-dev.json:/opt/keycloak/data/import/realm-dev.json:ro
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          '[ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { java.net.URI uri = java.net.URI.create(args[0]); System.exit(java.net.HttpURLConnection.HTTP_OK == ((java.net.HttpURLConnection)uri.toURL().openConnection()).getResponseCode() ? 0 : 1); } }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:9000/health/live',
-        ]
+      test: "{ printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0; grep 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/8080"
       interval: 5s
       timeout: 5s
       retries: 5
+
 
   surrealdb:
     image: surrealdb/surrealdb:latest


### PR DESCRIPTION
for some reason it no longer works and portainer attempts to restart the
    service over and over.
Let's just remove it