### PR TITLE
[bcd-wdc-treasury-service] Send melt to cdk via ebpp

### DIFF
--- a/crates/bcr-wdc-ebpp/src/service.rs
+++ b/crates/bcr-wdc-ebpp/src/service.rs
@@ -282,6 +282,25 @@ impl MintPayment for Service {
             return Err(PaymentError::UnsupportedPaymentOption);
         };
         let description = options.bolt11.description().to_string();
+
+        if let Some(amount_str) = description.strip_prefix("clowder:melt:") {
+            let amount = amount_str
+                .parse::<u64>()
+                .map_err(|_| PaymentError::UnsupportedPaymentOption)?;
+            let reqid = PaymentIdentifier::CustomId(Uuid::new_v4().to_string());
+            let outgoing =
+                payment::OutgoingRequest::new(reqid.clone(), cashu::Amount::from(amount));
+            self.payrepo.store_outgoing(outgoing).await?;
+            tracing::debug!("Clowder melt quote {reqid} for amount {amount}");
+            return Ok(PaymentQuoteResponse {
+                request_lookup_id: Some(reqid),
+                amount: cashu::Amount::from(amount),
+                unit: CurrencyUnit::Sat,
+                fee: cashu::Amount::ZERO,
+                state: MeltQuoteState::Unpaid,
+            });
+        }
+
         let request: wire_signatures::SignedRequestToMeltDesc =
             serde_json::from_str(&description).map_err(PaymentError::Serde)?;
         schnorr_verify_b64(&request.content, &request.signature, &self.treasury_pubkey)
