### PR TITLE
[bcr-wdc-key-service] minor change to config

### DIFF
--- a/crates/bcr-wdc-key-service/src/clowder.rs
+++ b/crates/bcr-wdc-key-service/src/clowder.rs
@@ -12,6 +12,7 @@ use crate::{
 // ----- end imports
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(tag = "type")]
 pub enum ClowderClientConfig {
     #[default]
     Dummy,


### PR DESCRIPTION
to allow clowder section to be passed via env variables


note: deploy submodule will be updated once wildcat-deployment:#52 is merged