### PR TITLE
[bcr-wdc-key-service] Increase credit keyset size to 32

### DIFF
--- a/crates/bcr-wdc-key-service/src/factory.rs
+++ b/crates/bcr-wdc-key-service/src/factory.rs
@@ -17,7 +17,7 @@ pub struct Factory {
 }
 
 impl Factory {
-    pub const MAX_ORDER: u8 = 20;
+    pub const MAX_ORDER: u8 = 32;
     pub const CURRENCY_UNIT: &'static str = "crsat";
 
     pub fn new(seed: &[u8], derivation: btc32::DerivationPath) -> Self {


### PR DESCRIPTION
Increase credit keyset size to 2^32  ~ 42btc, which aligns it with the default amount in CDK mintd (which requires a fork to override?)