### PR TITLE
remove all TODOs from code

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/foreign/crsat.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/crsat.rs
@@ -204,7 +204,6 @@ async fn try_online_htlc(
             &cashu::amount::SplitTarget::None,
         )
         .map_err(|e| Error::Internal(e.to_string()))?;
-        // TODO: allow different keyset_ids
         assert_eq!(
             1,
             f_proofs

--- a/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
@@ -166,7 +166,6 @@ async fn monitor(
             let request = cashu::SwapRequest::new(proofs, premints.blinded_messages());
             let Ok(response) = client.post_swap(request).await else {
                 warn!("post_swap failed {}, lost {}", mint.1, total);
-                //TODO: store the request for future replay
                 continue;
             };
             let mut news = Vec::with_capacity(response.signatures.len());
@@ -184,7 +183,6 @@ async fn monitor(
             }
             if online_repo.store(mint.clone(), news).await.is_err() {
                 error!("store new proofs failed {}, {total} lost", mint.1);
-                //TODO: store the request for future replay
             };
             if offline_repo.remove_proofs(&ys).await.is_err() {
                 warn!("remove_proofs failed {}", mint.1);

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -207,8 +207,6 @@ pub async fn mint_quote_onchain(
     }
 
     let clowder_quote = Uuid::new_v4();
-    // TODO update mint quote onchain to provide keyset id
-    // Which can be used later to select correct frost multisig
     let dummy_kid = cashu::Id::from_bytes(&[0_u8; 8])
         .map_err(|_| crate::error::Error::InvalidInput(String::from("Invalid keyset ID")))?;
     let address_response = ctrl

--- a/crates/bcr-wdc-wallet-aggregator/src/web.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/web.rs
@@ -330,7 +330,6 @@ pub async fn post_check_state(
     let n = request.ys.len();
     let credit_states = ctrl.swap_client.check_state(request.ys.clone()).await?;
     let debit_states = ctrl.cdk_client.post_check_state(request).await?.states;
-    // TODO ensure the order and length are the same as the input, which should always be the case anyway
     if debit_states.len() != n || credit_states.len() != n {
         return Err(Error::NotYet(
             "Unhandled credit and debit length mismatch".into(),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove TODO comments from codebase

- Clean up technical debt markers across multiple modules

- Improve code clarity by eliminating outdated notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TODO Comments"] -- "removed from" --> B["crsat.rs"]
  A -- "removed from" --> C["settle.rs"]
  A -- "removed from" --> D["web.rs<br/>treasury-service"]
  A -- "removed from" --> E["web.rs<br/>wallet-aggregator"]
  B --> F["Cleaner Codebase"]
  C --> F
  D --> F
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Code cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crsat.rs</strong><dd><code>Remove keyset_id TODO comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/foreign/crsat.rs

<ul><li>Removed TODO comment about allowing different keyset_ids<br> <li> Comment was located above keyset_id assertion logic</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/545/files#diff-e4140ec973539149af001a2bff4225b2a7f144af5f9ff7022c60ecfc5cb79469">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settle.rs</strong><dd><code>Remove replay request TODO comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/foreign/settle.rs

<ul><li>Removed two TODO comments about storing requests for future replay<br> <li> Comments were in error handling paths for post_swap and store <br>operations<br> <li> Improves readability of error handling logic</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/545/files#diff-16b8e795deaa58753acbf96f57dc604503d720a66e90674f4605fd1c7eccde20">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Remove mint quote keyset TODO comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-treasury-service/src/web.rs

<ul><li>Removed TODO comment about updating mint quote onchain with keyset id<br> <li> Comment was related to frost multisig selection logic<br> <li> Simplifies mint quote onchain function</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/545/files#diff-ad24c19ee9cc83165c7bac0ca341787f5354bd84be8abc7d35ac197f7350c323">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>web.rs</strong><dd><code>Remove state consistency TODO comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wdc-wallet-aggregator/src/web.rs

<ul><li>Removed TODO comment about ensuring order and length consistency<br> <li> Comment was in check_state endpoint validation logic<br> <li> Cleans up state checking function</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wildcat/pull/545/files#diff-5558fd821dba3268f729f3ca79eb75aff0edcd3fbf1b9414c170f6fbc18c72a1">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

