### PR TITLE
[bcr-wdc-treasury-service] Add threshold for melting

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use bcr_common::{
     core::{signature::serialize_n_schnorr_sign_borsh_msg, BillId},
-    wire::{melt as wire_melt, mint as wire_mint, signatures as wire_signatures},
+    wire::{melt as wire_melt, signatures as wire_signatures},
 };
 use bcr_wdc_utils::signatures as signatures_utils;
 use cashu::Amount;
@@ -113,22 +113,6 @@ impl Service {
             unit: Some(request.unit),
             state: cashu::nuts::MeltQuoteState::Unpaid,
             expiry,
-        })
-    }
-
-    pub async fn get_onchain_mint_quote(
-        &self,
-        quote_id: &str,
-    ) -> Result<wire_mint::MintQuoteOnchainResponse> {
-        let cdk_quote = Uuid::parse_str(quote_id)
-            .map_err(|_| Error::InvalidInput(String::from("Invalid quote ID")))?;
-        let data = self.repo.load_onchain_mint(cdk_quote).await?;
-        Ok(wire_mint::MintQuoteOnchainResponse {
-            quote: data.cdk_quote,
-            address: data.address,
-            amount: bitcoin::Amount::from_sat(data.amount.into()),
-            expiry: data.expiry,
-            state: None,
         })
     }
 