@@ -309,13 +328,31 @@ impl MintPayment for Service {
     ) -> PaymentResult<MakePaymentResponse> {
         let _span = tracing::debug_span!("make_payment");
 
-        if !matches!(unit, CurrencyUnit::Sat) {
-            return Err(PaymentError::UnsupportedUnit);
-        }
         let OutgoingPaymentOptions::Bolt11(options) = options else {
             return Err(PaymentError::UnsupportedPaymentOption);
         };
         let description = options.bolt11.description().to_string();
+
+        // Process before as unit is msat due to cdk processing
+        if let Some(amount_str) = description.strip_prefix("clowder:melt:") {
+            let amount = amount_str
+                .parse::<u64>()
+                .map_err(|_| PaymentError::UnsupportedPaymentOption)?;
+            let reqid = PaymentIdentifier::CustomId(Uuid::new_v4().to_string());
+            tracing::debug!("Clowder make payment {amount} {unit} {reqid}");
+            return Ok(MakePaymentResponse {
+                payment_lookup_id: reqid,
+                payment_proof: None,
+                status: MeltQuoteState::Paid,
+                total_spent: cashu::Amount::from(amount),
+                unit: CurrencyUnit::Sat,
+            });
+        }
+
+        if !matches!(unit, CurrencyUnit::Sat) {
+            return Err(PaymentError::UnsupportedUnit);
+        }
+
         let request: wire_signatures::SignedRequestToMeltDesc =
             serde_json::from_str(&description).map_err(PaymentError::Serde)?;
         schnorr_verify_b64(&request.content, &request.signature, &self.treasury_pubkey)

--- a/crates/bcr-wdc-ebpp/src/service.rs
+++ b/crates/bcr-wdc-ebpp/src/service.rs
@@ -334,6 +334,7 @@ impl MintPayment for Service {
         let description = options.bolt11.description().to_string();
 
         // Process before as unit is msat due to cdk processing
+        // This just exists to mark a clowder melt as paid and burn the input proofs
         if let Some(amount_str) = description.strip_prefix("clowder:melt:") {
             let amount = amount_str
                 .parse::<u64>()

--- a/crates/bcr-wdc-treasury-service/src/debit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/service.rs
@@ -14,6 +14,7 @@ use bcr_common::{
 };
 use bcr_wdc_utils::signatures as signatures_utils;
 use cashu::Amount;
+use cdk::wallet::MintConnector;
 use uuid::Uuid;
 // ----- local imports
 use crate::{
@@ -23,6 +24,27 @@ use crate::{
 };
 
 // ----- end imports
+
+fn create_clowder_melt_bolt11(amount: cashu::Amount) -> cashu::lightning_invoice::Bolt11Invoice {
+    use bitcoin::hashes::{sha256, Hash};
+    use cashu::lightning_invoice as ln;
+
+    // Random unused values
+    let payment_hash = sha256::Hash::hash(&rand::random::<[u8; 32]>());
+    let payment_secret = ln::PaymentSecret(rand::random());
+    let sk = secp256k1::SecretKey::new(&mut rand::thread_rng());
+    let description = format!("clowder:melt:{}", u64::from(amount));
+
+    ln::InvoiceBuilder::new(ln::Currency::Bitcoin)
+        .description(description)
+        .payment_hash(payment_hash)
+        .payment_secret(payment_secret)
+        .current_timestamp()
+        .amount_milli_satoshis(u64::from(amount) * 1000) // msat
+        .min_final_cltv_expiry_delta(144)
+        .build_signed(|hash| secp256k1::global::SECP256K1.sign_ecdsa_recoverable(hash, &sk))
+        .unwrap()
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ClowderMintQuoteOnchain {
@@ -100,6 +122,7 @@ pub struct Service {
     pub quote_expiry_seconds: u64,
     pub cancel: tokio_util::sync::CancellationToken,
     pub hndls: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    pub dbmint: cdk::wallet::HttpClient,
 }
 
 impl Service {
@@ -121,19 +144,39 @@ impl Service {
         request: wire_melt::MeltQuoteOnchainRequest,
     ) -> Result<wire_melt::MeltQuoteOnchainResponse> {
         let expiry = (chrono::Utc::now().timestamp() + self.quote_expiry_seconds as i64) as u64;
-        let quote_id = Uuid::new_v4();
-        tracing::info!("Creating onchain melt quote with ID {}", quote_id);
+        let amount = cashu::Amount::from(request.request.amount.to_sat());
+
+        let bolt11 = create_clowder_melt_bolt11(amount);
+        let melt_quote_req = cashu::MeltQuoteBolt11Request {
+            request: bolt11,
+            unit: cashu::CurrencyUnit::Sat,
+            options: None,
+        };
+
+        let cdk_quote = match self.dbmint.post_melt_quote(melt_quote_req).await {
+            Ok(resp) => {
+                tracing::info!("CDK melt quote created: {}", resp.quote);
+                Uuid::parse_str(&resp.quote)
+                    .map_err(|_| Error::InvalidInput("Invalid CDK quote ID".into()))?
+            }
+            Err(e) => {
+                tracing::error!("Failed to create CDK melt quote: {:?}", e);
+                return Err(Error::Internal(format!("CDK quote creation failed: {}", e)));
+            }
+        };
+
         let data = OnchainMeltQuote {
             request: request.clone(),
             expiry,
         };
-        self.repo.store_onchain_melt(quote_id, data).await?;
+        self.repo.store_onchain_melt(cdk_quote, data).await?;
+
         Ok(wire_melt::MeltQuoteOnchainResponse {
             txid: None,
-            quote: quote_id,
+            quote: cdk_quote,
             fee_reserve: bitcoin::Amount::ZERO,
             change: None,
-            amount: bitcoin::Amount::from_sat(request.request.amount.to_sat()),
+            amount: request.request.amount,
             unit: Some(request.unit),
             state: cashu::nuts::MeltQuoteState::Unpaid,
             expiry,
@@ -380,6 +423,9 @@ mod tests {
             .returning(|_| Ok(()));
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
+        let cdk_mint = cdk::wallet::HttpClient::new(
+            cashu::MintUrl::from_str("http://test_mint_url.com:3338").unwrap(),
+        );
         let service = Service {
             wallet: Arc::new(wallet),
             signing_keys,
@@ -391,6 +437,7 @@ mod tests {
             clowder_write: None,
             cancel: tokio_util::sync::CancellationToken::new(),
             hndls: Arc::new(Mutex::new(Vec::new())),
+            dbmint: cdk_mint,
         };
         let quote = service
             .mint_from_ebill(
@@ -411,6 +458,9 @@ mod tests {
         let clowder = MockClowderReadService::new();
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
+        let cdk_mint = cdk::wallet::HttpClient::new(
+            cashu::MintUrl::from_str("http://test_mint_url.com:3338").unwrap(),
+        );
         let service = Service {
             wallet: Arc::new(wallet),
             signing_keys,
@@ -422,6 +472,7 @@ mod tests {
             quote_expiry_seconds: 3600,
             cancel: tokio_util::sync::CancellationToken::new(),
             hndls: Arc::new(Mutex::new(Vec::new())),
+            dbmint: cdk_mint,
         };
 
         let (_, keyset) = generate_keyset();
@@ -441,6 +492,9 @@ mod tests {
         let clowder = MockClowderReadService::new();
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
+        let cdk_mint = cdk::wallet::HttpClient::new(
+            cashu::MintUrl::from_str("http://test_mint_url.com:3338").unwrap(),
+        );
         let service = Service {
             wallet: Arc::new(wallet),
             signing_keys,
@@ -452,6 +506,7 @@ mod tests {
             quote_expiry_seconds: 3600,
             cancel: tokio_util::sync::CancellationToken::new(),
             hndls: Arc::new(Mutex::new(Vec::new())),
+            dbmint: cdk_mint,
         };
 
         let (_, keyset) = generate_keyset();
@@ -468,6 +523,9 @@ mod tests {
         let clowder = MockClowderReadService::new();
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
+        let cdk_mint = cdk::wallet::HttpClient::new(
+            cashu::MintUrl::from_str("http://test_mint_url.com:3338").unwrap(),
+        );
         let service = Service {
             wallet: Arc::new(wallet),
             signing_keys,
@@ -479,6 +537,7 @@ mod tests {
             quote_expiry_seconds: 3600,
             cancel: tokio_util::sync::CancellationToken::new(),
             hndls: Arc::new(Mutex::new(Vec::new())),
+            dbmint: cdk_mint,
         };
 
         let (_, keyset) = generate_keyset();
@@ -512,6 +571,9 @@ mod tests {
         });
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
+        let cdk_mint = cdk::wallet::HttpClient::new(
+            cashu::MintUrl::from_str("http://test_mint_url.com:3338").unwrap(),
+        );
         let service = Service {
             wallet: Arc::new(wallet),
             signing_keys,
@@ -523,6 +585,7 @@ mod tests {
             quote_expiry_seconds: 3600,
             cancel: tokio_util::sync::CancellationToken::new(),
             hndls: Arc::new(Mutex::new(Vec::new())),
+            dbmint: cdk_mint,
         };
 
         let (_, keyset) = generate_keyset();
@@ -546,6 +609,9 @@ mod tests {
             .returning(|kids| Err(Error::UnknownKeyset(kids[0])));
 
         let signing_keys = bitcoin::secp256k1::Keypair::new(SECP256K1, &mut rand::thread_rng());
+        let cdk_mint = cdk::wallet::HttpClient::new(
+            cashu::MintUrl::from_str("http://test_mint_url.com:3338").unwrap(),
+        );
         let service = Service {
             wallet: Arc::new(wallet),
             signing_keys,
@@ -557,6 +623,7 @@ mod tests {
             quote_expiry_seconds: 3600,
             cancel: tokio_util::sync::CancellationToken::new(),
             hndls: Arc::new(Mutex::new(Vec::new())),
+            dbmint: cdk_mint,
         };
 
         let (_, keyset) = generate_keyset();

--- a/crates/bcr-wdc-treasury-service/src/error.rs
+++ b/crates/bcr-wdc-treasury-service/src/error.rs
@@ -92,6 +92,9 @@ pub enum Error {
 
     #[error("internal {0}")]
     Internal(String),
+
+    #[error("Clowder unavailable for onchain operations")]
+    ClowderUnavailable,
 }
 
 impl axum::response::IntoResponse for Error {
@@ -147,6 +150,10 @@ impl axum::response::IntoResponse for Error {
             Error::InsufficientOnchainMintAmount(_) => (StatusCode::BAD_REQUEST, String::new()),
             Error::MeltAmountMismatch(_) => (StatusCode::BAD_REQUEST, String::new()),
             Error::MintAmountMismatch(_) => (StatusCode::BAD_REQUEST, String::new()),
+            Error::ClowderUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Clowder unavailable".to_string(),
+            ),
         };
         resp.into_response()
     }

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -121,6 +121,7 @@ impl AppController {
             clwdr_nats.as_ref().map(|c| {
                 Arc::new(debit::ClowderNatsCl(c.clone())) as Arc<dyn debit::ClowderWriteService>
             });
+        let dbmint = cdk::wallet::HttpClient::new(cdk_mintd_url.clone());
         let debit = debit::Service {
             wallet: Arc::new(wallet),
             signing_keys,
@@ -132,6 +133,7 @@ impl AppController {
             quote_expiry_seconds,
             cancel: tokio_util::sync::CancellationToken::new(),
             hndls: Arc::new(Mutex::new(Vec::new())),
+            dbmint: dbmint.clone(),
         };
         debit
             .init_monitors_for_past_ebills()
@@ -204,7 +206,6 @@ impl AppController {
             .await
             .expect("Failed to create signer");
 
-        let dbmint = cdk::wallet::HttpClient::new(cdk_mintd_url.clone());
         let dev = devmode::Service {
             crkeys: bcr_common::client::keys::Client::new(credit_keys_url),
             dbmint: dbmint.clone(),

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -102,6 +102,9 @@ pub async fn melt_quote_onchain(
     State(ctrl): State<AppController>,
     Json(request): Json<wire_melt::MeltQuoteOnchainRequest>,
 ) -> Result<Json<wire_melt::MeltQuoteOnchainResponse>> {
+    if ctrl.clwdr_nats.is_none() {
+        return Err(crate::error::Error::ClowderUnavailable);
+    }
     if request.request.amount < ctrl.params.min_melt_threshold {
         return Err(crate::error::Error::InsufficientOnchainMeltAmount(
             request.request.amount,
@@ -156,37 +159,38 @@ pub async fn melt_onchain(
             cashu::Amount::from(total_proofs),
         ));
     }
-    if let Some(clowder) = ctrl.clwdr_nats {
-        tracing::debug!("Requesting onchain clowder melt transaction");
-        let melt_resp = clowder
-            .melt_onchain(messages::MeltOnchainRequest {
-                quote: *quote_id,
-                address: onchain_data.request.request.address,
-                amount: onchain_data.request.request.amount,
-                proofs: inputs.clone(),
-            })
-            .await?;
-        let resp = wire_melt::MeltQuoteOnchainResponse {
-            txid: Some(melt_resp.txid),
-            quote: *quote_id,
-            fee_reserve: bitcoin::Amount::ZERO,
-            change: None,
-            amount: onchain_data.request.request.amount,
-            unit: Some(onchain_data.request.unit.clone()),
-            state: cashu::nuts::MeltQuoteState::Paid,
-            expiry: onchain_data.expiry,
-        };
-        return Ok(Json(resp));
+
+    let Some(clowder) = ctrl.clwdr_nats else {
+        return Err(crate::error::Error::ClowderUnavailable);
+    };
+
+    let melt_request = cashu::MeltRequest::new(quote_id.to_string(), inputs.clone(), None);
+    let cdk_resp = ctrl.dbmint.post_melt(melt_request).await?;
+    if cdk_resp.paid != Some(true) {
+        tracing::error!("Invalid cdk resp state {:?}", cdk_resp);
+        return Err(crate::error::Error::Internal(
+            "CDK Mintd did not mark melt quote as paid".to_string(),
+        ));
     }
 
+    tracing::debug!("Requesting onchain clowder melt transaction");
+    let melt_resp = clowder
+        .melt_onchain(messages::MeltOnchainRequest {
+            quote: *quote_id,
+            address: onchain_data.request.request.address,
+            amount: onchain_data.request.request.amount,
+            proofs: inputs.clone(),
+        })
+        .await?;
+
     let resp = wire_melt::MeltQuoteOnchainResponse {
-        txid: None,
+        txid: Some(melt_resp.txid),
         quote: *quote_id,
         fee_reserve: bitcoin::Amount::ZERO,
         change: None,
         amount: onchain_data.request.request.amount,
         unit: Some(onchain_data.request.unit),
-        state: cashu::nuts::MeltQuoteState::Unpaid,
+        state: cashu::nuts::MeltQuoteState::Paid,
         expiry: onchain_data.expiry,
     };
 


### PR DESCRIPTION
### **User description**
* Fixed melting by sending to cdk and having ebpp process the request as well, marking proofs as spent #530 


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add CDK melt quote creation via EBPP with custom Bolt11 invoice format

- Integrate CDK mint client for melt operations in treasury service

- Handle clowder melt requests with "clowder:melt:" prefix in EBPP service

- Store and track CDK quote IDs for onchain melt operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Treasury Service"] -->|create_onchain_melt_quote| B["Create Clowder Bolt11"]
  B -->|post_melt_quote| C["CDK Mint"]
  C -->|quote_id| D["Store Quote"]
  E["EBPP Service"] -->|quote_description| F["Parse clowder:melt prefix"]
  F -->|store_outgoing| G["Payment Repository"]
  H["melt_onchain"] -->|post_melt| C
  C -->|melt_response| I["Return Status"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Handle clowder melt requests in EBPP service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-ebpp/src/service.rs

<ul><li>Add special handling for "clowder:melt:" prefixed descriptions in <br><code>quote_payment</code> method<br> <li> Parse amount from description and create outgoing payment request with <br>UUID<br> <li> Add similar clowder melt handling in <code>make_payment</code> method<br> <li> Return immediate payment response for clowder melt requests without <br>treasury verification</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/532/files#diff-b5acbddaada54279fd8bdaa1fd26b270a4cd28251ced566869426ee85da7c965">+38/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Integrate CDK melt quote creation with custom invoices</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/debit/service.rs

<ul><li>Add <code>create_clowder_melt_bolt11</code> function to generate custom Bolt11 <br>invoices with "clowder:melt:" description<br> <li> Add <code>cdk_mint</code> field to Service struct for CDK mint HTTP client<br> <li> Modify <code>create_onchain_melt_quote</code> to create Bolt11 invoice and post <br>melt quote to CDK<br> <li> Parse CDK quote response and use it as the quote ID instead of <br>generating random UUID<br> <li> Update all test cases to initialize <code>cdk_mint</code> field with test URL</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/532/files#diff-caaa9a1592f0e5ce710ca52d8f651b10978b6986cb1090c391f76ab4bd749b06">+72/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Refactor CDK mint client initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/lib.rs

<ul><li>Move <code>cdk_mint</code> initialization earlier in AppController setup<br> <li> Pass <code>cdk_mint</code> client to debit Service initialization<br> <li> Remove duplicate <code>cdk_mint</code> initialization from devmode service setup</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/532/files#diff-c37ae0172b7c48d3ef7ff2f2b24ff060ac7f261babf3b0a7c21720bde394c041">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Send melt request to CDK in onchain melt handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/web.rs

<ul><li>Add <code>post_melt</code> call to CDK mint before clowder melt transaction request<br> <li> Pass CDK melt response status to debug logging<br> <li> Ensure melt request is sent to CDK for state tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/532/files#diff-ad24c19ee9cc83165c7bac0ca341787f5354bd84be8abc7d35ac197f7350c323">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

