### PR TITLE
mint/melt refactor

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -5,6 +5,12 @@ services:
     volumes:
       - ./docker/ebpp/config.toml:/ebpp/config.toml
       - ./.docker_data/ebpp/:/data/
+    healthcheck:
+      test:
+        ["CMD", "curl", "--fail", "http://localhost:3338/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
 
   key-service:
     image: wildcat/key-service

--- a/crates/bcr-wdc-ebpp/Cargo.toml
+++ b/crates/bcr-wdc-ebpp/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = {workspace = true}
 async-stream = {version = "0.3"}
 async-trait = { workspace = true}
 axum = { workspace = true, features = ["macros"]}
-bcr-common = {workspace = true}
+bcr-common = {workspace = true, features = ["authorized"]}
 bcr-ebill-core = {workspace = true}
 bcr-wdc-utils = {workspace = true}
 bcr-wdc-webapi = {workspace = true}
@@ -42,6 +42,7 @@ tracing-subscriber = {workspace = true, features = ["serde"]}
 uuid = {workspace = true}
 
 [dev-dependencies]
+bcr-common = {workspace = true, features = ["test-utils"]}
 mockall = {workspace = true}
 secp256k1 = {workspace = true, features = ["global-context"]}
 surrealdb = {workspace = true, features = ["kv-mem"]}

--- a/crates/bcr-wdc-ebpp/src/lib.rs
+++ b/crates/bcr-wdc-ebpp/src/lib.rs
@@ -109,9 +109,13 @@ pub fn routes(ctrl: AppController) -> Router {
         "/v1/admin/ebpp/",
         Router::new().route("/onchain/balance", get(admin::balance)),
     );
-    let web = Router::new().nest(
+    let web = Router::new().route("/health", get(get_health)).nest(
         "/v1/ebpp",
         Router::new().route("/onchain/network", get(web::network)),
     );
     Router::new().merge(admin).merge(web).with_state(ctrl)
+}
+
+async fn get_health() -> &'static str {
+    "{ \"status\": \"OK\" }"
 }

--- a/crates/bcr-wdc-ebpp/src/onchain.rs
+++ b/crates/bcr-wdc-ebpp/src/onchain.rs
@@ -146,14 +146,6 @@ impl<ElectrumApi> OnChainWallet for Wallet<ElectrumApi>
 where
     ElectrumApi: electrum_client::ElectrumApi + Sync + Send + 'static,
 {
-    fn generate_new_recipient(&self) -> Result<btc::Address> {
-        let mut locked = self.main.lock().unwrap();
-        let (wlt, db) = &mut *locked;
-        let address_info = wlt.reveal_next_address(KeychainKind::External);
-        wlt.persist(db)?;
-        Ok(address_info.address)
-    }
-
     fn network(&self) -> bdk_wallet::bitcoin::Network {
         self.network
     }
@@ -274,51 +266,35 @@ where
         Ok(amount)
     }
 
-    async fn send_to(
+    async fn sweep_address_to(
         &self,
+        address: btc::Address,
         recipient: btc::Address,
-        amount: btc::Amount,
         max_fee: btc::Amount,
-    ) -> Result<(btc::Txid, btc::Amount)> {
+    ) -> Result<btc::Txid> {
         wallets_sync(
             self.main.clone(),
             &self.singles,
             self.electrum_client.clone(),
         )
         .await?;
-        // 1. send from a single wallet whose balance is greater than amount + max_fee
-        {
-            let locked_singles = self.singles.lock().unwrap();
-            for wlt in locked_singles.iter() {
-                let locked = wlt.lock().unwrap();
-                if locked.0.balance().confirmed > amount + max_fee {
-                    let sweeping_address = {
-                        let mut locked = self.main.lock().unwrap();
-                        let (wlt, db) = &mut *locked;
-                        let address_info = wlt.reveal_next_address(KeychainKind::External);
-                        wlt.persist(db)?;
-                        address_info.address
-                    };
-                    return sweep_to(
-                        self.electrum_client.clone(),
-                        locked,
-                        recipient,
-                        sweeping_address,
-                        amount,
-                        max_fee,
-                    );
-                }
+        let script = address.script_pubkey();
+        let locked_singles = self.singles.lock().unwrap();
+        for wlt in locked_singles.iter() {
+            let locked = wlt.lock().unwrap();
+            let (wlt, _) = &*locked;
+            if !wlt.is_mine(script.clone()) {
+                continue;
             }
+            let txid = sweep_to(
+                self.electrum_client.clone(),
+                locked,
+                recipient.clone(),
+                max_fee,
+            )?;
+            return Ok(txid);
         }
-        // 2. send from the main wallet
-        let main_locked = self.main.lock().unwrap();
-        return send_to(
-            self.electrum_client.clone(),
-            main_locked,
-            recipient,
-            amount,
-            max_fee,
-        );
+        return Err(Error::UnknownAddress(address));
     }
 
     async fn is_confirmed(&self, tx_id: btc::Txid) -> Result<bool> {
@@ -485,16 +461,13 @@ where
     }
     Ok(())
 }
-
 // blocking function as we need to keep the wallet locked
 fn sweep_to<ElectrumApi>(
     electrum_client: Arc<BdkElectrumClient<ElectrumApi>>,
     mut locked_wlt: MutexGuard<PersistedBdkWallet>,
     recipient: btc::Address,
-    sweeping_address: btc::Address,
-    amount: btc::Amount,
     max_fee: btc::Amount,
-) -> Result<(btc::Txid, btc::Amount)>
+) -> Result<btc::Txid>
 where
     ElectrumApi: electrum_client::ElectrumApi,
 {
@@ -503,9 +476,8 @@ where
         let mut builder = wallet.build_tx();
         builder
             .ordering(TxOrdering::Untouched)
-            .add_recipient(recipient.script_pubkey(), amount)
             .drain_wallet()
-            .drain_to(sweeping_address.script_pubkey())
+            .drain_to(recipient.script_pubkey())
             .fee_absolute(max_fee);
         builder.finish().map_err(Error::BDKCreateTx)?
     };
@@ -521,54 +493,11 @@ where
     if !finalok {
         return Err(Error::BDKSignOpNotOK);
     }
-    let total_fee = psbt.fee()?;
     let tx = psbt.extract_tx()?;
     let txid = electrum_client.transaction_broadcast(&tx)?;
     wallet.persist(db)?;
-    let total_spent = amount + total_fee;
-    Ok((txid, total_spent))
+    Ok(txid)
 }
