### PR TITLE
[bcr_wdc_quote_service] check offer expiration actively

### DIFF
--- a/crates/bcr-wdc-quote-service/src/monitor.rs
+++ b/crates/bcr-wdc-quote-service/src/monitor.rs
@@ -201,5 +201,14 @@ mod tests {
             srvc: Arc::new(serv),
         };
         monitor.check_quote_ebill(qid).await.unwrap();
+        // ||||||| parent of 1b0a4c4 ([bcr-wdc-quote-service] general minor improvements to quote-service)
+        //     async fn run_task(&self) -> AnyResult<()> {
+        //         self.check_quotes().await;
+        //         Ok(())
+        // =======
+        //     async fn run_task(&self, now: TStamp) -> AnyResult<Option<std::time::Duration>> {
+        //         self.check_quotes(now).await;
+        //         Ok(None)
+        // >>>>>>> 1b0a4c4 ([bcr-wdc-quote-service] general minor improvements to quote-service)
     }
 }


### PR DESCRIPTION
rather than waiting for any action to happen on the quote to trigger the update