### PR TITLE
ci: fix nightly paths-filter base

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,7 @@ jobs:
       id: filter
       uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       with:
+        base: dev
         filters: |
           code:
             - 'crates/**'


### PR DESCRIPTION
- set paths-filter base to dev to detect code changes in dev pushes that affect Docker images