-
-// blocking function as we need to keep the wallet locked
-fn send_to<ElectrumApi>(
-    electrum_client: Arc<BdkElectrumClient<ElectrumApi>>,
-    mut locked_wlt: MutexGuard<PersistedBdkWallet>,
-    recipient: btc::Address,
-    amount: btc::Amount,
-    max_fee: btc::Amount,
-) -> Result<(btc::Txid, btc::Amount)>
-where
-    ElectrumApi: electrum_client::ElectrumApi,
-{
-    let (wallet, db) = &mut *locked_wlt;
-    let mut psbt = {
-        let mut builder = wallet.build_tx();
-        builder
-            .ordering(TxOrdering::Untouched)
-            .add_recipient(recipient.script_pubkey(), amount)
-            .fee_absolute(max_fee);
-        builder.finish().map_err(Error::BDKCreateTx)?
-    };
-    let signok = wallet
-        .sign(&mut psbt, bdk_wallet::SignOptions::default())
-        .map_err(Error::BDKSigner)?;
-    if !signok {
-        return Err(Error::BDKSignOpNotOK);
-    }
-    let finalok = wallet
-        .finalize_psbt(&mut psbt, bdk_wallet::SignOptions::default())
-        .map_err(Error::BDKSigner)?;
-    if !finalok {
-        return Err(Error::BDKSignOpNotOK);
-    }
-    let total_fee = psbt.fee()?;
-    let tx = psbt.extract_tx()?;
-    let txid = electrum_client.transaction_broadcast(&tx)?;
-    let total_spent = amount + total_fee;
-    wallet.persist(db)?;
-    Ok((txid, total_spent))
-}
-
 async fn timed_spawn_blocking<F, T>(
     note: &'static str,
     f: F,

--- a/crates/bcr-wdc-ebpp/src/payment.rs
+++ b/crates/bcr-wdc-ebpp/src/payment.rs
@@ -5,7 +5,6 @@ use cashu::{MeltQuoteState, MintQuoteState};
 use cdk_common::payment::PaymentIdentifier;
 use uuid::Uuid;
 // ----- local imports
-use crate::error::{Error, Result};
 
 // ----- end imports
 
@@ -16,19 +15,21 @@ pub struct IncomingRequest {
     pub amount: btc::Amount,
     pub status: MintQuoteState,
     pub expiration: Option<chrono::DateTime<chrono::Utc>>,
+    pub sweep_tx: Option<bdk_wallet::bitcoin::Txid>,
 }
 
 #[derive(Debug, Clone)]
 pub enum PaymentType {
-    OnChain(btc::Address),
-    EBill(btc::Address),
+    EBill {
+        recipient: btc::Address,
+        sweep: btc::Address,
+    },
     ClowderOnchain(Uuid),
 }
 impl PaymentType {
     pub fn recipient(&self) -> Option<btc::Address> {
         match self {
-            PaymentType::EBill(add) => Some(add.clone()),
-            PaymentType::OnChain(add) => Some(add.clone()),
+            PaymentType::EBill { recipient, .. } => Some(recipient.clone()),
             PaymentType::ClowderOnchain(_) => None,
         }
     }
@@ -53,33 +54,19 @@ impl std::fmt::Display for IncomingRequest {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OutgoingRequest {
     pub reqid: PaymentIdentifier,
-    pub recipient: btc::Address,
-    pub amount: btc::Amount,
-    pub reserved_fees: btc::Amount,
-    pub status: MeltQuoteState,
-    pub proof: Option<btc::Txid>,
-    pub total_spent: Option<btc::Amount>,
+    pub amount: cashu::Amount,
+    pub state: MeltQuoteState,
 }
-
 impl OutgoingRequest {
-    pub fn new(
-        reqid: PaymentIdentifier,
-        uri: bip21::Uri,
-        reserved_fees: btc::Amount,
-    ) -> Result<Self> {
-        let amount = uri.amount.ok_or(Error::UnknownAmount)?;
-        Ok(Self {
+    pub fn new(reqid: PaymentIdentifier, amount: cashu::Amount) -> Self {
+        Self {
             reqid,
-            recipient: uri.address,
             amount,
-            reserved_fees,
-            status: MeltQuoteState::Unpaid,
-            proof: None,
-            total_spent: None,
-        })
+            state: MeltQuoteState::Pending,
+        }
     }
 }
 

--- a/crates/bcr-wdc-ebpp/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-ebpp/src/persistence/inmemory.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{Error, Result},
     onchain::{PrivateKeysRepository, SingleSecretKeyDescriptor},
     payment::{ForeignPayment, IncomingRequest, OutgoingRequest},
-    service::PaymentRepository,
+    persistence::PaymentRepository,
 };
 
 // ----- end imports

--- a/crates/bcr-wdc-ebpp/src/persistence/mod.rs
+++ b/crates/bcr-wdc-ebpp/src/persistence/mod.rs
@@ -1,7 +1,31 @@
 // ----- standard library imports
 // ----- extra library imports
+use async_trait::async_trait;
+use cdk_common::payment::PaymentIdentifier;
+// ----- local imports
+use crate::{error::Result, payment};
 // ----- local modules
 pub mod inmemory;
 pub mod surreal;
 
 // ----- end imports
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait PaymentRepository: Send + Sync {
+    async fn load_incoming(&self, reqid: &PaymentIdentifier) -> Result<payment::IncomingRequest>;
+    async fn store_incoming(&self, req: payment::IncomingRequest) -> Result<()>;
+    async fn update_incoming(&self, req: payment::IncomingRequest) -> Result<()>;
+    async fn list_unpaid_incoming_requests(&self) -> Result<Vec<payment::IncomingRequest>>;
+
+    async fn load_outgoing(&self, reqid: &PaymentIdentifier) -> Result<payment::OutgoingRequest>;
+    async fn store_outgoing(&self, req: payment::OutgoingRequest) -> Result<()>;
+    async fn update_outgoing(&self, req: payment::OutgoingRequest) -> Result<()>;
+
+    async fn store_foreign(&self, new: payment::ForeignPayment) -> Result<()>;
+    async fn check_foreign_nonce(&self, nonce: &str) -> Result<Option<payment::ForeignPayment>>;
+    async fn check_foreign_reqid(
+        &self,
+        reqid: &PaymentIdentifier,
+    ) -> Result<Option<payment::ForeignPayment>>;
+}

--- a/crates/bcr-wdc-ebpp/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-ebpp/src/persistence/surreal.rs
@@ -20,7 +20,7 @@ use crate::{
     error::{Error, Result},
     onchain::{PrivateKeysRepository, SingleSecretKeyDescriptor},
     payment::{ForeignPayment, IncomingRequest, OutgoingRequest, PaymentType},
-    service::PaymentRepository,
+    persistence::PaymentRepository,
 };
 
 // ----- end imports
@@ -115,33 +115,33 @@ impl PrivateKeysRepository for DBPrivateKeys {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum PaymentTypeDBEntry {
-    OnChain(btc::Address<btc::address::NetworkUnchecked>),
-    EBill(btc::Address<btc::address::NetworkUnchecked>),
+    EBill {
+        recipient: btc::Address<btc::address::NetworkUnchecked>,
+        sweep: btc::Address<btc::address::NetworkUnchecked>,
+    },
     ClowderOnchain(uuid::Uuid),
 }
 impl std::convert::From<PaymentType> for PaymentTypeDBEntry {
     fn from(pt: PaymentType) -> Self {
         match pt {
-            PaymentType::OnChain(addr) => PaymentTypeDBEntry::OnChain(addr.into_unchecked()),
-            PaymentType::EBill(addr) => PaymentTypeDBEntry::EBill(addr.into_unchecked()),
+            PaymentType::EBill { recipient, sweep } => PaymentTypeDBEntry::EBill {
+                recipient: recipient.into_unchecked(),
+                sweep: sweep.into_unchecked(),
+            },
             PaymentType::ClowderOnchain(uuid) => PaymentTypeDBEntry::ClowderOnchain(uuid),
         }
     }
 }
 fn into_payment_type(pt: PaymentTypeDBEntry, network: btc::Network) -> Result<PaymentType> {
     match pt {
-        PaymentTypeDBEntry::OnChain(addr) => {
-            let addr = addr
+        PaymentTypeDBEntry::EBill { recipient, sweep } => Ok(PaymentType::EBill {
+            recipient: recipient
                 .require_network(network)
-                .map_err(Error::BTCAddressParse)?;
-            Ok(PaymentType::OnChain(addr))
-        }
-        PaymentTypeDBEntry::EBill(addr) => {
-            let addr = addr
+                .map_err(Error::BTCAddressParse)?,
+            sweep: sweep
                 .require_network(network)
-                .map_err(Error::BTCAddressParse)?;
-            Ok(PaymentType::EBill(addr))
-        }
+                .map_err(Error::BTCAddressParse)?,
+        }),
         PaymentTypeDBEntry::ClowderOnchain(uuid) => Ok(PaymentType::ClowderOnchain(uuid)),
     }
 }
@@ -153,6 +153,7 @@ struct IncomingPaymentDBEntry {
     payment_type: PaymentTypeDBEntry,
     status: cdk_common::MintQuoteState,
     expiration: Option<chrono::DateTime<chrono::Utc>>,
+    sweep_tx: Option<bdk_wallet::bitcoin::Txid>,
 }
 impl std::convert::From<IncomingRequest> for IncomingPaymentDBEntry {
     fn from(req: IncomingRequest) -> Self {
@@ -162,6 +163,7 @@ impl std::convert::From<IncomingRequest> for IncomingPaymentDBEntry {
             payment_type: req.payment_type.into(),
             status: req.status,
             expiration: req.expiration,
+            sweep_tx: req.sweep_tx,
         }
     }
 }
@@ -176,45 +178,30 @@ fn into_incoming_request(
         payment_type: ttype,
         status: dbreq.status,
         expiration: dbreq.expiration,
+        sweep_tx: dbreq.sweep_tx,
     })
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct OutgoingPaymentDBEntry {
     reqid: PaymentIdentifier,
-    recipient: btc::Address<btc::address::NetworkUnchecked>,
-    amount: btc::Amount,
-    reserved_fees: btc::Amount,
-    status: cdk_common::MeltQuoteState,
-    proof: Option<btc::Txid>,
-    total_spent: Option<btc::Amount>,
+    amount: cashu::Amount,
+    state: cdk_common::MeltQuoteState,
 }
 impl std::convert::From<OutgoingRequest> for OutgoingPaymentDBEntry {
     fn from(req: OutgoingRequest) -> Self {
         Self {
             reqid: req.reqid,
             amount: req.amount,
-            reserved_fees: req.reserved_fees,
-            status: req.status,
-            recipient: req.recipient.into_unchecked(),
-            proof: req.proof,
-            total_spent: req.total_spent,
+            state: req.state,
         }
     }
 }
-fn into_outgoing_request(
-    dbreq: OutgoingPaymentDBEntry,
-    network: btc::Network,
-) -> Result<OutgoingRequest> {
-    let recipient = dbreq.recipient.require_network(network)?;
+fn into_outgoing_request(dbreq: OutgoingPaymentDBEntry) -> Result<OutgoingRequest> {
     Ok(OutgoingRequest {
         reqid: dbreq.reqid,
         amount: dbreq.amount,
-        reserved_fees: dbreq.reserved_fees,
-        recipient,
-        status: dbreq.status,
-        proof: dbreq.proof,
-        total_spent: dbreq.total_spent,
+        state: dbreq.state,
     })
 }
 
@@ -377,7 +364,7 @@ impl PaymentRepository for DBPayments {
             .await
             .map_err(|e| Error::DB(anyhow!(e)))?;
         let dbreq = dbreq.ok_or(Error::PaymentRequestNotFound(reqid.clone()))?;
-        into_outgoing_request(dbreq, self.network)
+        into_outgoing_request(dbreq)
     }
 
     async fn store_outgoing(&self, req: OutgoingRequest) -> Result<()> {
@@ -387,6 +374,7 @@ impl PaymentRepository for DBPayments {
             .map_err(|e| Error::DB(anyhow!(e)))?;
         Ok(())
     }
+
     async fn update_outgoing(&self, req: OutgoingRequest) -> Result<()> {
         let reqid = req.reqid.clone();
         let res: Option<OutgoingPaymentDBEntry> = self
@@ -482,8 +470,12 @@ mod tests {
             reqid: PaymentIdentifier::PaymentId(rand::random()),
             amount: btc::Amount::ZERO,
             expiration: None,
-            payment_type: PaymentTypeDBEntry::OnChain(address.clone()),
+            payment_type: PaymentTypeDBEntry::EBill {
+                recipient: address.clone().into_unchecked(),
+                sweep: address.clone().into_unchecked(),
+            },
             status: MintQuoteState::Unpaid,
+            sweep_tx: None,
         };
         unpaids.push(unpaid1.reqid.clone());
         let rid = RecordId::from_table_key(&db.incoming_table, unpaid1.reqid.to_string());
@@ -493,8 +485,12 @@ mod tests {
             reqid: PaymentIdentifier::PaymentId(rand::random()),
             amount: btc::Amount::ZERO,
             expiration: None,
-            payment_type: PaymentTypeDBEntry::OnChain(address.clone()),
+            payment_type: PaymentTypeDBEntry::EBill {
+                recipient: address.clone().into_unchecked(),
+                sweep: address.clone().into_unchecked(),
+            },
             status: MintQuoteState::Paid,
+            sweep_tx: None,
         };
         let rid = RecordId::from_table_key(&db.incoming_table, paid1.reqid.to_string());
         let _: Option<IncomingPaymentDBEntry> = db.db.insert(rid).content(paid1).await.unwrap();
@@ -503,8 +499,12 @@ mod tests {
             reqid: PaymentIdentifier::PaymentId(rand::random()),
             amount: btc::Amount::ZERO,
             expiration: None,
-            payment_type: PaymentTypeDBEntry::OnChain(address.clone()),
+            payment_type: PaymentTypeDBEntry::EBill {
+                recipient: address.clone().into_unchecked(),
+                sweep: address.clone().into_unchecked(),
+            },
             status: MintQuoteState::Unpaid,
+            sweep_tx: None,
         };
         unpaids.push(unpaid2.reqid.clone());
         let rid = RecordId::from_table_key(&db.incoming_table, unpaid2.reqid.to_string());

--- a/crates/bcr-wdc-ebpp/src/service.rs
+++ b/crates/bcr-wdc-ebpp/src/service.rs
@@ -7,7 +7,6 @@ use std::{
     time::Duration,
 };
 // ----- extra library imports
-use anyhow::anyhow;
 use async_trait::async_trait;
 use bcr_common::{
     core::{
@@ -25,7 +24,7 @@ use cdk_common::{
         IncomingPaymentOptions, MakePaymentResponse, MintPayment, OutgoingPaymentOptions,
         PaymentIdentifier, PaymentQuoteResponse, WaitPaymentResponse,
     },
-    {Amount, CurrencyUnit},
+    CurrencyUnit,
 };
 use futures::Stream;
 use tokio::sync::mpsc;
@@ -34,7 +33,9 @@ use uuid::Uuid;
 // ----- local imports
 use crate::{
     error::{Error, Result},
-    payment, TStamp,
+    payment,
+    persistence::PaymentRepository,
+    TStamp,
 };
 
 // ----- end imports
@@ -43,40 +44,19 @@ type PaymentResult<T> = std::result::Result<T, PaymentError>;
 
 #[async_trait]
 pub trait OnChainWallet: Send + Sync {
-    fn generate_new_recipient(&self) -> Result<btc::Address>;
     fn network(&self) -> btc::Network;
     async fn add_descriptor(&self, descriptor: &str) -> Result<btc::Address>;
     async fn balance(&self) -> Result<bdk_wallet::Balance>;
     async fn get_address_balance(&self, recipient: &btc::Address) -> Result<btc::Amount>;
     async fn estimate_fees(&self) -> Result<btc::Amount>;
     // returns (transaction_id, total_spent_fee)
-    async fn send_to(
+    async fn sweep_address_to(
         &self,
+        address: btc::Address,
         recipient: btc::Address,
-        amount: btc::Amount,
         max_fee: btc::Amount,
-    ) -> Result<(btc::Txid, btc::Amount)>;
+    ) -> Result<btc::Txid>;
     async fn is_confirmed(&self, tx_id: btc::Txid) -> Result<bool>;
-}
-
-#[cfg_attr(test, mockall::automock)]
-#[async_trait]
-pub trait PaymentRepository: Send + Sync {
-    async fn load_incoming(&self, reqid: &PaymentIdentifier) -> Result<payment::IncomingRequest>;
-    async fn store_incoming(&self, req: payment::IncomingRequest) -> Result<()>;
-    async fn update_incoming(&self, req: payment::IncomingRequest) -> Result<()>;
-    async fn list_unpaid_incoming_requests(&self) -> Result<Vec<payment::IncomingRequest>>;
-
-    async fn load_outgoing(&self, reqid: &PaymentIdentifier) -> Result<payment::OutgoingRequest>;
-    async fn store_outgoing(&self, req: payment::OutgoingRequest) -> Result<()>;
-    async fn update_outgoing(&self, req: payment::OutgoingRequest) -> Result<()>;
-
-    async fn store_foreign(&self, new: payment::ForeignPayment) -> Result<()>;
-    async fn check_foreign_nonce(&self, nonce: &str) -> Result<Option<payment::ForeignPayment>>;
-    async fn check_foreign_reqid(
-        &self,
-        reqid: &PaymentIdentifier,
-    ) -> Result<Option<payment::ForeignPayment>>;
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -172,7 +152,7 @@ impl MintPayment for Service {
         let amount = btc::Amount::from_sat(options.amount.into());
         let parsed_description = ParsedDescription::parse(&options.description.unwrap_or_default());
         let payment_type = match parsed_description {
-            ParsedDescription::ForeignECash(request) => {
+            Ok(ParsedDescription::ForeignECash(request)) => {
                 tracing::debug!("Parsed foreign ecash request",);
                 let payload: web_exchange::RequestToMintFromForeigneCashPayload =
                     deserialize_borsh_msg(&request.payload).map_err(Error::from)?;
@@ -196,21 +176,27 @@ impl MintPayment for Service {
                 self.payrepo.store_foreign(foreign).await?;
                 return Ok(response);
             }
-            ParsedDescription::EbillRequestToPay(request) => {
+            Ok(ParsedDescription::EbillRequestToPay(request)) => {
                 tracing::trace!("Parsed EBill request",);
-                let message: wire_signatures::RequestToMintFromEBillDesc =
-                    deserialize_borsh_msg(&request.content).map_err(Error::from)?;
                 schnorr_verify_b64(&request.content, &request.signature, &self.treasury_pubkey)
                     .map_err(Error::from)?;
+                let message: wire_signatures::RequestToMintFromEBillDesc =
+                    deserialize_borsh_msg(&request.content).map_err(Error::from)?;
                 let output = self
                     .ebill
                     .request_to_pay(&message.ebill_id, amount, message.deadline)
                     .await?;
                 let recipient = self.onchain.add_descriptor(&output).await?;
-                payment::PaymentType::EBill(recipient)
+                let sweep = btc::Address::from_str(&message.sweeping_address)
+                    .map_err(|_| PaymentError::UnsupportedPaymentOption)?
+                    .require_network(self.onchain.network())
+                    .map_err(|_| PaymentError::UnsupportedPaymentOption)?;
+                payment::PaymentType::EBill { recipient, sweep }
             }
-            ParsedDescription::ClowderOnchain(uuid) => payment::PaymentType::ClowderOnchain(uuid),
-            ParsedDescription::Dev => {
+            Ok(ParsedDescription::ClowderOnchain(uuid)) => {
+                payment::PaymentType::ClowderOnchain(uuid)
+            }
+            Ok(ParsedDescription::Dev) => {
                 let idx: u32 = rand::random();
                 let pid = PaymentIdentifier::Label(format!("dev{idx}"));
                 self.dev_payments
@@ -223,12 +209,9 @@ impl MintPayment for Service {
                     expiry: None,
                 });
             }
-            ParsedDescription::None => {
-                let recipient = self
-                    .onchain
-                    .generate_new_recipient()
-                    .map_err(PaymentError::from)?;
-                payment::PaymentType::OnChain(recipient)
+            Err(e) => {
+                tracing::error!("Empty or unrecognized description field");
+                return Err(e);
             }
         };
         let expiration = options
@@ -240,6 +223,7 @@ impl MintPayment for Service {
             amount,
             expiration,
             status: MintQuoteState::Unpaid,
+            sweep_tx: None,
         };
         let reqid = request.reqid.clone();
         let recipient = request.payment_type.recipient();
@@ -288,17 +272,21 @@ impl MintPayment for Service {
             return Err(PaymentError::UnsupportedPaymentOption);
         };
         let description = options.bolt11.description().to_string();
-        let uri = parse_to_bip21_uri(&description, self.onchain.network())?;
-        let fees_btc = self.onchain.estimate_fees().await?;
-        let fee = Amount::from(fees_btc.to_sat());
-        let reqid = PaymentIdentifier::CustomId(Uuid::new_v4().to_string());
-        let outgoing = payment::OutgoingRequest::new(reqid, uri, fees_btc)?;
+        let request: wire_signatures::SignedRequestToMeltDesc =
+            serde_json::from_str(&description).map_err(PaymentError::Serde)?;
+        schnorr_verify_b64(&request.content, &request.signature, &self.treasury_pubkey)
+            .map_err(|_| PaymentError::UnsupportedPaymentOption)?;
+        let content: wire_signatures::RequestToMeltDesc =
+            deserialize_borsh_msg(&request.content)
+                .map_err(|_| PaymentError::UnsupportedPaymentOption)?;
+        let reqid = PaymentIdentifier::CustomId(content.qid.to_string());
+        let outgoing = payment::OutgoingRequest::new(reqid, content.amount);
         let response = PaymentQuoteResponse {
             request_lookup_id: Some(outgoing.reqid.clone()),
-            amount: Amount::from(outgoing.amount.to_sat()),
+            amount: content.amount,
             unit: CurrencyUnit::Sat,
-            fee,
-            state: outgoing.status,
+            fee: cashu::Amount::ZERO,
+            state: MeltQuoteState::Paid,
         };
         self.payrepo.store_outgoing(outgoing).await?;
         Ok(response)
@@ -317,59 +305,38 @@ impl MintPayment for Service {
         let OutgoingPaymentOptions::Bolt11(options) = options else {
             return Err(PaymentError::UnsupportedPaymentOption);
         };
-        let reqid = PaymentIdentifier::CustomId(options.bolt11.description().to_string());
-        let outgoing = self.payrepo.load_outgoing(&reqid).await;
-        let mut request = match outgoing {
-            Ok(request) => match request.status {
-                MeltQuoteState::Paid => return Err(PaymentError::InvoiceAlreadyPaid),
-                MeltQuoteState::Pending => return Err(PaymentError::InvoicePaymentPending),
-                _ => request,
-            },
-            Err(Error::PaymentRequestNotFound(_)) => return Err(PaymentError::UnknownPaymentState),
-            Err(e) => return Err(e.into()),
-        };
-
-        let quote_amount = btc::Amount::from_sat(
-            options.bolt11.amount_milli_satoshis().unwrap_or_default() / 1000,
-        );
-        if request.amount != quote_amount {
-            return Err(PaymentError::Amount(
-                cdk_common::amount::Error::InvalidAmount(format!(
-                    "melt_quote.amount {quote_amount} != request.amount {}",
-                    request.amount
-                )),
-            ));
+        let description = options.bolt11.description().to_string();
+        let request: wire_signatures::SignedRequestToMeltDesc =
+            serde_json::from_str(&description).map_err(PaymentError::Serde)?;
+        schnorr_verify_b64(&request.content, &request.signature, &self.treasury_pubkey)
+            .map_err(|_| PaymentError::UnsupportedPaymentOption)?;
+        let content: wire_signatures::RequestToMeltDesc =
+            deserialize_borsh_msg(&request.content)
+                .map_err(|_| PaymentError::UnsupportedPaymentOption)?;
+        let invoice_amount =
+            cashu::Amount::from(options.bolt11.amount_milli_satoshis().unwrap_or_default() / 1000);
+        if invoice_amount != content.amount {
+            return Err(PaymentError::Amount(cashu::amount::Error::InvalidAmount(
+                format!(
+                    "Invoice amount {invoice_amount} does not match requested amount {}",
+                    content.amount
+                ),
+            )));
         }
-        request.status = MeltQuoteState::Pending;
-        self.payrepo.update_outgoing(request.clone()).await?;
-        let (tx_id, total_fee) = self
-            .onchain
-            .send_to(
-                request.recipient.clone(),
-                request.amount,
-                request.reserved_fees,
-            )
-            .await?;
-        request.proof = Some(tx_id);
-        let total_spent = request.amount + total_fee;
-        request.total_spent = Some(total_spent);
-        let store_result = self.payrepo.update_outgoing(request.clone()).await;
-        if let Err(e) = store_result {
-            tracing::error!(
-                "Error in storing proof for reqid {}, tx_id {tx_id}, e: {e}",
-                request.reqid
-            );
+        let reqid = PaymentIdentifier::CustomId(content.qid.to_string());
+        let mut outgoing = self.payrepo.load_outgoing(&reqid).await?;
+        if matches!(outgoing.state, MeltQuoteState::Paid) {
+            return Err(PaymentError::InvoiceAlreadyPaid);
         }
-
-        let total_spent = Amount::from(total_spent.to_sat());
         let response = MakePaymentResponse {
-            payment_lookup_id: reqid,
-            payment_proof: Some(tx_id.to_string()),
-            status: MeltQuoteState::Pending,
-            total_spent,
+            payment_lookup_id: outgoing.reqid.clone(),
+            payment_proof: None,
+            status: MeltQuoteState::Paid,
+            total_spent: outgoing.amount,
             unit: CurrencyUnit::Sat,
         };
-
+        outgoing.state = MeltQuoteState::Paid;
+        self.payrepo.update_outgoing(outgoing).await?;
         Ok(response)
     }
 
@@ -412,6 +379,7 @@ impl MintPayment for Service {
     ) -> PaymentResult<Vec<WaitPaymentResponse>> {
         let _span = tracing::debug_span!("check_incoming_payment_status");
 
+        // Dev payment
         if let Some(amount) = self.dev_payments.lock().unwrap().get(payment_identifier) {
             return Ok(vec![WaitPaymentResponse {
                 payment_identifier: payment_identifier.clone(),
@@ -421,6 +389,7 @@ impl MintPayment for Service {
             }]);
         }
 
+        // Foreign eCash payment
         let mut response = Vec::new();
         let foreign = self.payrepo.check_foreign_reqid(payment_identifier).await?;
         if let Some(foreign) = foreign {
@@ -433,31 +402,77 @@ impl MintPayment for Service {
             });
             return Ok(response);
         }
-        // nothing to look at, proceed
+
+        // E-Bill payment
         let mut request = self.payrepo.load_incoming(payment_identifier).await?;
-        if request.status == MintQuoteState::Unpaid {
-            request.status = if let Some(recipient) = request.payment_type.recipient() {
-                check_incoming_payment(&recipient, request.amount, self.onchain.as_ref()).await?
-            } else {
-                MintQuoteState::Paid
-            };
-            self.payrepo.update_incoming(request.clone()).await?;
-        }
-        if request.status == MintQuoteState::Paid {
-            let payment_id = request
-                .payment_type
-                .recipient()
-                .map(|a| a.to_string())
-                .or_else(|| request.payment_type.clowder_quote().map(|u| u.to_string()))
-                .unwrap_or_default();
-            response.push(WaitPaymentResponse {
+        match (request.status, request.payment_type.clone()) {
+            (MintQuoteState::Unpaid, payment::PaymentType::ClowderOnchain(_)) => {
+                request.status = MintQuoteState::Paid;
+                self.payrepo.update_incoming(request.clone()).await?;
+                Ok(vec![WaitPaymentResponse {
+                    payment_identifier: payment_identifier.clone(),
+                    payment_amount: cashu::Amount::from(request.amount.to_sat()),
+                    unit: CurrencyUnit::Sat,
+                    payment_id: payment_identifier.to_string(),
+                }])
+            }
+            (MintQuoteState::Unpaid, payment::PaymentType::EBill { recipient, sweep }) => {
+                let state =
+                    check_incoming_payment(&recipient, request.amount, self.onchain.as_ref())
+                        .await?;
+                match state {
+                    MintQuoteState::Unpaid => Ok(vec![]),
+                    MintQuoteState::Paid => {
+                        request.status = MintQuoteState::Paid;
+                        let max_fees = self.onchain.estimate_fees().await?;
+                        let txid = self
+                            .onchain
+                            .sweep_address_to(recipient, sweep, max_fees)
+                            .await?;
+                        request.sweep_tx = Some(txid);
+                        self.payrepo.update_incoming(request).await?;
+                        Ok(vec![])
+                    }
+                    _ => Err(PaymentError::UnknownPaymentState),
+                }
+            }
+            (MintQuoteState::Paid, payment::PaymentType::ClowderOnchain(_)) => {
+                request.status = MintQuoteState::Issued;
+                self.payrepo.update_incoming(request.clone()).await?;
+                Ok(vec![WaitPaymentResponse {
+                    payment_identifier: payment_identifier.clone(),
+                    payment_amount: cashu::Amount::from(request.amount.to_sat()),
+                    unit: CurrencyUnit::Sat,
+                    payment_id: payment_identifier.to_string(),
+                }])
+            }
+            (MintQuoteState::Paid, payment::PaymentType::EBill { .. }) => match request.sweep_tx {
+                Some(txid) => {
+                    if self.onchain.is_confirmed(txid).await? {
+                        request.status = MintQuoteState::Issued;
+                        self.payrepo.update_incoming(request.clone()).await?;
+                        Ok(vec![WaitPaymentResponse {
+                            payment_identifier: payment_identifier.clone(),
+                            payment_amount: cashu::Amount::from(request.amount.to_sat()),
+                            unit: CurrencyUnit::Sat,
+                            payment_id: payment_identifier.to_string(),
+                        }])
+                    } else {
+                        Ok(vec![])
+                    }
+                }
+                None => {
+                    tracing::error!("No sweep transaction found for paid E-Bill payment");
+                    return Err(PaymentError::UnknownPaymentState);
+                }
+            },
+            (MintQuoteState::Issued, _) => Ok(vec![WaitPaymentResponse {
                 payment_identifier: payment_identifier.clone(),
                 payment_amount: cashu::Amount::from(request.amount.to_sat()),
                 unit: CurrencyUnit::Sat,
-                payment_id,
-            });
+                payment_id: payment_identifier.to_string(),
+            }]),
         }
-        Ok(response)
     }
 
     async fn check_outgoing_payment(
@@ -466,22 +481,15 @@ impl MintPayment for Service {
     ) -> PaymentResult<MakePaymentResponse> {
         let _span = tracing::debug_span!("check_outgoing_payment", payment_identifier = %payment_identifier);
 
-        let mut request = self.payrepo.load_outgoing(payment_identifier).await?;
-        let total_spent = Amount::from(request.total_spent.unwrap_or(request.amount).to_sat());
+        let request = self.payrepo.load_outgoing(payment_identifier).await?;
+        let total_spent = request.amount;
         let response = MakePaymentResponse {
             payment_lookup_id: payment_identifier.clone(),
-            payment_proof: request.proof.map(|txid| txid.to_string()),
+            payment_proof: None,
             unit: CurrencyUnit::Sat,
-            status: request.status,
+            status: MeltQuoteState::Paid,
             total_spent,
         };
-        if matches!(request.status, MeltQuoteState::Paid) {
-            return Ok(response);
-        }
-
-        let new_state = check_outgoing_payment(request.proof, self.onchain.as_ref()).await?;
-        request.status = new_state;
-        self.payrepo.update_outgoing(request).await?;
         Ok(response)
     }
 }
@@ -530,55 +538,32 @@ async fn check_incoming_payment(
     }
 }
 
-async fn check_outgoing_payment(
-    tx_id: Option<btc::Txid>,
-    onchain: &dyn OnChainWallet,
-) -> Result<cdk_common::MeltQuoteState> {
-    if let Some(tx_id) = tx_id {
-        if onchain.is_confirmed(tx_id).await? {
-            Ok(cdk_common::MeltQuoteState::Paid)
-        } else {
-            Ok(cdk_common::MeltQuoteState::Pending)
-        }
-    } else {
-        Ok(cdk_common::MeltQuoteState::Unpaid)
-    }
-}
-
-fn parse_to_bip21_uri(input: &str, network: btc::Network) -> Result<bip21::Uri<'_>> {
-    bip21::Uri::from_str(input)
-        .map_err(|e| Error::Bip21Parse(anyhow!(e)))?
-        .require_network(network)
-        .map_err(|e| Error::Bip21Parse(anyhow!(e)))
-}
-
 enum ParsedDescription {
     Dev,
     EbillRequestToPay(wire_signatures::SignedRequestToMintFromEBillDesc),
     ForeignECash(web_exchange::RequestToMintFromForeigneCash),
     ClowderOnchain(Uuid),
-    None,
 }
 impl ParsedDescription {
-    fn parse(input: &str) -> Self {
+    fn parse(input: &str) -> PaymentResult<Self> {
         if let Ok(ebill_request) =
             serde_json::from_str::<wire_signatures::SignedRequestToMintFromEBillDesc>(input)
         {
-            Self::EbillRequestToPay(ebill_request)
+            Ok(Self::EbillRequestToPay(ebill_request))
         } else if let Ok(foreign_ecash_request) =
             serde_json::from_str::<web_exchange::RequestToMintFromForeigneCash>(input)
         {
-            Self::ForeignECash(foreign_ecash_request)
+            Ok(Self::ForeignECash(foreign_ecash_request))
         } else if let Some(uuid_str) = input.strip_prefix("clowder:") {
             if let Ok(uuid) = Uuid::parse_str(uuid_str) {
-                Self::ClowderOnchain(uuid)
+                Ok(Self::ClowderOnchain(uuid))
             } else {
-                Self::None
+                Err(PaymentError::UnsupportedPaymentOption)
             }
         } else if input == "it's me, Mario" {
-            Self::Dev
+            Ok(Self::Dev)
         } else {
-            Self::None
+            Err(PaymentError::UnsupportedPaymentOption)
         }
     }
 }
@@ -586,27 +571,23 @@ impl ParsedDescription {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persistence::MockPaymentRepository;
+    use bcr_common::{
+        core::signature::serialize_n_schnorr_sign_borsh_msg, core_tests::generate_random_keypair,
+    };
     use bdk_wallet::bitcoin::hashes::{sha256, Hash};
     use cashu::lightning_invoice as ln;
     use cdk_common::payment::{Bolt11IncomingPaymentOptions, Bolt11OutgoingPaymentOptions};
     use mockall::predicate::*;
 
-    fn generate_random_pubkey() -> btc::XOnlyPublicKey {
-        let kp = btc::key::Keypair::new(secp256k1::global::SECP256K1, &mut rand::thread_rng());
-        btc::XOnlyPublicKey::from_keypair(&kp).0
-    }
-
-    fn generate_random_address() -> btc::Address {
-        let sk = btc::PrivateKey::generate(btc::Network::Testnet);
-        let pk =
-            btc::CompressedPublicKey::from_private_key(secp256k1::global::SECP256K1, &sk).unwrap();
-        btc::Address::p2wpkh(&pk, btc::Network::Testnet)
-    }
-
-    fn generate_fake_bolt11(description: String, amount: cashu::Amount) -> ln::Bolt11Invoice {
+    fn generate_fake_bolt11(
+        description: wire_signatures::SignedRequestToMeltDesc,
+        amount: cashu::Amount,
+    ) -> ln::Bolt11Invoice {
         let payment_hash = sha256::Hash::from_slice(&[0; 32][..]).unwrap();
         let payment_secret = ln::PaymentSecret([42u8; 32]);
         let sk = secp256k1::SecretKey::new(&mut rand::thread_rng());
+        let description = serde_json::to_string(&description).unwrap();
         ln::InvoiceBuilder::new(ln::Currency::Bitcoin)
             .description(description)
             .payment_hash(payment_hash)
@@ -622,18 +603,17 @@ mod tests {
         OnChainWallet{}
         #[async_trait]
         impl OnChainWallet for OnChainWallet {
-            fn generate_new_recipient(&self) -> Result<btc::Address>;
             fn network(&self) -> btc::Network;
             async fn add_descriptor(&self, descriptor: &str) -> Result<btc::Address>;
             async fn balance(&self) -> Result<bdk_wallet::Balance>;
             async fn get_address_balance(&self, recipient: &btc::Address) -> Result<btc::Amount>;
             async fn estimate_fees(&self) -> Result<btc::Amount>;
-            async fn send_to(
+            async fn sweep_address_to(
                 &self,
+                address: btc::Address,
                 recipient: btc::Address,
-                amount: btc::Amount,
                 max_fee: btc::Amount,
-            ) -> Result<(btc::Txid, btc::Amount)>;
+            ) -> Result<btc::Txid>;
             async fn is_confirmed(&self, tx_id: btc::Txid) -> Result<bool>;
         }
 
@@ -649,7 +629,15 @@ mod tests {
         let payrepo = Arc::new(MockPaymentRepository::new());
         let ebill = Arc::new(MockEBillNode::new());
         let interval = Duration::from_secs(1);
-        let srvc = Service::new(onchain, payrepo, ebill, interval, generate_random_pubkey()).await;
+        let tkp = generate_random_keypair();
+        let srvc = Service::new(
+            onchain,
+            payrepo,
+            ebill,
+            interval,
+            tkp.public_key().x_only_public_key().0,
+        )
+        .await;
         let result = srvc
             .create_incoming_payment_request(
                 &CurrencyUnit::Usd,
@@ -664,13 +652,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_incoming_payment_request_getnewaddress() {
-        let address = generate_random_address();
-        let cloned_address = address.clone();
-        let mut onchain = MockOnChainWallet::new();
-        onchain
-            .expect_generate_new_recipient()
-            .returning(move || Ok(address.clone()));
+    async fn create_incoming_payment_request_no_description() {
+        let onchain = MockOnChainWallet::new();
+        let tkp = generate_random_keypair();
         let mut payrepo = MockPaymentRepository::new();
         payrepo.expect_store_incoming().returning(|_| Ok(()));
         let ebill = Arc::new(MockEBillNode::new());
@@ -680,7 +664,7 @@ mod tests {
             Arc::new(payrepo),
             ebill,
             interval,
-            generate_random_pubkey(),
+            tkp.x_only_public_key().0,
         )
         .await;
         let result = srvc
@@ -692,13 +676,8 @@ mod tests {
                     unix_expiry: None,
                 }),
             )
-            .await
-            .unwrap();
-        let uri: bip21::Uri = bip21::Uri::from_str(&result.request)
-            .unwrap()
-            .require_network(btc::Network::Testnet)
-            .unwrap();
-        assert_eq!(uri.address, cloned_address);
+            .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -707,12 +686,22 @@ mod tests {
         let payrepo = Arc::new(MockPaymentRepository::new());
         let ebill = Arc::new(MockEBillNode::new());
         let interval = Duration::from_secs(1);
-        let srvc = Service::new(onchain, payrepo, ebill, interval, generate_random_pubkey()).await;
+        let tkp = generate_random_keypair();
+        let srvc = Service::new(onchain, payrepo, ebill, interval, tkp.x_only_public_key().0).await;
+        let description = wire_signatures::RequestToMeltDesc {
+            qid: Uuid::new_v4(),
+            amount: cashu::Amount::ZERO,
+        };
+        let (content, payload) = serialize_n_schnorr_sign_borsh_msg(&description, &tkp).unwrap();
+        let signed_desc = wire_signatures::SignedRequestToMeltDesc {
+            content,
+            signature: payload,
+        };
         let result = srvc
             .make_payment(
                 &cashu::CurrencyUnit::Usd,
                 OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
-                    bolt11: generate_fake_bolt11(String::default(), cashu::Amount::ZERO),
+                    bolt11: generate_fake_bolt11(signed_desc, cashu::Amount::ZERO),
                     max_fee_amount: None,
                     timeout_secs: None,
                     melt_options: None,
@@ -725,22 +714,20 @@ mod tests {
 
     #[tokio::test]
     async fn make_payment_alreadypaid() {
-        let reqid = PaymentIdentifier::CustomId(Uuid::new_v4().to_string());
+        let qid = Uuid::new_v4();
+        let reqid = PaymentIdentifier::CustomId(qid.to_string());
         let onchain = Arc::new(MockOnChainWallet::new());
         let mut payrepo = MockPaymentRepository::new();
         let cloned_reqid = reqid.clone();
+        let tkp = generate_random_keypair();
         payrepo
             .expect_load_outgoing()
             .with(eq(cloned_reqid.clone()))
             .returning(move |_| {
                 Ok(payment::OutgoingRequest {
                     reqid: cloned_reqid.clone(),
-                    reserved_fees: btc::Amount::ZERO,
-                    amount: btc::Amount::ZERO,
-                    recipient: generate_random_address(),
-                    status: MeltQuoteState::Paid,
-                    proof: None,
-                    total_spent: None,
+                    amount: cashu::Amount::ZERO,
+                    state: MeltQuoteState::Paid,
                 })
             });
         let ebill = Arc::new(MockEBillNode::new());
@@ -750,14 +737,20 @@ mod tests {
             Arc::new(payrepo),
             ebill,
             interval,
-            generate_random_pubkey(),
+            tkp.x_only_public_key().0,
         )
         .await;
+        let desc = wire_signatures::RequestToMeltDesc {
+            qid,
+            amount: cashu::Amount::ZERO,
+        };
+        let (content, signature) = serialize_n_schnorr_sign_borsh_msg(&desc, &tkp).unwrap();
+        let signed_desc = wire_signatures::SignedRequestToMeltDesc { content, signature };
         let result = srvc
             .make_payment(
                 &cashu::CurrencyUnit::Sat,
                 OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
-                    bolt11: generate_fake_bolt11(reqid.to_string(), Amount::ZERO),
+                    bolt11: generate_fake_bolt11(signed_desc, cashu::Amount::ZERO),
                     max_fee_amount: None,
                     timeout_secs: None,
                     melt_options: None,
@@ -772,10 +765,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn make_payment_pending() {
-        let reqid = PaymentIdentifier::CustomId(Uuid::new_v4().to_string());
+    async fn make_payment_paid() {
+        let qid = Uuid::new_v4();
+        let reqid = PaymentIdentifier::CustomId(qid.to_string());
         let onchain = MockOnChainWallet::new();
         let mut payrepo = MockPaymentRepository::new();
+        let tkp = generate_random_keypair();
         let cloned_reqid = reqid.clone();
         payrepo
             .expect_load_outgoing()
@@ -783,14 +778,19 @@ mod tests {
             .returning(move |_| {
                 Ok(payment::OutgoingRequest {
                     reqid: cloned_reqid.clone(),
-                    amount: btc::Amount::ZERO,
-                    recipient: generate_random_address(),
-                    status: MeltQuoteState::Pending,
-                    proof: None,
-                    total_spent: None,
-                    reserved_fees: btc::Amount::ZERO,
+                    amount: cashu::Amount::ZERO,
+                    state: MeltQuoteState::Pending,
                 })
             });
+        let cloned_reqid = reqid.clone();
+        payrepo
+            .expect_update_outgoing()
+            .with(eq(payment::OutgoingRequest {
+                reqid: cloned_reqid.clone(),
+                amount: cashu::Amount::ZERO,
+                state: MeltQuoteState::Paid,
+            }))
+            .returning(move |_| Ok(()));
         let ebill = MockEBillNode::new();
         let interval = Duration::from_secs(1);
         let srvc = Service::new(
@@ -798,31 +798,33 @@ mod tests {
             Arc::new(payrepo),
             Arc::new(ebill),
             interval,
-            generate_random_pubkey(),
+            tkp.x_only_public_key().0,
         )
         .await;
-        let result = srvc
-            .make_payment(
-                &cashu::CurrencyUnit::Sat,
-                OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
-                    bolt11: generate_fake_bolt11(reqid.to_string(), Amount::ZERO),
-                    max_fee_amount: None,
-                    timeout_secs: None,
-                    melt_options: None,
-                })),
-            )
-            .await;
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            PaymentError::InvoicePaymentPending
-        ));
+        let desc = wire_signatures::RequestToMeltDesc {
+            qid,
+            amount: cashu::Amount::ZERO,
+        };
+        let (content, signature) = serialize_n_schnorr_sign_borsh_msg(&desc, &tkp).unwrap();
+        let signed_desc = wire_signatures::SignedRequestToMeltDesc { content, signature };
+        srvc.make_payment(
+            &cashu::CurrencyUnit::Sat,
+            OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
+                bolt11: generate_fake_bolt11(signed_desc, cashu::Amount::ZERO),
+                max_fee_amount: None,
+                timeout_secs: None,
+                melt_options: None,
+            })),
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
     async fn make_payment_quoteandrequestamountsdonotmatch() {
         let reqid = PaymentIdentifier::CustomId(Uuid::new_v4().to_string());
         let mut onchain = MockOnChainWallet::new();
+        let tkp = generate_random_keypair();
         onchain.expect_network().returning(|| btc::Network::Testnet);
         let mut payrepo = MockPaymentRepository::new();
         let cloned_reqid = reqid.clone();
@@ -832,12 +834,8 @@ mod tests {
             .returning(move |_| {
                 Ok(payment::OutgoingRequest {
                     reqid: cloned_reqid.clone(),
-                    amount: btc::Amount::from_sat(10),
-                    recipient: generate_random_address(),
-                    status: MeltQuoteState::Unpaid,
-                    proof: None,
-                    total_spent: None,
-                    reserved_fees: btc::Amount::ZERO,
+                    amount: cashu::Amount::from(10),
+                    state: MeltQuoteState::Pending,
                 })
             });
         let ebill = MockEBillNode::new();
@@ -847,14 +845,20 @@ mod tests {
             Arc::new(payrepo),
             Arc::new(ebill),
             interval,
-            generate_random_pubkey(),
+            tkp.x_only_public_key().0,
         )
         .await;
+        let desc = wire_signatures::RequestToMeltDesc {
+            qid: Uuid::new_v4(),
+            amount: cashu::Amount::from(10),
+        };
+        let (content, signature) = serialize_n_schnorr_sign_borsh_msg(&desc, &tkp).unwrap();
+        let signed_desc = wire_signatures::SignedRequestToMeltDesc { content, signature };
         let result = srvc
             .make_payment(
                 &cashu::CurrencyUnit::Sat,
                 OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
-                    bolt11: generate_fake_bolt11(reqid.to_string(), cashu::Amount::from(11)),
+                    bolt11: generate_fake_bolt11(signed_desc, cashu::Amount::from(11)),
                     max_fee_amount: None,
                     timeout_secs: None,
                     melt_options: None,

--- a/crates/bcr-wdc-quote-service/src/admin.rs
+++ b/crates/bcr-wdc-quote-service/src/admin.rs
@@ -188,7 +188,7 @@ pub async fn lookup_quote(
     State(ctrl): State<Service>,
     Path(id): Path<uuid::Uuid>,
 ) -> Result<Json<wire_quotes::InfoReply>> {
-    tracing::debug!("Received mint quote lookup request");
+    tracing::debug!("Received mint quote lookup request {id}");
 
     let now = chrono::Utc::now();
     let (quote, minting_status) = ctrl.lookup(id, now).await?;

--- a/crates/bcr-wdc-treasury-service/src/debit/clowder.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/clowder.rs
@@ -1,0 +1,25 @@
+// ----- standard library imports
+// ----- extra library imports
+use async_trait::async_trait;
+use clwdr_client::ClowderRestClient;
+// ----- local imports
+use crate::{
+    debit::service::ClowderService,
+    error::{Error, Result},
+};
+
+// ----- end imports
+
+pub struct ClowderCl(pub ClowderRestClient);
+
+#[async_trait]
+impl ClowderService for ClowderCl {
+    async fn get_sweep(&self, qid: uuid::Uuid, kid: cashu::Id) -> Result<bitcoin::Address> {
+        let response = self
+            .0
+            .request_mint_address(qid, kid)
+            .await
+            .map_err(Error::ClowderClient)?;
+        Ok(response.address.assume_checked())
+    }
+}

--- a/crates/bcr-wdc-treasury-service/src/debit/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/mod.rs
@@ -1,14 +1,15 @@
 // ----- standard library imports
 // ----- extra library imports
 // ----- local modules
+mod clowder;
 mod service;
 mod wallet;
 mod wildcat;
-
 // ----- local imports
 
 // ----- end imports
 
-pub use service::{ClowderMintQuoteOnchain, MintQuote, OnchainMeltQuote, Repository, Service};
+pub use clowder::ClowderCl;
+pub use service::{ClowderMintQuoteOnchain, MintQuote, OnchainMeltQuote, Service};
 pub use wallet::{CDKWallet, CDKWalletConfig};
 pub use wildcat::{WildcatCl, WildcatClientConfig};

--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -4,16 +4,15 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use bcr_common::{
     core::{signature::serialize_n_schnorr_sign_borsh_msg, BillId},
-    wire::{melt as wire_melt, mint as wire_mint, signatures as wire_signatures},
+    wire::{melt as wire_melt, signatures as wire_signatures},
 };
 use bcr_wdc_utils::signatures as signatures_utils;
 use cashu::Amount;
-use cdk::nuts::nut00 as cdk00;
-use cdk::nuts::nut02 as cdk02;
 use uuid::Uuid;
 // ----- local imports
 use crate::{
     error::{Error, Result},
+    persistence::Repository,
     TStamp,
 };
 
@@ -34,6 +33,7 @@ pub struct OnchainMeltQuote {
     pub expiry: u64,
 }
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait Wallet: Send + Sync {
     async fn mint_quote(
@@ -42,18 +42,26 @@ pub trait Wallet: Send + Sync {
         signed_request: wire_signatures::SignedRequestToMintFromEBillDesc,
     ) -> Result<cdk::wallet::MintQuote>;
     async fn mint(&self, quote: String) -> Result<cashu::MintQuoteState>;
-    async fn keysets_info(&self, kids: &[cdk02::Id]) -> Result<Vec<cdk02::KeySetInfo>>;
+    async fn keysets_info(&self, kids: &[cashu::Id]) -> Result<Vec<cashu::KeySetInfo>>;
     async fn swap_to_messages(
         &self,
-        outputs: &[cdk00::BlindedMessage],
-    ) -> Result<Vec<cdk00::BlindSignature>>;
+        outputs: &[cashu::BlindedMessage],
+    ) -> Result<Vec<cashu::BlindSignature>>;
     async fn balance(&self) -> Result<Amount>;
+    async fn active_keyset(&self) -> Result<cashu::KeySetInfo>;
 }
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait WildcatService: Send + Sync {
-    async fn burn(&self, inputs: &[cdk00::Proof]) -> Result<()>;
-    async fn keyset_info(&self, kid: cdk02::Id) -> Result<cdk02::KeySetInfo>;
+    async fn burn(&self, inputs: &[cashu::Proof]) -> Result<()>;
+    async fn keyset_info(&self, kid: cashu::Id) -> Result<cashu::KeySetInfo>;
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait ClowderService: Send + Sync {
+    async fn get_sweep(&self, qid: uuid::Uuid, kid: cashu::Id) -> Result<bitcoin::Address>;
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -62,27 +70,13 @@ pub struct MintQuote {
     pub ebill_id: BillId,
 }
 
-#[async_trait]
-pub trait Repository: Send + Sync {
-    async fn store_quote(&self, quote: MintQuote) -> Result<()>;
-    async fn delete_quote(&self, qid: String) -> Result<()>;
-    async fn list_quotes(&self) -> Result<Vec<MintQuote>>;
-    async fn store_onchain_melt(&self, quote_id: uuid::Uuid, data: OnchainMeltQuote) -> Result<()>;
-    async fn load_onchain_melt(&self, quote_id: uuid::Uuid) -> Result<OnchainMeltQuote>;
-    async fn store_onchain_mint(
-        &self,
-        quote_id: uuid::Uuid,
-        data: ClowderMintQuoteOnchain,
-    ) -> Result<()>;
-    async fn load_onchain_mint(&self, quote_id: uuid::Uuid) -> Result<ClowderMintQuoteOnchain>;
-}
-
 #[derive(Clone)]
 pub struct Service {
     pub wallet: Arc<dyn Wallet>,
     pub wdc: Arc<dyn WildcatService>,
-    pub signing_keys: bitcoin::secp256k1::Keypair,
     pub repo: Arc<dyn Repository>,
+    pub clowder: Arc<dyn ClowderService>,
+    pub signing_keys: bitcoin::secp256k1::Keypair,
     pub monitor_interval: tokio::time::Duration,
     pub quote_expiry_seconds: u64,
 }
@@ -116,22 +110,6 @@ impl Service {
         })
     }
 
-    pub async fn get_onchain_mint_quote(
-        &self,
-        quote_id: &str,
-    ) -> Result<wire_mint::MintQuoteOnchainResponse> {
-        let cdk_quote = Uuid::parse_str(quote_id)
-            .map_err(|_| Error::InvalidInput(String::from("Invalid quote ID")))?;
-        let data = self.repo.load_onchain_mint(cdk_quote).await?;
-        Ok(wire_mint::MintQuoteOnchainResponse {
-            quote: data.cdk_quote,
-            address: data.address,
-            amount: bitcoin::Amount::from_sat(data.amount.into()),
-            expiry: data.expiry,
-            state: None,
-        })
-    }
-
     pub async fn init_monitors_for_past_ebills(&self) -> Result<()> {
         let quotes = self.repo.list_quotes().await?;
         for quote in quotes {
@@ -153,9 +131,13 @@ impl Service {
         amount: bitcoin::Amount,
         deadline: TStamp,
     ) -> Result<cdk::wallet::MintQuote> {
+        let active_kinfo = self.wallet.active_keyset().await?;
+        let clowder_qid = Uuid::new_v4();
+        let sweeping_address = self.clowder.get_sweep(clowder_qid, active_kinfo.id).await?;
         let request = wire_signatures::RequestToMintFromEBillDesc {
             ebill_id: ebill_id.clone(),
             deadline,
+            sweeping_address: sweeping_address.to_string(),
         };
         let (content, signature) =
             serialize_n_schnorr_sign_borsh_msg(&request, &self.signing_keys)?;
@@ -181,9 +163,9 @@ impl Service {
 
     pub async fn redeem(
         &self,
-        inputs: &[cdk00::Proof],
-        outputs: &[cdk00::BlindedMessage],
-    ) -> Result<Vec<cdk00::BlindSignature>> {
+        inputs: &[cashu::Proof],
+        outputs: &[cashu::BlindedMessage],
+    ) -> Result<Vec<cashu::BlindSignature>> {
         // cheap verifications
         signatures_utils::basic_proofs_checks(inputs)
             .map_err(|e| Error::InvalidInput(e.to_string()))?;
@@ -273,72 +255,32 @@ async fn monitor_quote(
 
 #[cfg(test)]
 mod tests {
-    mockall::mock! {
-        Wallet {}
-        impl Clone for Wallet {
-            fn clone(&self) -> Self;
-        }
-        #[async_trait]
-        impl super::Wallet for Wallet {
-            async fn mint_quote(
-                &self,
-                amount: Amount,
-                signed_request: wire_signatures::SignedRequestToMintFromEBillDesc,
-            ) -> Result<cdk::wallet::MintQuote>;
-            async fn mint(&self, quote: String) -> Result<cashu::MintQuoteState>;
-            async fn keysets_info(&self, kids: &[cdk02::Id]) -> Result<Vec<cdk02::KeySetInfo>>;
-            async fn swap_to_messages(
-                &self,
-                outputs: &[cdk00::BlindedMessage],
-            ) -> Result<Vec<cdk00::BlindSignature>>;
-            async fn balance(&self) -> Result<Amount>;
-        }
-    }
-    mockall::mock! {
-        WildcatService {}
-        impl Clone for WildcatService {
-            fn clone(&self) -> Self;
-        }
-        #[async_trait]
-        impl super::WildcatService for WildcatService {
-            async fn burn(&self, inputs: &[cdk00::Proof]) -> Result<()>;
-            async fn keyset_info(&self, kid: cdk02::Id) -> Result<cdk02::KeySetInfo>;
-        }
-    }
-    mockall::mock! {
-        Repository {}
-        impl Clone for Repository {
-            fn clone(&self) -> Self;
-        }
-        #[async_trait]
-        impl super::Repository for Repository {
-            async fn store_quote(&self, quote: MintQuote) -> Result<()>;
-            async fn delete_quote(&self, qid: String) -> Result<()>;
-            async fn list_quotes(&self) -> Result<Vec<MintQuote>>;
-            async fn store_onchain_melt(&self, quote_id: uuid::Uuid, data: super::OnchainMeltQuote) -> Result<()>;
-            async fn load_onchain_melt(&self, quote_id: uuid::Uuid) -> Result<super::OnchainMeltQuote>;
-            async fn store_onchain_mint(&self, quote_id: uuid::Uuid, data: super::ClowderMintQuoteOnchain) -> Result<()>;
-            async fn load_onchain_mint(&self, quote_id: uuid::Uuid) -> Result<super::ClowderMintQuoteOnchain>;
-        }
-    }
 
     use super::*;
+    use crate::persistence::MockRepository;
+    use bcr_common::core_tests::generate_random_ecash_keyset;
     use bcr_wdc_utils::keys::test_utils::generate_keyset;
     use bcr_wdc_utils::signatures::test_utils as signatures_test;
-    use cashu::{nut00 as cdk00, nut23 as cdk23, Amount};
+    use cashu::{nut23 as cdk23, Amount};
     use mockall::predicate::*;
     use secp256k1::global::SECP256K1;
     use std::str::FromStr;
 
     #[tokio::test]
     async fn mint_from_ebill() {
+        let sweep: bitcoin::Address =
+            bitcoin::Address::from_str("1BwBExCU5qfkt1G7rqX8zDkKhhGe2p9Fdb")
+                .unwrap()
+                .assume_checked();
+        let (info, _) = generate_random_ecash_keyset();
         let btc_amount = bitcoin::Amount::from_sat(1000);
         let amount = cashu::Amount::from(btc_amount.to_sat());
         let ebill_id =
             BillId::from_str("bitcrt285psGq4Lz4fEQwfM3We5HPznJq8p1YvRaddszFaU5dY").unwrap();
-        let mut wdc = MockWildcatService::new();
+        let wdc = MockWildcatService::new();
         let mut repo = MockRepository::new();
         let mut wallet = MockWallet::new();
+        let mut clowder = MockClowderService::new();
         let mint_quote = cdk::wallet::MintQuote {
             id: String::from("mint_quote_id"),
             mint_url: cdk_common::mint_url::MintUrl::from_str("http://test_mint_url.com:3338")
@@ -347,19 +289,26 @@ mod tests {
             amount_paid: amount,
             amount_issued: amount,
             payment_method: cashu::PaymentMethod::Bolt11,
-            unit: cdk00::CurrencyUnit::Sat,
+            unit: cashu::CurrencyUnit::Sat,
             request: Default::default(),
             state: cdk23::QuoteState::Paid,
             expiry: Default::default(),
             secret_key: None,
         };
+        clowder
+            .expect_get_sweep()
+            .times(1)
+            .returning(move |_, _| Ok(sweep.clone()));
         let qid_cloned = mint_quote.id.clone();
         let ebill_cloned = ebill_id.clone();
         wallet
             .expect_mint_quote()
+            .times(1)
             .returning(move |_, _| Ok(mint_quote.clone()));
-        let wallet_cloned = MockWallet::new();
-        wallet.expect_clone().return_once(move || wallet_cloned);
+        wallet
+            .expect_active_keyset()
+            .times(1)
+            .returning(move || Ok(info.clone().into()));
 
         repo.expect_store_quote()
             .with(eq(MintQuote {
@@ -367,11 +316,6 @@ mod tests {
                 ebill_id: ebill_cloned,
             }))
             .returning(|_| Ok(()));
-        let repo_cloned = MockRepository::new();
-        repo.expect_clone().return_once(move || repo_cloned);
-
-        let wdc_cloned = MockWildcatService::new();
-        wdc.expect_clone().return_once(move || wdc_cloned);
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
         let service = Service {
@@ -381,6 +325,7 @@ mod tests {
             repo: Arc::new(repo),
             monitor_interval: tokio::time::Duration::from_secs(5),
             quote_expiry_seconds: 3600,
+            clowder: Arc::new(clowder),
         };
         let quote = service
             .mint_from_ebill(
@@ -398,6 +343,7 @@ mod tests {
         let wdc = MockWildcatService::new();
         let wallet = MockWallet::new();
         let repo = MockRepository::new();
+        let clowder = MockClowderService::new();
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
         let service = Service {
@@ -405,6 +351,7 @@ mod tests {
             signing_keys,
             wdc: Arc::new(wdc),
             repo: Arc::new(repo),
+            clowder: Arc::new(clowder),
             monitor_interval: tokio::time::Duration::from_secs(5),
             quote_expiry_seconds: 3600,
         };
@@ -423,6 +370,7 @@ mod tests {
         let wdc = MockWildcatService::new();
         let wallet = MockWallet::new();
         let repo = MockRepository::new();
+        let clowder = MockClowderService::new();
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
         let service = Service {
@@ -430,6 +378,7 @@ mod tests {
             signing_keys,
             wdc: Arc::new(wdc),
             repo: Arc::new(repo),
+            clowder: Arc::new(clowder),
             monitor_interval: tokio::time::Duration::from_secs(5),
             quote_expiry_seconds: 3600,
         };
@@ -445,6 +394,7 @@ mod tests {
         let wdc = MockWildcatService::new();
         let wallet = MockWallet::new();
         let repo = MockRepository::new();
+        let clowder = MockClowderService::new();
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
         let service = Service {
@@ -452,6 +402,7 @@ mod tests {
             signing_keys,
             wdc: Arc::new(wdc),
             repo: Arc::new(repo),
+            clowder: Arc::new(clowder),
             monitor_interval: tokio::time::Duration::from_secs(5),
             quote_expiry_seconds: 3600,
         };
@@ -471,13 +422,14 @@ mod tests {
         let wdc = MockWildcatService::new();
         let repo = MockRepository::new();
         let mut wallet = MockWallet::new();
+        let clowder = MockClowderService::new();
         wallet.expect_keysets_info().returning(|kids| {
             let mut infos = Vec::new();
             for kid in kids {
-                infos.push(cdk02::KeySetInfo {
+                infos.push(cashu::KeySetInfo {
                     id: *kid,
                     active: false,
-                    unit: cdk00::CurrencyUnit::Sat,
+                    unit: cashu::CurrencyUnit::Sat,
                     input_fee_ppk: 0,
                     final_expiry: None,
                 });
@@ -491,6 +443,7 @@ mod tests {
             signing_keys,
             wdc: Arc::new(wdc),
             repo: Arc::new(repo),
+            clowder: Arc::new(clowder),
             monitor_interval: tokio::time::Duration::from_secs(5),
             quote_expiry_seconds: 3600,
         };
@@ -510,6 +463,7 @@ mod tests {
         let wdc = MockWildcatService::new();
         let repo = MockRepository::new();
         let mut wallet = MockWallet::new();
+        let clowder = MockClowderService::new();
         wallet
             .expect_keysets_info()
             .returning(|kids| Err(Error::UnknownKeyset(kids[0])));
@@ -520,6 +474,7 @@ mod tests {
             signing_keys,
             wdc: Arc::new(wdc),
             repo: Arc::new(repo),
+            clowder: Arc::new(clowder),
             monitor_interval: tokio::time::Duration::from_secs(5),
             quote_expiry_seconds: 3600,
         };

--- a/crates/bcr-wdc-treasury-service/src/debit/wallet.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/wallet.rs
@@ -24,7 +24,6 @@ pub struct CDKWalletConfig {
     pub storage: std::path::PathBuf,
 }
 
-#[derive(Clone)]
 pub struct CDKWallet {
     wlt: cdk::wallet::Wallet,
     client: cdk::wallet::HttpClient,
@@ -121,5 +120,9 @@ impl Wallet for CDKWallet {
     async fn balance(&self) -> Result<Amount> {
         self.wlt.check_all_mint_quotes().await?;
         self.wlt.total_balance().await.map_err(Error::CDKWallet)
+    }
+
+    async fn active_keyset(&self) -> Result<cashu::KeySetInfo> {
+        self.wlt.get_active_keyset().await.map_err(Error::CDKWallet)
     }
 }

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -96,11 +96,13 @@ impl AppController {
             secp256k1::Keypair::from_secret_key(secp256k1::global::SECP256K1, &secret);
         tracing::info!("signing public key: {}", signing_keys.public_key());
         let monitor_interval = tokio::time::Duration::from_secs(monitor_interval_sec);
+        let clowder_cl = debit::ClowderCl(ClowderRestClient::new(clowder_url.clone()));
         let debit = debit::Service {
             wallet: Arc::new(wallet),
             signing_keys,
             wdc: Arc::new(wdc),
             repo: Arc::new(repo),
+            clowder: Arc::new(clowder_cl),
             monitor_interval,
             quote_expiry_seconds,
         };

--- a/crates/bcr-wdc-treasury-service/src/persistence/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/mod.rs
@@ -1,6 +1,30 @@
 // ----- standard library imports
 // ----- extra library imports
+use async_trait::async_trait;
+// ----- local imports
+use crate::{
+    debit::MintQuote,
+    debit::{ClowderMintQuoteOnchain, OnchainMeltQuote},
+    error::Result,
+};
 // ----- local modules
 pub mod inmemory;
 pub mod surreal;
-// ----- local imports
+
+// ----- end imports
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait Repository: Send + Sync {
+    async fn store_quote(&self, quote: MintQuote) -> Result<()>;
+    async fn delete_quote(&self, qid: String) -> Result<()>;
+    async fn list_quotes(&self) -> Result<Vec<MintQuote>>;
+    async fn store_onchain_melt(&self, quote_id: uuid::Uuid, data: OnchainMeltQuote) -> Result<()>;
+    async fn load_onchain_melt(&self, quote_id: uuid::Uuid) -> Result<OnchainMeltQuote>;
+    async fn store_onchain_mint(
+        &self,
+        quote_id: uuid::Uuid,
+        data: ClowderMintQuoteOnchain,
+    ) -> Result<()>;
+    async fn load_onchain_mint(&self, quote_id: uuid::Uuid) -> Result<ClowderMintQuoteOnchain>;
+}

--- a/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use crate::{
     debit,
     error::{Error, Result},
-    foreign,
+    foreign, persistence,
 };
 
 // ----- end imports
@@ -97,7 +97,7 @@ impl DebitRepository {
 }
 
 #[async_trait]
-impl debit::Repository for DebitRepository {
+impl persistence::Repository for DebitRepository {
     async fn store_quote(&self, quote: debit::MintQuote) -> Result<()> {
         let rid = RecordId::from_table_key(&self.table, quote.qid.clone());
         let _: Option<debit::MintQuote> = self
@@ -497,8 +497,8 @@ impl foreign::OfflineRepository for ForeignOfflineRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::debit::Repository;
     use crate::foreign::OfflineRepository;
+    use crate::persistence::Repository;
     use bcr_common::core_tests;
     use bcr_common::core_tests::generate_random_keypair;
     use bitcoin::hashes::Hash;


### PR DESCRIPTION
mint and melt refactors

- mint: the ebill payment is straightforwardly moved to a sweeping address
- melt: deleted from ebpp logic as the treasury-service will do everything