### PR TITLE
[bcr-wdc-treasury-service] add credit mint operations repository -- part 1

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/admin.rs
+++ b/crates/bcr-wdc-treasury-service/src/admin.rs
@@ -5,10 +5,13 @@ use axum::extract::{Json, Path, State};
 use bcr_common::{
     cashu,
     core::BillId,
-    wire::{exchange as wire_exchange, signatures as wire_signatures, wallet as wire_wallet},
+    wire::{
+        exchange as wire_exchange, signatures as wire_signatures, treasury as wire_treasury,
+        wallet as wire_wallet,
+    },
 };
 // ----- local imports
-use crate::{debit, error::Result, foreign};
+use crate::{credit, debit, error::Result, foreign};
 // ----- end imports
 
 // ----- sat APIs
@@ -70,5 +73,57 @@ pub async fn is_ebill_minting_completed(
 
     let complete = ctrl.is_ebill_payment_minted(bill_id).await?;
     let response = wire_wallet::EbillPaymentComplete { complete };
+    Ok(Json(response))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn new_mintop(
+    State(ctrl): State<Arc<credit::Service>>,
+    Json(request): Json<wire_treasury::NewMintOperationRequest>,
+) -> Result<Json<wire_treasury::NewMintOperationResponse>> {
+    tracing::debug!("Received new mint operation request");
+
+    ctrl.new_minting_operation(
+        request.quote_id,
+        request.kid,
+        request.pub_key,
+        request.target,
+        request.bill_id,
+    )
+    .await?;
+    let response = wire_treasury::NewMintOperationResponse {};
+    Ok(Json(response))
+}
+
+fn convert_mintop_status(status: credit::MintOperation) -> wire_treasury::MintOperationStatus {
+    wire_treasury::MintOperationStatus {
+        kid: status.kid,
+        quote_id: status.uid,
+        target: status.target,
+        current: status.minted,
+    }
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn mintop_status(
+    State(ctrl): State<Arc<credit::Service>>,
+    Path(qid): Path<uuid::Uuid>,
+) -> Result<Json<wire_treasury::MintOperationStatus>> {
+    tracing::debug!("Received mint operation status request {qid}");
+
+    let status = ctrl.mintop_status(qid).await?;
+    let status = convert_mintop_status(status);
+    Ok(Json(status))
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
+pub async fn list_mintops(
+    State(ctrl): State<Arc<credit::Service>>,
+    Path(kid): Path<cashu::Id>,
+) -> Result<Json<Vec<cashu::Amount>>> {
+    tracing::debug!("Received list mint operations request");
+
+    let mint_ops = ctrl.list_mintops_for_kid(kid).await?;
+    let response = mint_ops.into_iter().map(|mop| mop.minted).collect();
     Ok(Json(response))
 }

--- a/crates/bcr-wdc-treasury-service/src/credit/client.rs
+++ b/crates/bcr-wdc-treasury-service/src/credit/client.rs
@@ -1,0 +1,93 @@
+// ----- standard library imports
+// ----- extra library imports
+use async_trait::async_trait;
+use bcr_common::{
+    cashu,
+    client::core::{Client as CoreClient, Error as CoreError},
+    core,
+    wire::clowder as wire_clowder,
+};
+use clwdr_client::ClowderNatsClient;
+use uuid::Uuid;
+// ----- local imports
+use crate::{
+    credit,
+    error::{Error, Result},
+};
+
+// ----- end imports
+
+pub struct DummyClwdr {}
+#[async_trait]
+impl credit::ClowderClient for DummyClwdr {
+    async fn minting_ebill(
+        &self,
+        _keyset_id: cashu::Id,
+        _quote_id: Uuid,
+        _amount: cashu::Amount,
+        _bill_id: core::BillId,
+        signatures: Vec<cashu::BlindSignature>,
+    ) -> Result<Vec<cashu::BlindSignature>> {
+        Ok(signatures)
+    }
+}
+
+pub struct ClwdrCl(pub ClowderNatsClient);
+#[async_trait]
+impl credit::ClowderClient for ClwdrCl {
+    async fn minting_ebill(
+        &self,
+        keyset_id: cashu::Id,
+        quote_id: Uuid,
+        amount: cashu::Amount,
+        bill_id: core::BillId,
+        signatures: Vec<cashu::BlindSignature>,
+    ) -> Result<Vec<cashu::BlindSignature>> {
+        let request = wire_clowder::messages::MintEbillRequest {
+            keyset_id,
+            amount,
+            bill_id,
+            quote_id,
+        };
+        let response = wire_clowder::messages::MintEbillResponse { signatures };
+        let res = self
+            .0
+            .mint_bill(request, response)
+            .await
+            .map_err(Error::ClowderClient)?;
+        Ok(res.signatures)
+    }
+}
+pub async fn new_clowder_client(
+    url: Option<reqwest::Url>,
+) -> Result<Box<dyn credit::ClowderClient>> {
+    let cl: Box<dyn credit::ClowderClient> = match url {
+        None => Box::new(DummyClwdr {}),
+        Some(url) => {
+            let clowder_client = ClowderNatsClient::new(url)
+                .await
+                .map_err(Error::ClowderClient)?;
+            Box::new(ClwdrCl(clowder_client))
+        }
+    };
+    Ok(cl)
+}
+
+pub struct CoreCl(pub CoreClient);
+#[async_trait]
+impl credit::CoreClient for CoreCl {
+    async fn info(&self, kid: cashu::Id) -> Result<cashu::KeySetInfo> {
+        match self.0.keyset_info(kid).await {
+            Ok(info) => Ok(info),
+            Err(CoreError::KeysetIdNotFound(kid)) => {
+                Err(Error::InvalidInput(format!("Unknown keyset: {kid}")))
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn sign(&self, blind: cashu::BlindedMessage) -> Result<cashu::BlindSignature> {
+        let res = self.0.sign(&blind).await?;
+        Ok(res)
+    }
+}

--- a/crates/bcr-wdc-treasury-service/src/credit/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/credit/mod.rs
@@ -1,0 +1,59 @@
+// ----- standard library imports
+// ----- extra library imports
+use async_trait::async_trait;
+use bcr_common::{cashu, core::BillId};
+use uuid::Uuid;
+// ----- local modules
+mod client;
+mod service;
+// ----- local imports
+use crate::error::Result;
+
+// ----- end imports
+
+pub use client::{new_clowder_client, CoreCl};
+pub use service::Service;
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct MintOperation {
+    pub uid: Uuid,
+    pub kid: cashu::Id,
+    pub pub_key: cashu::PublicKey,
+    pub target: cashu::Amount,
+    pub minted: cashu::Amount,
+    pub bill_id: BillId,
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait MintOpRepository: Send + Sync {
+    async fn store(&self, mint_operation: MintOperation) -> Result<()>;
+    async fn load(&self, uid: Uuid) -> Result<MintOperation>;
+    async fn list(&self, kid: cashu::Id) -> Result<Vec<MintOperation>>;
+    async fn update(
+        &self,
+        uid: Uuid,
+        old_minted: cashu::Amount,
+        new_minted: cashu::Amount,
+    ) -> Result<()>;
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait CoreClient: Send + Sync {
+    async fn info(&self, kid: cashu::Id) -> Result<cashu::KeySetInfo>;
+    async fn sign(&self, blind: cashu::BlindedMessage) -> Result<cashu::BlindSignature>;
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait ClowderClient: Send + Sync {
+    async fn minting_ebill(
+        &self,
+        kid: cashu::Id,
+        qid: Uuid,
+        amount: cashu::Amount,
+        bid: BillId,
+        signs: Vec<cashu::BlindSignature>,
+    ) -> Result<Vec<cashu::BlindSignature>>;
+}

--- a/crates/bcr-wdc-treasury-service/src/credit/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/credit/service.rs
@@ -1,0 +1,293 @@
+// ----- standard library imports
+use std::collections::HashSet;
+// ----- extra library imports
+use bcr_common::{cashu, core::BillId};
+use futures::future::JoinAll;
+use uuid::Uuid;
+// ----- local imports
+use crate::{
+    credit::{ClowderClient, CoreClient, MintOpRepository, MintOperation},
+    error::{Error, Result},
+};
+
+// ----- end imports
+
+pub struct Service {
+    pub mintops: Box<dyn MintOpRepository>,
+    pub corecl: Box<dyn CoreClient>,
+    pub clowdercl: Box<dyn ClowderClient>,
+}
+
+impl Service {
+    pub async fn new_minting_operation(
+        &self,
+        uid: Uuid,
+        kid: cashu::Id,
+        pub_key: cashu::PublicKey,
+        amount: cashu::Amount,
+        bill_id: BillId,
+    ) -> Result<()> {
+        let _kinfo = self.corecl.info(kid).await?;
+        let new = MintOperation {
+            uid,
+            kid,
+            pub_key,
+            target: amount,
+            minted: cashu::Amount::ZERO,
+            bill_id,
+        };
+        self.mintops.store(new).await?;
+        Ok(())
+    }
+
+    pub async fn mintop_status(&self, uid: Uuid) -> Result<MintOperation> {
+        let operation = self.mintops.load(uid).await?;
+        Ok(operation)
+    }
+
+    pub async fn list_mintops_for_kid(&self, kid: cashu::Id) -> Result<Vec<MintOperation>> {
+        self.mintops.list(kid).await
+    }
+
+    pub async fn mint(&self, request: cashu::MintRequest<Uuid>) -> Result<cashu::MintResponse> {
+        // basic checks
+        if request.signature.is_none() {
+            return Err(Error::InvalidInput(String::from("signature missing")));
+        }
+        bcr_wdc_utils::signatures::basic_blinds_checks(&request.outputs)
+            .map_err(|e| Error::InvalidInput(e.to_string()))?;
+        //  check if the ids of the outputs are all the same
+        let unique_ids: Vec<_> = request
+            .outputs
+            .iter()
+            .map(|p| p.keyset_id)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        if unique_ids.len() != 1 {
+            return Err(Error::InvalidInput(String::from("multiple keyset IDs")));
+        }
+        let kid = unique_ids.first().expect("unique_ids len should be 1");
+        let output_amount = request
+            .outputs
+            .iter()
+            .fold(cashu::Amount::ZERO, |acc, blind| acc + blind.amount);
+        let operation = self.mintops.load(request.quote).await?;
+        let signature_verification = request.verify_signature(operation.pub_key);
+        if signature_verification.is_err() {
+            return Err(Error::InvalidInput(String::from("invalid signature")));
+        }
+        if operation.kid != *kid {
+            return Err(Error::InvalidInput(String::from("invalid keyset id")));
+        }
+        if operation.minted + output_amount > operation.target {
+            return Err(Error::InvalidInput(String::from("exceeding amount")));
+        }
+        let joined: JoinAll<_> = request
+            .outputs
+            .into_iter()
+            .map(|blind| self.corecl.sign(blind))
+            .collect();
+        let signatures: Vec<cashu::BlindSignature> =
+            joined.await.into_iter().collect::<Result<_>>()?;
+        self.mintops
+            .update(
+                operation.uid,
+                operation.minted,
+                operation.minted + output_amount,
+            )
+            .await?;
+        let response = self
+            .clowdercl
+            .minting_ebill(
+                *kid,
+                request.quote,
+                output_amount,
+                operation.bill_id.clone(),
+                signatures,
+            )
+            .await;
+        match response {
+            Ok(signatures) => Ok(cashu::MintResponse { signatures }),
+            Err(e) => {
+                self.mintops
+                    .update(
+                        operation.uid,
+                        operation.minted + output_amount,
+                        operation.minted,
+                    )
+                    .await?;
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credit::{MockClowderClient, MockCoreClient, MockMintOpRepository};
+    use bcr_common::{cashu, core_tests};
+    use bcr_wdc_utils::signatures::test_utils as signatures_test;
+    use mockall::predicate::eq;
+
+    #[tokio::test]
+    async fn new_minting_operation_missing_keyset() {
+        let mintop_repo = MockMintOpRepository::new();
+        let clowder_cl = MockClowderClient::new();
+        let mut core_cl = MockCoreClient::new();
+        let kid = bcr_common::core_tests::generate_random_ecash_keyset().0.id;
+        let uid = Uuid::new_v4();
+        let pub_key = bcr_common::core_tests::generate_random_keypair()
+            .public_key()
+            .into();
+        let amount = cashu::Amount::from(32);
+        let bill_id = core_tests::random_bill_id();
+        core_cl
+            .expect_info()
+            .times(1)
+            .with(eq(kid))
+            .returning(|_| Err(Error::InvalidInput(String::new())));
+        let service = Service {
+            clowdercl: Box::new(clowder_cl),
+            corecl: Box::new(core_cl),
+            mintops: Box::new(mintop_repo),
+        };
+        let err = service
+            .new_minting_operation(uid, kid, pub_key, amount, bill_id)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn new_minting_operation_ok() {
+        let mut mintop_repo = MockMintOpRepository::new();
+        let clowder_cl = MockClowderClient::new();
+        let mut core_cl = MockCoreClient::new();
+        let (kinfo, _keyset) = bcr_common::core_tests::generate_random_ecash_keyset();
+        let kid = kinfo.id;
+        let uid = Uuid::new_v4();
+        let pub_key = bcr_common::core_tests::generate_random_keypair()
+            .public_key()
+            .into();
+        let amount = cashu::Amount::from(64);
+        let bill_id = core_tests::random_bill_id();
+        core_cl
+            .expect_info()
+            .times(1)
+            .with(eq(kid))
+            .returning(move |_| Ok(kinfo.clone().into()));
+        let mintop = MintOperation {
+            uid,
+            kid,
+            pub_key,
+            target: amount,
+            minted: cashu::Amount::ZERO,
+            bill_id: bill_id.clone(),
+        };
+        mintop_repo
+            .expect_store()
+            .times(1)
+            .with(eq(mintop))
+            .returning(|_| Ok(()));
+        let service = Service {
+            clowdercl: Box::new(clowder_cl),
+            corecl: Box::new(core_cl),
+            mintops: Box::new(mintop_repo),
+        };
+        service
+            .new_minting_operation(uid, kid, pub_key, amount, bill_id)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn mint_ok() {
+        let mut mintop_repo = MockMintOpRepository::new();
+        let mut clowder_cl = MockClowderClient::new();
+        let mut core_cl = MockCoreClient::new();
+        let (kinfo, keyset) = bcr_common::core_tests::generate_random_ecash_keyset();
+        let kid = kinfo.id;
+        let uid = Uuid::new_v4();
+        let kp = bcr_common::core_tests::generate_random_keypair();
+        let pub_key = cashu::PublicKey::from(kp.public_key());
+        let amounts = [cashu::Amount::from(128), cashu::Amount::from(64)];
+        let total = amounts
+            .iter()
+            .fold(cashu::Amount::ZERO, |acc, amount| acc + *amount);
+        let bill_id = core_tests::random_bill_id();
+        mintop_repo
+            .expect_update()
+            .times(1)
+            .with(eq(uid), eq(cashu::Amount::ZERO), eq(total))
+            .returning(|_, _, _| Ok(()));
+        core_cl.expect_sign().times(2).returning(move |msg| {
+            Ok(core_tests::generate_ecash_signatures(&keyset, &[msg.amount])[0].clone())
+        });
+        let mintop = MintOperation {
+            uid,
+            kid,
+            pub_key,
+            target: total,
+            minted: cashu::Amount::ZERO,
+            bill_id: bill_id.clone(),
+        };
+        mintop_repo
+            .expect_load()
+            .times(1)
+            .with(eq(uid))
+            .returning(move |_| Ok(mintop.clone()));
+        clowder_cl
+            .expect_minting_ebill()
+            .times(1)
+            .returning(|_, _, _, _, signatures| Ok(signatures));
+
+        let service = Service {
+            clowdercl: Box::new(clowder_cl),
+            corecl: Box::new(core_cl),
+            mintops: Box::new(mintop_repo),
+        };
+        let outputs = signatures_test::generate_blinds(kid, &amounts);
+        let blinds = outputs.iter().map(|(blind, _, _)| blind.clone()).collect();
+        let mut request = cashu::MintRequest {
+            quote: uid,
+            outputs: blinds,
+            signature: None,
+        };
+        request.sign(kp.secret_key().into()).unwrap();
+        let response = service.mint(request).await.unwrap();
+        assert_eq!(response.signatures.len(), amounts.len());
+    }
+
+    #[tokio::test]
+    async fn mint_missing_mintop() {
+        let mut mintop_repo = MockMintOpRepository::new();
+        let clowder_cl = MockClowderClient::new();
+        let core_cl = MockCoreClient::new();
+        let kid = bcr_common::core_tests::generate_random_ecash_keyset().0.id;
+        let uid = Uuid::new_v4();
+        let kp = bcr_common::core_tests::generate_random_keypair();
+        let amounts = [cashu::Amount::from(128)];
+        mintop_repo
+            .expect_load()
+            .times(1)
+            .with(eq(uid))
+            .returning(move |_| Err(Error::InvalidInput(String::new())));
+        let service = Service {
+            clowdercl: Box::new(clowder_cl),
+            corecl: Box::new(core_cl),
+            mintops: Box::new(mintop_repo),
+        };
+        let outputs = signatures_test::generate_blinds(kid, &amounts);
+        let blinds = outputs.iter().map(|(blind, _, _)| blind.clone()).collect();
+        let mut request = cashu::MintRequest {
+            quote: uid,
+            outputs: blinds,
+            signature: None,
+        };
+        request.sign(kp.secret_key().into()).unwrap();
+        let err = service.mint(request).await.unwrap_err();
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+}

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -6,12 +6,16 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use bcr_common::{cashu, cdk, client::treasury::Client as TreasuryClient};
+use bcr_common::{
+    cashu, cdk,
+    client::{core::Client as CoreClient, treasury::Client as TreasuryClient},
+};
 use bcr_wdc_utils::surreal;
 use bitcoin::secp256k1;
 use clwdr_client::{ClowderNatsClient, ClowderRestClient, SignatoryNatsClient};
 // ----- local modules
 mod admin;
+mod credit;
 mod debit;
 mod devmode;
 mod error;
@@ -24,7 +28,6 @@ mod web;
 
 type TStamp = chrono::DateTime<chrono::Utc>;
 
-type ProdCrsatService = foreign::crsat::Service;
 type ProdCrsatOnlineRepository = persistence::surreal::ForeignOnlineRepository;
 type ProdCrsatOfflineRepository = persistence::surreal::ForeignOfflineRepository;
 type ProdCrsatKeysClient = foreign::clients::CrsatCoreClient;
@@ -36,15 +39,18 @@ type ProdSatKeysClient = foreign::clients::SatKeysClient;
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct AppConfig {
-    credit_keys_url: reqwest::Url,
+    debit: DebitConfig,
+    foreign: ForeignConfig,
+    credit: CreditConfig,
+    clwdr_nats_url: Option<reqwest::Url>,
+    keys_url: reqwest::Url,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct DebitConfig {
     cdk_mintd_url: cashu::MintUrl,
     debit_repo: surreal::DBConnConfig,
-    crsatonline_repo: surreal::DBConnConfig,
-    crsatoffline_repo: surreal::DBConnConfig,
-    satonline_repo: surreal::DBConnConfig,
-    satoffline_repo: surreal::DBConnConfig,
     clowder_url: reqwest::Url,
-    clwdr_nats_url: Option<reqwest::Url>,
     signer_url: reqwest::Url,
     sat_wallet: debit::CDKWalletConfig,
     wildcat: debit::WildcatClientConfig,
@@ -53,6 +59,19 @@ pub struct AppConfig {
     min_confirmations: u32,
     min_melt_threshold: bitcoin::Amount,
     min_mint_threshold: bitcoin::Amount,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct ForeignConfig {
+    crsatonline_repo: surreal::DBConnConfig,
+    crsatoffline_repo: surreal::DBConnConfig,
+    satonline_repo: surreal::DBConnConfig,
+    satoffline_repo: surreal::DBConnConfig,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct CreditConfig {
+    mintops: surreal::DBConnConfig,
 }
 
 #[derive(Clone)]
@@ -64,8 +83,9 @@ struct Parameters {
 
 #[derive(Clone, FromRef)]
 pub struct AppController {
+    credit: Arc<credit::Service>,
     debit: debit::Service,
-    crsat: Arc<ProdCrsatService>,
+    crsat: Arc<foreign::crsat::Service>,
     sat: Arc<ProdSatService>,
     signer: Arc<SignatoryNatsClient>,
     clwdr_nats: Option<Arc<ClowderNatsClient>>,
@@ -78,16 +98,17 @@ pub struct AppController {
 impl AppController {
     pub async fn new(seed: [u8; 64], secret: secp256k1::SecretKey, cfg: AppConfig) -> Self {
         let AppConfig {
-            credit_keys_url,
+            debit,
+            foreign,
+            credit,
+            clwdr_nats_url,
+            keys_url,
+        } = cfg;
+        let DebitConfig {
             cdk_mintd_url,
             clowder_url,
-            clwdr_nats_url,
             signer_url,
             debit_repo,
-            crsatonline_repo,
-            crsatoffline_repo,
-            satonline_repo,
-            satoffline_repo,
             sat_wallet,
             wildcat,
             monitor_interval_sec,
@@ -95,7 +116,14 @@ impl AppController {
             min_confirmations,
             min_melt_threshold,
             min_mint_threshold,
-        } = cfg;
+        } = debit;
+        let ForeignConfig {
+            crsatonline_repo,
+            crsatoffline_repo,
+            satonline_repo,
+            satoffline_repo,
+        } = foreign;
+        let CreditConfig { mintops } = credit;
 
         let wallet = debit::CDKWallet::new(sat_wallet, seed)
             .await
@@ -109,7 +137,7 @@ impl AppController {
         tracing::info!("signing public key: {}", signing_keys.public_key());
         let monitor_interval = tokio::time::Duration::from_secs(monitor_interval_sec);
         let clowder_cl = debit::ClowderCl(ClowderRestClient::new(clowder_url.clone()));
-        let clwdr_nats = if let Some(url) = clwdr_nats_url {
+        let clwdr_nats = if let Some(url) = clwdr_nats_url.clone() {
             Some(Arc::new(
                 ClowderNatsClient::new(url)
                     .await
@@ -151,7 +179,7 @@ impl AppController {
                 .await
                 .expect("Failed to create crsat offline repository"),
         );
-        let crsatkeys = ProdCrsatKeysClient::new(credit_keys_url.clone());
+        let crsatkeys = ProdCrsatKeysClient::new(keys_url.clone());
         let clwdr_rest = Arc::new(ClowderRestClient::new(clowder_url.clone()));
         let clowder = Arc::new(ProdClowderClient::new(clowder_url));
         let factory = Arc::new(foreign::clients::MintClientFactory {});
@@ -165,7 +193,7 @@ impl AppController {
                 &online, &offline, &clwdr, &fctry, interval,
             ))
         };
-        let crsat = Arc::new(ProdCrsatService {
+        let crsat = Arc::new(foreign::crsat::Service {
             online_repo: crsatonlinerepo,
             offline_repo: crsatofflinerepo,
             keys: Box::new(crsatkeys),
@@ -208,10 +236,23 @@ impl AppController {
             .expect("Failed to create signer");
 
         let dev = devmode::Service {
-            crcore: bcr_common::client::core::Client::new(credit_keys_url),
+            crcore: bcr_common::client::core::Client::new(keys_url.clone()),
             dbmint: dbmint.clone(),
         };
+        let mintops_repo = persistence::surreal::DBMintOps::new(mintops)
+            .await
+            .expect("Failed to create mintops repository");
+        let corecl = credit::CoreCl(CoreClient::new(keys_url));
+        let clowdercl = credit::new_clowder_client(clwdr_nats_url)
+            .await
+            .expect("Failed to create clowder client");
+        let credit = Arc::new(credit::Service {
+            mintops: Box::new(mintops_repo),
+            corecl: Box::new(corecl),
+            clowdercl,
+        });
         Self {
+            credit,
             debit,
             crsat,
             sat,
@@ -268,7 +309,8 @@ pub fn routes(app: AppController) -> Router {
             TreasuryClient::MINTQUOTE_ONCHAIN_GET_EP_V1,
             get(web::get_mint_quote_onchain),
         )
-        .route(TreasuryClient::MINT_ONCHAIN_EP_V1, post(web::mint_onchain));
+        .route(TreasuryClient::MINT_ONCHAIN_EP_V1, post(web::mint_onchain))
+        .route(TreasuryClient::MINT_EP_V1, post(web::mint_ebill));
     let admin = Router::new()
         .route(
             TreasuryClient::REQTOPAY_EP_V1,
@@ -286,6 +328,12 @@ pub fn routes(app: AppController) -> Router {
         .route(
             TreasuryClient::IS_EBILL_MINT_COMPLETE_EP_V1,
             get(admin::is_ebill_minting_completed),
+        )
+        .route(TreasuryClient::NEWMINTOP_EP_V1, post(admin::new_mintop))
+        .route(TreasuryClient::LISTMINTOPS_EP_V1, get(admin::list_mintops))
+        .route(
+            TreasuryClient::MINTOPSTATUS_EP_V1,
+            get(admin::mintop_status),
         );
     admin.merge(web).with_state(app)
 }

--- a/crates/bcr-wdc-treasury-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/inmemory.rs
@@ -1,14 +1,19 @@
 // ----- standard library imports
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
 };
 // ----- extra library imports
 use async_trait::async_trait;
 use bcr_common::{cashu, wire::keys::ProofFingerprint};
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
+use uuid::Uuid;
 // ----- local imports
-use crate::{error::Result, foreign};
+use crate::{
+    credit,
+    error::{Error, Result},
+    foreign,
+};
 
 // ----- end imports
 
@@ -125,6 +130,75 @@ impl foreign::OfflineRepository for InMemoryOfflineRepository {
         for proofs in locked.values_mut() {
             proofs.retain(|p| !ys.contains(&p.y().expect("proof should have y")));
         }
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+type MintOperationsReferences = (
+    HashMap<uuid::Uuid, credit::MintOperation>,
+    HashMap<cashu::Id, Vec<uuid::Uuid>>,
+);
+
+#[allow(dead_code)]
+#[derive(Default, Debug, Clone)]
+pub struct MintOpMap {
+    operations: Arc<RwLock<MintOperationsReferences>>,
+}
+#[async_trait]
+impl credit::MintOpRepository for MintOpMap {
+    async fn store(&self, mint_op: credit::MintOperation) -> Result<()> {
+        let mut wlocked = self.operations.write().unwrap();
+        let (cs, cs_kid) = &mut *wlocked;
+        if cs.contains_key(&mint_op.uid) {
+            return Err(Error::InvalidInput(format!(
+                "mint_op {}, already exists",
+                mint_op.uid
+            )));
+        }
+        let uid = mint_op.uid;
+        let kid = mint_op.kid;
+        cs.insert(mint_op.uid, mint_op);
+        cs_kid
+            .entry(kid)
+            .and_modify(|conds| conds.push(uid))
+            .or_insert(vec![uid]);
+        Ok(())
+    }
+    async fn load(&self, uid: Uuid) -> Result<credit::MintOperation> {
+        let rlocked = self.operations.read().unwrap();
+        let (cs, _) = &*rlocked;
+        let op = cs
+            .get(&uid)
+            .ok_or(Error::InvalidInput(format!("mint_op {uid} not found")))?;
+        Ok(op.clone())
+    }
+    async fn list(&self, kid: cashu::Id) -> Result<Vec<credit::MintOperation>> {
+        let rlocked = self.operations.read().unwrap();
+        let (cs, cs_kid) = &*rlocked;
+        let empty = Vec::default();
+        let uids = cs_kid.get(&kid).unwrap_or(&empty);
+        let mut a = Vec::with_capacity(uids.len());
+        for uid in uids {
+            if let Some(condition) = cs.get(uid) {
+                a.push(condition.clone())
+            }
+        }
+        Ok(a)
+    }
+    async fn update(&self, uid: uuid::Uuid, old: cashu::Amount, new: cashu::Amount) -> Result<()> {
+        let mut wlocked = self.operations.write().unwrap();
+        let (cs, _) = &mut *wlocked;
+        let operation = cs.get_mut(&uid).ok_or(Error::Internal(format!(
+            "MintOperation internal uuid does not exist {uid}"
+        )))?;
+        if operation.minted != old {
+            return Err(Error::Internal(format!(
+                "MintOperation internal minted value changed {} != {}",
+                operation.minted, old
+            )));
+        }
+        operation.minted = new;
         Ok(())
     }
 }

--- a/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
@@ -2,71 +2,22 @@
 // ----- extra library imports
 use anyhow::anyhow;
 use async_trait::async_trait;
-use bcr_common::{
-    cashu::{self, secret::Secret, Amount},
-    wire::keys as wire_keys,
-};
+use bcr_common::{cashu, core, wire::keys as wire_keys};
 use bcr_wdc_utils::surreal;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
-use surrealdb::{engine::any::Any, RecordId, Result as SurrealResult, Surreal};
+use surrealdb::{
+    engine::any::Any, error::Db as SurrealDBError, Error as SurrealError, RecordId,
+    Result as SurrealResult, Surreal,
+};
 use uuid::Uuid;
 // ----- local imports
 use crate::{
-    debit,
+    credit, debit,
     error::{Error, Result},
     foreign, persistence,
 };
 
 // ----- end imports
-
-// cashu::PreMint is not Deserialize
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct DBEntryPremint {
-    blinded: cashu::BlindedMessage,
-    secret: Secret,
-    r: cashu::SecretKey,
-    amount: Amount,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct DBEntryPremintSecret {
-    request_id: Uuid,
-    kid: cashu::Id,
-    secrets: Vec<DBEntryPremint>,
-}
-
-impl std::convert::From<DBEntryPremint> for cashu::PreMint {
-    fn from(entry: DBEntryPremint) -> Self {
-        Self {
-            blinded_message: entry.blinded,
-            secret: entry.secret,
-            r: entry.r,
-            amount: entry.amount,
-        }
-    }
-}
-
-impl std::convert::From<cashu::PreMint> for DBEntryPremint {
-    fn from(entry: cashu::PreMint) -> Self {
-        Self {
-            blinded: entry.blinded_message,
-            secret: entry.secret,
-            r: entry.r,
-            amount: entry.amount,
-        }
-    }
-}
-
-impl std::convert::From<DBEntryPremintSecret> for cashu::PreMintSecrets {
-    fn from(entry: DBEntryPremintSecret) -> Self {
-        let DBEntryPremintSecret { kid, secrets, .. } = entry;
-        let secrets: Vec<cashu::PreMint> = secrets.into_iter().map(|e| e.into()).collect();
-        Self {
-            keyset_id: kid,
-            secrets,
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct DebitRepository {
@@ -210,6 +161,136 @@ impl ForeignOnlineRepository {
         db_connection.use_ns(config.namespace).await?;
         db_connection.use_db(config.database).await?;
         Ok(Self { db: db_connection })
+    }
+}
+
+////////////////////////////////////////////////////////////////////// MintOp DB
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MintOpDBEntry {
+    id: RecordId,
+    kid: cashu::Id,
+    pub_key: cashu::PublicKey,
+    target: cashu::Amount,
+    minted: cashu::Amount,
+    bill_id: core::BillId,
+}
+
+fn convert_to_mintopdbentry(entry: credit::MintOperation, table: &str) -> MintOpDBEntry {
+    let credit::MintOperation {
+        uid,
+        kid,
+        pub_key,
+        target,
+        minted,
+        bill_id,
+    } = entry;
+    let id = RecordId::from_table_key(table, uid);
+    MintOpDBEntry {
+        id,
+        kid,
+        pub_key,
+        target,
+        minted,
+        bill_id,
+    }
+}
+impl std::convert::From<MintOpDBEntry> for credit::MintOperation {
+    fn from(entry: MintOpDBEntry) -> Self {
+        let key = entry.id.key();
+        let uid = Uuid::try_from(key.clone()).expect("key is a uuid");
+        Self {
+            uid,
+            kid: entry.kid,
+            pub_key: entry.pub_key,
+            target: entry.target,
+            minted: entry.minted,
+            bill_id: entry.bill_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DBMintOps {
+    db: Surreal<surrealdb::engine::any::Any>,
+}
+
+impl DBMintOps {
+    const TABLE: &'static str = "mint_ops";
+
+    pub async fn new(cfg: surreal::DBConnConfig) -> SurrealResult<Self> {
+        let db_connection = Surreal::<Any>::init();
+        db_connection.connect(cfg.connection).await?;
+        db_connection.use_ns(cfg.namespace).await?;
+        db_connection.use_db(cfg.database).await?;
+        Ok(Self { db: db_connection })
+    }
+}
+
+#[async_trait]
+impl credit::MintOpRepository for DBMintOps {
+    async fn store(&self, mint_op: credit::MintOperation) -> Result<()> {
+        let uid = mint_op.uid;
+        let entry = convert_to_mintopdbentry(mint_op, Self::TABLE);
+        let res: SurrealResult<Option<MintOpDBEntry>> =
+            self.db.insert(&entry.id).content(entry).await;
+        match res {
+            Ok(..) => Ok(()),
+            Err(SurrealError::Db(SurrealDBError::RecordExists { .. })) => {
+                Err(Error::InvalidInput(format!("mintop already exist {uid}")))
+            }
+            Err(e) => Err(Error::DB(anyhow!(e))),
+        }
+    }
+
+    async fn load(&self, uid: Uuid) -> Result<credit::MintOperation> {
+        let rid = RecordId::from_table_key(Self::TABLE, uid);
+        let res: SurrealResult<Option<MintOpDBEntry>> = self.db.select(rid.clone()).await;
+        match res {
+            Ok(Some(entry)) => Ok(credit::MintOperation::from(entry)),
+            Ok(None) => Err(Error::InvalidInput(format!("mintop not found {uid}"))),
+            Err(e) => Err(Error::DB(anyhow!(e))),
+        }
+    }
+
+    async fn list(&self, kid: cashu::Id) -> Result<Vec<credit::MintOperation>> {
+        let ops: Vec<MintOpDBEntry> = self
+            .db
+            .query("SELECT * FROM type::table($table) WHERE kid == $kid")
+            .bind(("table", Self::TABLE))
+            .bind(("kid", kid))
+            .await
+            .map_err(|e| Error::DB(anyhow!(e)))?
+            .take(0)
+            .map_err(|e| Error::DB(anyhow!(e)))?;
+
+        let ops = ops.into_iter().map(credit::MintOperation::from).collect();
+        Ok(ops)
+    }
+    async fn update(&self, uid: Uuid, old: cashu::Amount, new: cashu::Amount) -> Result<()> {
+        let rid = RecordId::from_table_key(Self::TABLE, uid);
+        let before: Option<MintOpDBEntry> = self
+            .db
+            .query("UPDATE $rid SET minted = $new WHERE minted == $old RETURN BEFORE")
+            .bind(("rid", rid))
+            .bind(("new", new))
+            .bind(("old", old))
+            .await
+            .map_err(|e| Error::DB(anyhow!(e)))?
+            .take(0)
+            .map_err(|e| Error::DB(anyhow!(e)))?;
+        let Some(before) = before else {
+            return Err(Error::InvalidInput(format!(
+                "mintop {uid} and {old} amount not found"
+            )));
+        };
+        debug_assert_eq!(before.minted, old, "Minted amount did not match for {uid}");
+        if before.minted != old {
+            tracing::error!(
+                "Minted amount did not match for mintop {uid}: expected {old}, got {}",
+                before.minted,
+            );
+        }
+        Ok(())
     }
 }
 
@@ -495,14 +576,14 @@ impl foreign::OfflineRepository for ForeignOfflineRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::credit::MintOpRepository;
     use crate::foreign::OfflineRepository;
     use crate::persistence::Repository;
     use bcr_common::core_tests;
-    use bcr_common::core_tests::generate_random_keypair;
     use bitcoin::hashes::Hash;
     use std::str::FromStr;
 
-    async fn init_deb_mem_db() -> DebitRepository {
+    async fn init_debit_mem_db() -> DebitRepository {
         let sdb = Surreal::<Any>::init();
         sdb.connect("mem://").await.unwrap();
         sdb.use_ns("test").await.unwrap();
@@ -512,7 +593,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mint_quote() {
-        let db = init_deb_mem_db().await;
+        let db = init_debit_mem_db().await;
 
         let quote = debit::MintQuote {
             qid: Uuid::new_v4().to_string(),
@@ -541,13 +622,13 @@ mod tests {
     async fn offline_search_fps() {
         let db = init_foreignoffline_mem_db().await;
 
-        let alpha_pk = generate_random_keypair().public_key();
+        let alpha_pk = core_tests::generate_random_keypair().public_key();
         let alpha = (
             alpha_pk,
             cashu::MintUrl::from_str("http://example.com").unwrap(),
         );
-        let y = cashu::PublicKey::from(generate_random_keypair().public_key());
-        let c = cashu::PublicKey::from(generate_random_keypair().public_key());
+        let y = cashu::PublicKey::from(core_tests::generate_random_keypair().public_key());
+        let c = cashu::PublicKey::from(core_tests::generate_random_keypair().public_key());
         let fps = vec![
             wire_keys::ProofFingerprint {
                 amount: 10,
@@ -560,8 +641,8 @@ mod tests {
             wire_keys::ProofFingerprint {
                 amount: 10,
                 keyset_id: cashu::Id::from_bytes(&[1; 33]).unwrap(),
-                y: cashu::PublicKey::from(generate_random_keypair().public_key()),
-                c: cashu::PublicKey::from(generate_random_keypair().public_key()),
+                y: cashu::PublicKey::from(core_tests::generate_random_keypair().public_key()),
+                c: cashu::PublicKey::from(core_tests::generate_random_keypair().public_key()),
                 witness: None,
                 dleq: None,
             },
@@ -578,5 +659,122 @@ mod tests {
         let (mint, fp) = result.unwrap();
         assert_eq!(mint.0, alpha.0);
         assert_eq!(fp.y, y);
+    }
+
+    async fn init_mintops_mem_db() -> DBMintOps {
+        let sdb = Surreal::<Any>::init();
+        sdb.connect("mem://").await.unwrap();
+        sdb.use_ns("test").await.unwrap();
+        sdb.use_db("test").await.unwrap();
+        DBMintOps { db: sdb }
+    }
+
+    #[tokio::test]
+    async fn store_mintop() {
+        let db = init_mintops_mem_db().await;
+        let keys = core_tests::generate_random_ecash_keyset();
+        let kid = keys.0.id;
+        let kp = core_tests::generate_random_keypair();
+        let op = credit::MintOperation {
+            uid: Uuid::new_v4(),
+            kid,
+            pub_key: kp.public_key().into(),
+            target: cashu::Amount::ZERO,
+            minted: cashu::Amount::ZERO,
+            bill_id: bcr_common::core_tests::random_bill_id(),
+        };
+        db.store(op).await.unwrap();
+    }
+    #[tokio::test]
+    async fn store_mintop_twice() {
+        let db = init_mintops_mem_db().await;
+        let keys = core_tests::generate_random_ecash_keyset();
+        let kid = keys.0.id;
+        let kp = core_tests::generate_random_keypair();
+        let op = credit::MintOperation {
+            uid: Uuid::new_v4(),
+            kid,
+            pub_key: kp.public_key().into(),
+            target: cashu::Amount::ZERO,
+            minted: cashu::Amount::ZERO,
+            bill_id: bcr_common::core_tests::random_bill_id(),
+        };
+        db.store(op.clone()).await.unwrap();
+        let res = db.store(op).await;
+        assert!(matches!(res, Err(Error::InvalidInput(_))));
+    }
+
+    #[tokio::test]
+    async fn load_mintop() {
+        let db = init_mintops_mem_db().await;
+        let keys = core_tests::generate_random_ecash_keyset();
+        let kid = keys.0.id;
+        let kp = core_tests::generate_random_keypair();
+        let op = credit::MintOperation {
+            uid: Uuid::new_v4(),
+            kid,
+            pub_key: kp.public_key().into(),
+            target: cashu::Amount::ZERO,
+            minted: cashu::Amount::ZERO,
+            bill_id: bcr_common::core_tests::random_bill_id(),
+        };
+        db.store(op.clone()).await.unwrap();
+        let res = db.load(op.uid).await.unwrap();
+        assert_eq!(res.kid, kid);
+        assert_eq!(res.pub_key, kp.public_key().into());
+    }
+
+    #[tokio::test]
+    async fn update_mintop() {
+        let db = init_mintops_mem_db().await;
+        let keys = core_tests::generate_random_ecash_keyset();
+        let kid = keys.0.id;
+        let kp = core_tests::generate_random_keypair();
+        let op = credit::MintOperation {
+            uid: Uuid::new_v4(),
+            kid,
+            pub_key: kp.public_key().into(),
+            target: cashu::Amount::ZERO,
+            minted: cashu::Amount::ZERO,
+            bill_id: bcr_common::core_tests::random_bill_id(),
+        };
+        db.store(op.clone()).await.unwrap();
+        db.update(op.uid, cashu::Amount::ZERO, cashu::Amount::from(100u64))
+            .await
+            .unwrap();
+        let res = db.load(op.uid).await.unwrap();
+        assert_eq!(res.kid, kid);
+        assert_eq!(res.minted, cashu::Amount::from(100u64));
+    }
+
+    #[tokio::test]
+    async fn list_mintops() {
+        let db = init_mintops_mem_db().await;
+        let keys = core_tests::generate_random_ecash_keyset();
+        let kid = keys.0.id;
+        let kp = core_tests::generate_random_keypair();
+        let op1 = credit::MintOperation {
+            uid: Uuid::new_v4(),
+            kid,
+            pub_key: kp.public_key().into(),
+            target: cashu::Amount::ZERO,
+            minted: cashu::Amount::ZERO,
+            bill_id: bcr_common::core_tests::random_bill_id(),
+        };
+        db.store(op1.clone()).await.unwrap();
+        let op2 = credit::MintOperation {
+            uid: Uuid::new_v4(),
+            kid,
+            pub_key: kp.public_key().into(),
+            target: cashu::Amount::ZERO,
+            minted: cashu::Amount::ZERO,
+            bill_id: bcr_common::core_tests::random_bill_id(),
+        };
+        db.store(op2.clone()).await.unwrap();
+        let res = db.list(kid).await.unwrap();
+        assert_eq!(res.len(), 2);
+        let rids: Vec<_> = res.iter().map(|op| op.uid).collect();
+        assert!(rids.contains(&op1.uid));
+        assert!(rids.contains(&op2.uid));
     }
 }

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -10,7 +10,7 @@ use bcr_common::{
 use bitcoin::base64::prelude::*;
 use uuid::Uuid;
 // ----- local imports
-use crate::{debit, error::Result, foreign, AppController};
+use crate::{credit, debit, error::Result, foreign, AppController};
 
 // ----- end imports
 
@@ -364,5 +364,15 @@ pub async fn mint_onchain(
         tracing::debug!("Sent mint to clowder");
     }
 
+    Ok(Json(response))
+}
+
+pub async fn mint_ebill(
+    State(ctrl): State<Arc<credit::Service>>,
+    Json(req): Json<cashu::MintRequest<uuid::Uuid>>,
+) -> Result<Json<cashu::MintResponse>> {
+    tracing::debug!("Received mint request for {}", req.quote);
+
+    let response = ctrl.mint(req).await?;
     Ok(Json(response))
 }


### PR DESCRIPTION
all APIs that track the minting operations for credit satoshi are now in the treasury-service


~~part 1 / 3 - add mint operations to treasury-service~~
part 2 / 3 - move services to treasury-client for minting operations ( quote-service, admin-aggregator, wallet-aggregator)
part 3 / 3 - remove minting operations facility from core-service
part 4 / 3 - remove APIs from core-client in bcr-common