--- a/crates/bcr-wdc-treasury-service/src/error.rs
+++ b/crates/bcr-wdc-treasury-service/src/error.rs
@@ -141,11 +141,9 @@ impl axum::response::IntoResponse for Error {
             Error::Borsh(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::BcrBorshSignature(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::BcrEcash(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
-            Error::InsufficientOnchainMeltAmount(_) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, String::new())
-            }
-            Error::MeltAmountMismatch(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
-            Error::MintAmountMismatch(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::InsufficientOnchainMeltAmount(_) => (StatusCode::BAD_REQUEST, String::new()),
+            Error::MeltAmountMismatch(_) => (StatusCode::BAD_REQUEST, String::new()),
+            Error::MintAmountMismatch(_) => (StatusCode::BAD_REQUEST, String::new()),
         };
         resp.into_response()
     }

--- a/crates/bcr-wdc-treasury-service/src/error.rs
+++ b/crates/bcr-wdc-treasury-service/src/error.rs
@@ -81,6 +81,12 @@ pub enum Error {
     RequestIDNotFound(Uuid),
     #[error("ebill id not found {0}")]
     EBillNotFound(String),
+    #[error("Insufficient amount for melting {0}")]
+    InsufficientOnchainMeltAmount(bitcoin::Amount),
+    #[error("Proofs supplied for melting does not match original request")]
+    MeltAmountMismatch(cashu::Amount),
+    #[error("Signatures supplied for minting does not match original request")]
+    MintAmountMismatch(cashu::Amount),
 
     #[error("internal {0}")]
     Internal(String),
@@ -135,6 +141,11 @@ impl axum::response::IntoResponse for Error {
             Error::Borsh(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::BcrBorshSignature(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::BcrEcash(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::InsufficientOnchainMeltAmount(_) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, String::new())
+            }
+            Error::MeltAmountMismatch(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::MintAmountMismatch(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
         };
         resp.into_response()
     }

--- a/crates/bcr-wdc-treasury-service/src/error.rs
+++ b/crates/bcr-wdc-treasury-service/src/error.rs
@@ -83,6 +83,8 @@ pub enum Error {
     EBillNotFound(String),
     #[error("Insufficient amount for melting {0}")]
     InsufficientOnchainMeltAmount(bitcoin::Amount),
+    #[error("Insufficient amount for minting {0}")]
+    InsufficientOnchainMintAmount(bitcoin::Amount),
     #[error("Proofs supplied for melting does not match original request")]
     MeltAmountMismatch(cashu::Amount),
     #[error("Signatures supplied for minting does not match original request")]
@@ -142,6 +144,7 @@ impl axum::response::IntoResponse for Error {
             Error::BcrBorshSignature(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::BcrEcash(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
             Error::InsufficientOnchainMeltAmount(_) => (StatusCode::BAD_REQUEST, String::new()),
+            Error::InsufficientOnchainMintAmount(_) => (StatusCode::BAD_REQUEST, String::new()),
             Error::MeltAmountMismatch(_) => (StatusCode::BAD_REQUEST, String::new()),
             Error::MintAmountMismatch(_) => (StatusCode::BAD_REQUEST, String::new()),
         };

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -50,6 +50,7 @@ pub struct AppConfig {
     monitor_interval_sec: u64,
     quote_expiry_seconds: u64,
     min_confirmations: u32,
+    min_melt_sats: u64,
 }
 
 #[derive(Clone, FromRef)]
@@ -63,6 +64,7 @@ pub struct AppController {
     dbmint: cdk::wallet::HttpClient,
     dev: Arc<devmode::Service>,
     min_confirmations: u32,
+    min_melt_sats: u64,
 }
 
 impl AppController {
@@ -83,6 +85,7 @@ impl AppController {
             monitor_interval_sec,
             quote_expiry_seconds,
             min_confirmations,
+            min_melt_sats,
         } = cfg;
 
         let wallet = debit::CDKWallet::new(sat_wallet, seed)
@@ -200,6 +203,7 @@ impl AppController {
             dbmint,
             dev: Arc::new(dev),
             min_confirmations,
+            min_melt_sats,
         }
     }
 

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -51,6 +51,14 @@ pub struct AppConfig {
     quote_expiry_seconds: u64,
     min_confirmations: u32,
     min_melt_sats: u64,
+    min_mint_sats: u64,
+}
+
+#[derive(Clone)]
+struct Parameters {
+    pub min_confirmations: u32,
+    pub min_melt_sats: u64,
+    pub min_mint_sats: u64,
 }
 
 #[derive(Clone, FromRef)]
@@ -63,8 +71,7 @@ pub struct AppController {
     clwdr_rest: Arc<ClowderRestClient>,
     dbmint: cdk::wallet::HttpClient,
     dev: Arc<devmode::Service>,
-    min_confirmations: u32,
-    min_melt_sats: u64,
+    params: Parameters,
 }
 
 impl AppController {
@@ -86,6 +93,7 @@ impl AppController {
             quote_expiry_seconds,
             min_confirmations,
             min_melt_sats,
+            min_mint_sats,
         } = cfg;
 
         let wallet = debit::CDKWallet::new(sat_wallet, seed)
@@ -202,8 +210,11 @@ impl AppController {
             clwdr_rest,
             dbmint,
             dev: Arc::new(dev),
-            min_confirmations,
-            min_melt_sats,
+            params: Parameters {
+                min_confirmations,
+                min_melt_sats,
+                min_mint_sats,
+            },
         }
     }
 

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -50,15 +50,15 @@ pub struct AppConfig {
     monitor_interval_sec: u64,
     quote_expiry_seconds: u64,
     min_confirmations: u32,
-    min_melt_sats: u64,
-    min_mint_sats: u64,
+    min_melt_threshold: bitcoin::Amount,
+    min_mint_threshold: bitcoin::Amount,
 }
 
 #[derive(Clone)]
 struct Parameters {
     pub min_confirmations: u32,
-    pub min_melt_sats: u64,
-    pub min_mint_sats: u64,
+    pub min_melt_threshold: bitcoin::Amount,
+    pub min_mint_threshold: bitcoin::Amount,
 }
 
 #[derive(Clone, FromRef)]
@@ -92,8 +92,8 @@ impl AppController {
             monitor_interval_sec,
             quote_expiry_seconds,
             min_confirmations,
-            min_melt_sats,
-            min_mint_sats,
+            min_melt_threshold,
+            min_mint_threshold,
         } = cfg;
 
         let wallet = debit::CDKWallet::new(sat_wallet, seed)
@@ -212,8 +212,8 @@ impl AppController {
             dev: Arc::new(dev),
             params: Parameters {
                 min_confirmations,
-                min_melt_sats,
-                min_mint_sats,
+                min_melt_threshold,
+                min_mint_threshold,
             },
         }
     }

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -102,7 +102,7 @@ pub async fn melt_quote_onchain(
     State(ctrl): State<AppController>,
     Json(request): Json<wire_melt::MeltQuoteOnchainRequest>,
 ) -> Result<Json<wire_melt::MeltQuoteOnchainResponse>> {
-    if request.request.amount < bitcoin::Amount::from_sat(ctrl.params.min_melt_sats) {
+    if request.request.amount < ctrl.params.min_melt_threshold {
         return Err(crate::error::Error::InsufficientOnchainMeltAmount(
             request.request.amount,
         ));
@@ -200,7 +200,7 @@ pub async fn mint_quote_onchain(
 ) -> Result<Json<wire_mint::MintQuoteOnchainResponse>> {
     tracing::debug!("Received mint_quote_onchain request");
 
-    if request.amount < bitcoin::Amount::from_sat(ctrl.params.min_mint_sats) {
+    if request.amount < ctrl.params.min_mint_threshold {
         return Err(crate::error::Error::InsufficientOnchainMintAmount(
             request.amount,
         ));

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -115,6 +115,25 @@ pub async fn melt_onchain(
     let quote_id = request.quote_id();
     tracing::debug!("Loading onchain melt quote with ID {}", quote_id);
     let onchain_data = ctrl.debit.repo.load_onchain_melt(*quote_id).await?;
+
+    let total_proofs: u64 = request
+        .inputs_amount()
+        .map_err(|_| crate::error::Error::InvalidInput(String::from("No amount for inputs")))?
+        .into();
+
+    tracing::info!(
+        "On chain melt request id {} total inputs {} sat addr {} original quote amount {}",
+        request.quote(),
+        onchain_data
+            .request
+            .request
+            .address
+            .clone()
+            .assume_checked(),
+        total_proofs,
+        onchain_data.request.request.amount
+    );
+
     let current_time = chrono::Utc::now().timestamp() as u64;
     if current_time > onchain_data.expiry {
         return Err(crate::error::Error::InvalidInput(String::from(
@@ -126,14 +145,10 @@ pub async fn melt_onchain(
         return Err(crate::error::Error::InvalidInput(String::from("No inputs")));
     }
 
-    let total_proofs: u64 = request
-        .inputs_amount()
-        .map_err(|_| crate::error::Error::InvalidInput(String::from("No amount for inputs")))?
-        .into();
     if total_proofs != onchain_data.request.request.amount.to_sat() {
-        return Err(crate::error::Error::InvalidInput(String::from(
-            "Requested amount mismatch",
-        )));
+        return Err(crate::error::Error::MeltAmountMismatch(
+            cashu::Amount::from(total_proofs),
+        ));
     }
     if let Some(clowder) = ctrl.clwdr_nats {
         tracing::debug!("Requesting onchain clowder melt transaction");
@@ -178,6 +193,12 @@ pub async fn mint_quote_onchain(
     Json(request): Json<wire_mint::MintQuoteOnchainRequest>,
 ) -> Result<Json<wire_mint::MintQuoteOnchainResponse>> {
     tracing::debug!("Received mint_quote_onchain request");
+
+    if request.amount < bitcoin::Amount::from_sat(ctrl.min_melt_sats) {
+        return Err(crate::error::Error::InsufficientOnchainMeltAmount(
+            request.amount,
+        ));
+    }
 
     let clowder_quote = Uuid::new_v4();
     // TODO update mint quote onchain to provide keyset id
@@ -270,6 +291,7 @@ pub async fn mint_onchain(
     let cdk_quote = Uuid::parse_str(&request.quote)
         .map_err(|_| crate::error::Error::InvalidInput(String::from("Invalid quote ID")))?;
     let data = ctrl.debit.repo.load_onchain_mint(cdk_quote).await?;
+
     let current_time = chrono::Utc::now().timestamp() as u64;
     if current_time > data.expiry {
         return Err(crate::error::Error::InvalidInput(String::from(
@@ -297,6 +319,14 @@ pub async fn mint_onchain(
         .iter()
         .fold(cashu::Amount::ZERO, |acc, o| acc + o.amount)
         .into();
+
+    tracing::info!("On chain mint cdk id {} clowder id {} total outputs {outputs_amount} payment received {}, original quote amount {}", data.cdk_quote, data.clowder_quote, payment_response.amount, outputs_amount);
+
+    if outputs_amount != u64::from(data.amount) {
+        return Err(crate::error::Error::MintAmountMismatch(
+            cashu::Amount::from(outputs_amount),
+        ));
+    }
 
     if outputs_amount > payment_response.amount.to_sat() {
         return Err(crate::error::Error::InvalidInput(format!(

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -102,7 +102,7 @@ pub async fn melt_quote_onchain(
     State(ctrl): State<AppController>,
     Json(request): Json<wire_melt::MeltQuoteOnchainRequest>,
 ) -> Result<Json<wire_melt::MeltQuoteOnchainResponse>> {
-    if request.request.amount < bitcoin::Amount::from_sat(ctrl.min_melt_sats) {
+    if request.request.amount < bitcoin::Amount::from_sat(ctrl.params.min_melt_sats) {
         return Err(crate::error::Error::InsufficientOnchainMeltAmount(
             request.request.amount,
         ));
@@ -200,6 +200,12 @@ pub async fn mint_quote_onchain(
 ) -> Result<Json<wire_mint::MintQuoteOnchainResponse>> {
     tracing::debug!("Received mint_quote_onchain request");
 
+    if request.amount < bitcoin::Amount::from_sat(ctrl.params.min_mint_sats) {
+        return Err(crate::error::Error::InsufficientOnchainMintAmount(
+            request.amount,
+        ));
+    }
+
     let clowder_quote = Uuid::new_v4();
     // TODO update mint quote onchain to provide keyset id
     // Which can be used later to select correct frost multisig
@@ -262,7 +268,7 @@ pub async fn get_mint_quote_onchain(
             .map_err(|_| crate::error::Error::InvalidInput(String::from("Invalid keyset ID")))?;
         let payment = ctrl
             .clwdr_rest
-            .verify_mint_payment(data.clowder_quote, dummy_kid, ctrl.min_confirmations)
+            .verify_mint_payment(data.clowder_quote, dummy_kid, ctrl.params.min_confirmations)
             .await?;
 
         if payment.amount.to_sat() >= data.amount.into() {
@@ -309,7 +315,7 @@ pub async fn mint_onchain(
 
     let payment_response = ctrl
         .clwdr_rest
-        .verify_mint_payment(data.clowder_quote, kid, ctrl.min_confirmations)
+        .verify_mint_payment(data.clowder_quote, kid, ctrl.params.min_confirmations)
         .await?;
 
     tracing::debug!("Clowder payment check {:?} sats", payment_response.amount);

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -99,10 +99,16 @@ pub async fn sat_offline_exchange(
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn melt_quote_onchain(
-    State(ctrl): State<debit::Service>,
+    State(ctrl): State<AppController>,
     Json(request): Json<wire_melt::MeltQuoteOnchainRequest>,
 ) -> Result<Json<wire_melt::MeltQuoteOnchainResponse>> {
-    let response = ctrl.create_onchain_melt_quote(request).await?;
+    if request.request.amount < bitcoin::Amount::from_sat(ctrl.min_melt_sats) {
+        return Err(crate::error::Error::InsufficientOnchainMeltAmount(
+            request.request.amount,
+        ));
+    }
+
+    let response = ctrl.debit.create_onchain_melt_quote(request).await?;
     Ok(Json(response))
 }
 
@@ -124,13 +130,13 @@ pub async fn melt_onchain(
     tracing::info!(
         "On chain melt request id {} total inputs {} sat addr {} original quote amount {}",
         request.quote(),
+        total_proofs,
         onchain_data
             .request
             .request
             .address
             .clone()
             .assume_checked(),
-        total_proofs,
         onchain_data.request.request.amount
     );
 
@@ -193,12 +199,6 @@ pub async fn mint_quote_onchain(
     Json(request): Json<wire_mint::MintQuoteOnchainRequest>,
 ) -> Result<Json<wire_mint::MintQuoteOnchainResponse>> {
     tracing::debug!("Received mint_quote_onchain request");
-
-    if request.amount < bitcoin::Amount::from_sat(ctrl.min_melt_sats) {
-        return Err(crate::error::Error::InsufficientOnchainMeltAmount(
-            request.amount,
-        ));
-    }
 
     let clowder_quote = Uuid::new_v4();
     // TODO update mint quote onchain to provide keyset id

--- a/docker/treasury-service/config.toml
+++ b/docker/treasury-service/config.toml
@@ -12,6 +12,7 @@ quote_expiry_seconds = 86400
 clwdr_nats_url = "nats://nats:4222"
 min_confirmations = 1
 min_melt_sats = 1000
+min_mint_sats = 1000
 
 [appcfg.credit_repo]
 connection = "ws://surrealdb:8000"

--- a/docker/treasury-service/config.toml
+++ b/docker/treasury-service/config.toml
@@ -11,8 +11,8 @@ signer_url = "nats://nats:4222"
 quote_expiry_seconds = 86400
 clwdr_nats_url = "nats://nats:4222"
 min_confirmations = 1
-min_melt_sats = 1000
-min_mint_sats = 1000
+min_melt_threshold = 1000
+min_mint_threshold = 1000
 
 [appcfg.credit_repo]
 connection = "ws://surrealdb:8000"

--- a/docker/treasury-service/config.toml
+++ b/docker/treasury-service/config.toml
@@ -11,6 +11,7 @@ signer_url = "nats://nats:4222"
 quote_expiry_seconds = 86400
 clwdr_nats_url = "nats://nats:4222"
 min_confirmations = 1
+min_melt_sats = 1000
 
 [appcfg.credit_repo]
 connection = "ws://surrealdb:8000"


### PR DESCRIPTION
Addresses #477 requiring melts to be above a configuration threshold

Also ensure minting blinded signatures match those in the original request
And adds additional tracing logs