### PR TITLE
refactor after currency unification

### DIFF
--- a/crates/bcr-wdc-admin-aggregator/src/admin.rs
+++ b/crates/bcr-wdc-admin-aggregator/src/admin.rs
@@ -8,12 +8,12 @@ use axum::{
 };
 use bcr_common::{
     cashu::{self, ProofsMethods},
-    client::treasury::Error as TreasuryClientError,
+    client::ebill::Error as EbillClientError,
     core::BillId,
     wire::{
         bill as wire_bill, clowder as wire_clowder, common as wire_common,
         identity as wire_identity, info as wire_info, keys as wire_keys, quotes as wire_quotes,
-        signatures as wire_signatures, treasury as wire_treasury, wallet as wire_wallet,
+        signatures as wire_signatures, treasury as wire_treasury,
     },
 };
 use wire_clowder::ClowderNodeInfo;
@@ -107,7 +107,7 @@ pub async fn get_mintop_status(
 ) -> Result<Json<wire_treasury::MintOperationStatus>> {
     tracing::debug!("Received mint operation status request");
 
-    let status = ctrl.treasury_cl.mint_operation_status(qid).await?;
+    let status = ctrl.treasury_cl.ebill_mint_operation_status(qid).await?;
     Ok(Json(status))
 }
 
@@ -129,7 +129,7 @@ pub async fn list_mintops(
 ) -> Result<Json<Vec<uuid::Uuid>>> {
     tracing::debug!("Received list mint operation request");
 
-    let ids = ctrl.treasury_cl.list_mint_operations(kid).await?;
+    let ids = ctrl.treasury_cl.list_ebill_mint_operations(kid).await?;
     Ok(Json(ids))
 }
 
@@ -364,8 +364,12 @@ pub async fn get_ebill_paymentstatus(
 ) -> Result<Json<wire_bill::SimplifiedBillPaymentStatus>> {
     tracing::debug!("Received ebill payment status request for {bid}");
 
-    let status = ctrl.ebill_cl.get_payment_status(bid).await?;
-    Ok(Json(status))
+    let response = ctrl.ebill_cl.get_payment_status(bid).await;
+    match response {
+        Ok(status) => Ok(Json(status)),
+        Err(EbillClientError::ResourceNotFound(resource)) => Err(Error::ResourceNotFound(resource)),
+        Err(e) => Err(Error::EBillClient(e)),
+    }
 }
 
 #[utoipa::path(
@@ -546,50 +550,6 @@ pub async fn post_ebill_reqtopay(
         .request_to_pay_ebill(req.ebill_id, req.amount, req.deadline)
         .await?;
     Ok(Json(response))
-}
-
-#[utoipa::path(
-    get,
-    path = endpoints::GET_SAT_BALANCE,
-    responses (
-        (status = 200, description = "Successful response", body = wire_wallet::ECashBalance, content_type = "application/json"),
-    )
-)]
-#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn get_sat_balance(
-    State(ctrl): State<AppController>,
-) -> Result<Json<wire_wallet::ECashBalance>> {
-    tracing::debug!("Received request for treasury sat balance");
-
-    let response = ctrl.treasury_cl.sat_balance().await?;
-    Ok(Json(response))
-}
-
-#[utoipa::path(
-    get,
-    path = endpoints::EBILL_PAY_COMPLETE,
-    responses (
-        (status = 200, description = "Successful response", body = wire_wallet::EbillPaymentComplete, content_type = "application/json"),
-        (status = 404, description = "bill id not found"),
-    )
-)]
-#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn get_ebill_mint_complete(
-    State(ctrl): State<AppController>,
-    Path(bid): Path<BillId>,
-) -> Result<Json<wire_wallet::EbillPaymentComplete>> {
-    tracing::debug!("Received request for ebill payment complete {bid}");
-
-    let response = ctrl.treasury_cl.is_ebill_mint_complete(bid).await;
-    match response {
-        Err(TreasuryClientError::ResourceNotFound(resource)) => {
-            Err(Error::ResourceNotFound(resource))
-        }
-        Err(err) => Err(Error::TreasuryClient(err)),
-        Ok(response) => Ok(Json(wire_wallet::EbillPaymentComplete {
-            complete: response,
-        })),
-    }
 }
 
 #[utoipa::path(

--- a/crates/bcr-wdc-admin-aggregator/src/lib.rs
+++ b/crates/bcr-wdc-admin-aggregator/src/lib.rs
@@ -45,6 +45,8 @@ pub struct AppController {
 }
 
 impl AppController {
+    const MINIMUM_KEYSET_FEE_RATE_PPK: u64 = 0;
+
     pub async fn new(cfg: AppConfig) -> Self {
         let AppConfig {
             core_url,
@@ -60,18 +62,25 @@ impl AppController {
         let treasury_cl = TreasuryClient::new(treasury_url);
 
         // pre-flight checklist
-        let filters = wire_keys::KeysetInfoFilters {
-            unit: Some(CoreClient::debit_unit()),
+        let filter = wire_keys::KeysetInfoFilters {
+            unit: Some(CoreClient::currency_unit()),
             ..Default::default()
         };
         let kinfos = core_cl
-            .list_keyset_info(filters)
+            .list_keyset_info(filter)
             .await
             .expect("pre-flight check failed: core service is not responding");
-        if kinfos.is_empty() {
-            tracing::warn!("pre-flight check warning: core service has no keysets configured");
+        let perpetual_kinfo = kinfos.iter().find(|k| k.final_expiry.is_none() && k.active);
+        if perpetual_kinfo.is_none() {
+            tracing::warn!(
+                "pre-flight check warning: core service has no perpetual keysets configured"
+            );
             core_cl
-                .new_keyset(CoreClient::debit_unit(), None, 0)
+                .new_keyset(
+                    CoreClient::currency_unit(),
+                    None,
+                    Self::MINIMUM_KEYSET_FEE_RATE_PPK,
+                )
                 .await
                 .expect("pre-flight check failed: core service is not responding to new_keyset");
         }
@@ -116,8 +125,6 @@ pub mod endpoints {
     pub const MINT_OP_STATUS: &str = "/v1/admin/treasury/credit/mint_op_status/{qid}";
     pub const LIST_MINT_OPS: &str = "/v1/admin/treasury/credit/mint_ops/{kid}";
     pub const POST_EBILL_REQTOPAY: &str = "/v1/admin/treasury/ebill/reqtopay";
-    pub const GET_SAT_BALANCE: &str = "/v1/admin/treasury/balance/sat";
-    pub const EBILL_PAY_COMPLETE: &str = "/v1/admin/treasury/ebill/payment_complete/{bid}";
 }
 
 pub fn routes(ctrl: AppController) -> Router {
@@ -183,11 +190,6 @@ pub fn routes(ctrl: AppController) -> Router {
         .route(
             endpoints::POST_EBILL_REQTOPAY,
             post(admin::post_ebill_reqtopay),
-        )
-        .route(endpoints::GET_SAT_BALANCE, get(admin::get_sat_balance))
-        .route(
-            endpoints::EBILL_PAY_COMPLETE,
-            get(admin::get_ebill_mint_complete),
         );
     Router::new().merge(admin).with_state(ctrl).merge(swagger)
 }
@@ -261,8 +263,6 @@ pub fn routes(ctrl: AppController) -> Router {
         admin::get_clowder_status,
         // treasury service
         admin::post_ebill_reqtopay,
-        admin::get_sat_balance,
-        admin::get_ebill_mint_complete,
     )
 )]
 pub struct ApiDoc;

--- a/crates/bcr-wdc-e2e-tests/src/clients.rs
+++ b/crates/bcr-wdc-e2e-tests/src/clients.rs
@@ -161,7 +161,7 @@ impl Service<UserService> {
         outputs: Vec<cashu::BlindedMessage>,
         sk: cashu::SecretKey,
     ) -> Vec<cashu::BlindSignature> {
-        self.treasury_cl.mint(qid, outputs, sk).await.unwrap()
+        self.treasury_cl.ebill_mint(qid, outputs, sk).await.unwrap()
     }
     /// GET v1/info
     pub async fn mint_info(&self) -> cashu::nut06::MintInfo {

--- a/crates/bcr-wdc-quote-service/src/client.rs
+++ b/crates/bcr-wdc-quote-service/src/client.rs
@@ -34,7 +34,7 @@ impl WdcClient for WildcatCl {
     ) -> Result<cashu::Id> {
         let kinfo = self
             .core
-            .get_or_create_credit_keyset_with_expiration(redemption_date)
+            .get_or_create_keyset_with_expiration(redemption_date)
             .await?;
         Ok(kinfo.id)
     }
@@ -53,7 +53,7 @@ impl WdcClient for WildcatCl {
         bill_id: BillId,
     ) -> Result<()> {
         self.treasury
-            .new_mint_operation(qid, kid, pk, target, bill_id)
+            .new_ebill_mint_operation(qid, kid, pk, target, bill_id)
             .await?;
         Ok(())
     }
@@ -64,7 +64,7 @@ impl WdcClient for WildcatCl {
     }
 
     async fn get_minting_status(&self, qid: Uuid) -> Result<MintingStatus> {
-        let response = self.treasury.mint_operation_status(qid).await;
+        let response = self.treasury.ebill_mint_operation_status(qid).await;
         match response {
             Ok(status) => Ok(MintingStatus::Enabled(status.current)),
             Err(TreasuryError::MintOpNotFound(_)) => Ok(MintingStatus::Disabled),

--- a/crates/bcr-wdc-treasury-service/src/admin.rs
+++ b/crates/bcr-wdc-treasury-service/src/admin.rs
@@ -29,17 +29,7 @@ pub async fn request_to_pay_ebill(
     Ok(Json(response))
 }
 
-pub async fn crsat_try_htlc_swap(
-    State(ctrl): State<Arc<foreign::crsat::Service>>,
-    Json(request): Json<wire_exchange::HtlcSwapAttemptRequest>,
-) -> Result<Json<cashu::Amount>> {
-    tracing::debug!("Received request to try_htlc_swap");
-
-    let amount = ctrl.try_swap_htlc(&request.preimage).await?;
-    Ok(Json(amount))
-}
-
-pub async fn sat_try_htlc_swap(
+pub async fn try_htlc_swap(
     State(ctrl): State<Arc<foreign::sat::Service>>,
     Json(request): Json<wire_exchange::HtlcSwapAttemptRequest>,
 ) -> Result<Json<cashu::Amount>> {
@@ -50,7 +40,7 @@ pub async fn sat_try_htlc_swap(
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn new_cr_mintop(
+pub async fn new_ebill_mintop(
     State(ctrl): State<Arc<credit::Service>>,
     Json(request): Json<wire_treasury::NewMintOperationRequest>,
 ) -> Result<Json<wire_treasury::NewMintOperationResponse>> {
@@ -68,7 +58,9 @@ pub async fn new_cr_mintop(
     Ok(Json(response))
 }
 
-fn convert_cr_mintop_status(status: credit::MintOperation) -> wire_treasury::MintOperationStatus {
+fn convert_ebill_mintop_status(
+    status: credit::MintOperation,
+) -> wire_treasury::MintOperationStatus {
     wire_treasury::MintOperationStatus {
         kid: status.kid,
         quote_id: status.uid,
@@ -78,19 +70,19 @@ fn convert_cr_mintop_status(status: credit::MintOperation) -> wire_treasury::Min
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn cr_mintop_status(
+pub async fn ebill_mintop_status(
     State(ctrl): State<Arc<credit::Service>>,
     Path(qid): Path<uuid::Uuid>,
 ) -> Result<Json<wire_treasury::MintOperationStatus>> {
     tracing::debug!("Received mint operation status request {qid}");
 
     let status = ctrl.mintop_status(qid).await?;
-    let status = convert_cr_mintop_status(status);
+    let status = convert_ebill_mintop_status(status);
     Ok(Json(status))
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn list_cr_mintops(
+pub async fn list_ebill_mintops(
     State(ctrl): State<Arc<credit::Service>>,
     Path(kid): Path<cashu::Id>,
 ) -> Result<Json<Vec<uuid::Uuid>>> {

--- a/crates/bcr-wdc-treasury-service/src/credit/client.rs
+++ b/crates/bcr-wdc-treasury-service/src/credit/client.rs
@@ -121,7 +121,7 @@ impl credit::WildcatClient for WildcatCl {
         let request = wire_bill::RequestToPayBitcreditBillPayload {
             bill_id,
             deadline,
-            currency: CoreClient::debit_unit().to_string(),
+            currency: CoreClient::currency_unit().to_string(),
             payment_address: todo!("payment_address not yet plumbed through"),
         };
         self.ebill.request_to_pay_bill(&request).await?;

--- a/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
@@ -37,7 +37,7 @@ impl crsat::KeysClient for CoreCl {
     ) -> Result<cashu::KeySet> {
         let kinfo = self
             .core
-            .get_or_create_credit_keyset_with_expiration(expiration)
+            .get_or_create_keyset_with_expiration(expiration)
             .await?;
         let keyset = self.core.keys(kinfo.id).await?;
         Ok(keyset)
@@ -48,13 +48,13 @@ impl crsat::KeysClient for CoreCl {
 impl sat::KeysClient for CoreCl {
     async fn get_active_keyset(&self) -> Result<cashu::KeySet> {
         let filters = wire_keys::KeysetInfoFilters {
-            unit: Some(CoreClient::debit_unit()),
+            unit: Some(CoreClient::currency_unit()),
             ..Default::default()
         };
         let kinfos = self.core.list_keyset_info(filters).await?;
         let Some(kinfo) = kinfos
             .into_iter()
-            .find(|kinfo| kinfo.unit == CoreClient::debit_unit() && kinfo.active)
+            .find(|kinfo| kinfo.unit == CoreClient::currency_unit() && kinfo.active)
         else {
             return Err(Error::InvalidInput(String::from(
                 "No active keyset found for debit unit",

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -258,21 +258,13 @@ pub async fn init_app(
 pub fn routes(app: AppController) -> Router {
     let web = Router::new()
         .route(
-            TreasuryClient::CRSATEXCHANGEONLINE_EP_V1,
-            post(web::crsat_online_exchange),
-        )
-        .route(
-            TreasuryClient::SATEXCHANGEONLINE_EP_V1,
-            post(web::sat_online_exchange),
-        )
-        .route(
-            TreasuryClient::CRSATEXCHANGEOFFLINE_EP_V1,
-            post(web::crsat_offline_exchange),
+            TreasuryClient::EXCHANGEONLINE_EP_V1,
+            post(web::online_exchange),
         )
         .route("/v1/free_money", post(devmode::free_money))
         .route(
-            TreasuryClient::SATEXCHANGEOFFLINE_EP_V1,
-            post(web::sat_offline_exchange),
+            TreasuryClient::EXCHANGEOFFLINE_EP_V1,
+            post(web::offline_exchange),
         )
         .route(
             TreasuryClient::MELTQUOTE_ONCHAIN_EP_V1,
@@ -288,22 +280,18 @@ pub fn routes(app: AppController) -> Router {
             TreasuryClient::REQTOPAY_EP_V1,
             post(admin::request_to_pay_ebill),
         )
+        .route(TreasuryClient::TRYHTLC_EP_V1, post(admin::try_htlc_swap))
         .route(
-            TreasuryClient::TRYCRSATHTLC_EP_V1,
-            post(admin::crsat_try_htlc_swap),
+            TreasuryClient::NEWEBILLMINTOP_EP_V1,
+            post(admin::new_ebill_mintop),
         )
         .route(
-            TreasuryClient::TRYSATHTLC_EP_V1,
-            post(admin::sat_try_htlc_swap),
-        )
-        .route(TreasuryClient::NEWMINTOP_EP_V1, post(admin::new_cr_mintop))
-        .route(
-            TreasuryClient::LISTMINTOPS_EP_V1,
-            get(admin::list_cr_mintops),
+            TreasuryClient::LISTEBILLMINTOPS_EP_V1,
+            get(admin::list_ebill_mintops),
         )
         .route(
-            TreasuryClient::MINTOPSTATUS_EP_V1,
-            get(admin::cr_mintop_status),
+            TreasuryClient::EBILLMINTOPSTATUS_EP_V1,
+            get(admin::ebill_mintop_status),
         );
     admin.merge(web).with_state(app)
 }

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -13,24 +13,7 @@ use crate::{debit, error::Result, foreign, AppController};
 // ----- end imports
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn crsat_online_exchange(
-    State(ctrl): State<Arc<foreign::crsat::Service>>,
-    Json(request): Json<wire_exchange::OnlineExchangeRequest>,
-) -> Result<Json<wire_exchange::OnlineExchangeResponse>> {
-    tracing::debug!("Received request to online exchange");
-
-    let exchange_path: Vec<cashu::PublicKey> = request
-        .exchange_path
-        .iter()
-        .map(|p| cashu::PublicKey::from(*p))
-        .collect();
-    let signatures = ctrl.online_exchange(request.proofs, &exchange_path).await?;
-    let response = wire_exchange::OnlineExchangeResponse { proofs: signatures };
-    Ok(Json(response))
-}
-
-#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn sat_online_exchange(
+pub async fn online_exchange(
     State(ctrl): State<Arc<foreign::sat::Service>>,
     Json(request): Json<wire_exchange::OnlineExchangeRequest>,
 ) -> Result<Json<wire_exchange::OnlineExchangeResponse>> {
@@ -47,26 +30,7 @@ pub async fn sat_online_exchange(
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn crsat_offline_exchange(
-    State(ctrl): State<AppController>,
-    Json(request): Json<wire_exchange::OfflineExchangeRequest>,
-) -> Result<Json<wire_exchange::OfflineExchangeResponse>> {
-    tracing::debug!("Received request to offline exchange");
-
-    let proofs = ctrl
-        .crsat
-        .offline_exchange(request.fingerprints, request.hashes, request.wallet_pk)
-        .await?;
-    let payload = wire_exchange::OfflineExchangePayload { proofs };
-    let serialized = borsh::to_vec(&payload)?;
-    let signature = ctrl.signer.sign_schnorr_preimage(&serialized).await?;
-    let content = BASE64_STANDARD.encode(&serialized);
-    let response = wire_exchange::OfflineExchangeResponse { content, signature };
-    Ok(Json(response))
-}
-
-#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn sat_offline_exchange(
+pub async fn offline_exchange(
     State(ctrl): State<AppController>,
     Json(request): Json<wire_exchange::OfflineExchangeRequest>,
 ) -> Result<Json<wire_exchange::OfflineExchangeResponse>> {

--- a/crates/bcr-wdc-wallet-aggregator/src/web.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/web.rs
@@ -1,14 +1,9 @@
 // ----- standard library imports
-use std::{collections::HashSet, sync::Arc};
 // ----- extra library imports
-use async_trait::async_trait;
 use axum::extract::{Json, Path, State};
 use bcr_common::{
     cashu::{self, MintVersion},
-    client::{
-        clowder::Client as ClowderClient, core::Client as CoreClient,
-        treasury::Client as TreasuryClient,
-    },
+    client::{clowder::Client as ClowderClient, treasury::Client as TreasuryClient},
     wire::{
         clowder::{self as wire_clowder, messages},
         exchange as wire_exchange,
@@ -17,7 +12,6 @@ use bcr_common::{
     },
 };
 use bitcoin::base64::{engine::general_purpose::STANDARD, Engine};
-use futures::future::JoinAll;
 // ----- local imports
 use crate::{
     error::{Error, Result},
@@ -231,23 +225,17 @@ pub async fn post_swap(
     ctrl.commit_srv
         .check_swap(now, &request.inputs, &request.outputs, &request.commitment)
         .await?;
-
     let wire_swap::SwapRequest {
         inputs,
         outputs,
         commitment,
     } = request;
-
-    let input_type =
-        determine_input_type(&ctrl.core_client, inputs.iter().map(|p| p.keyset_id)).await?;
-    let htlc_unlocked = test_for_htlc(&inputs, input_type, &ctrl.treasury_client).await?;
+    let htlc_unlocked = test_for_htlc(&inputs, &ctrl.treasury_client).await?;
     tracing::info!("HTLC unlocked in intermint exchange: {}", htlc_unlocked);
-
     let signatures = ctrl
         .core_client
         .swap(inputs.clone(), outputs.clone(), commitment)
         .await?;
-
     let req = messages::SwapRequest {
         proofs: inputs,
         blinds: outputs,
@@ -257,7 +245,6 @@ pub async fn post_swap(
         signatures: signatures.clone(),
     };
     ctrl.clwdr_stream_client.mint_swap(req, resp).await?;
-
     Ok(Json(wire_swap::SwapResponse { signatures }))
 }
 
@@ -439,12 +426,6 @@ pub async fn post_online_exchange(
             "minimum exchange path [alpha_pk, this_mint_pk, wallet_pk] not met",
         )));
     }
-    let clowder_keys = ForeignKeyClientWithClowder {
-        clwdr_cl: ctrl.clwdr_rest_client.clone(),
-        pk: request.exchange_path[0],
-    };
-    let input_type =
-        determine_input_type(&clowder_keys, request.proofs.iter().map(|p| p.keyset_id)).await?;
     // Clone what we need for the stream before consuming request
     let stream_proofs = request.proofs.clone();
     let stream_exchange_path = request.exchange_path.clone();
@@ -452,18 +433,10 @@ pub async fn post_online_exchange(
         proofs,
         exchange_path,
     } = request;
-    let proofs = match input_type {
-        InputType::Sat => {
-            ctrl.treasury_client
-                .sat_exchange_online(proofs, exchange_path)
-                .await?
-        }
-        InputType::CrSat => {
-            ctrl.treasury_client
-                .crsat_exchange_online(proofs, exchange_path)
-                .await?
-        }
-    };
+    let proofs = ctrl
+        .treasury_client
+        .exchange_online(proofs, exchange_path)
+        .await?;
     if let Err(e) = ctrl
         .clwdr_stream_client
         .mint_foreign_ecash(
@@ -495,19 +468,10 @@ pub async fn post_offline_exchange(
     State(ctrl): State<AppController>,
     Json(request): Json<wire_exchange::OfflineExchangeRequest>,
 ) -> Result<Json<wire_exchange::OfflineExchangeResponse>> {
-    let origin = ctrl
+    let _origin = ctrl
         .clwdr_rest_client
         .post_fingerprints_origin(request.fingerprints.clone())
         .await?;
-    let clowder_keys = ForeignKeyClientWithClowder {
-        clwdr_cl: ctrl.clwdr_rest_client.clone(),
-        pk: origin.node_id,
-    };
-    let input_type = determine_input_type(
-        &clowder_keys,
-        request.fingerprints.iter().map(|fp| fp.keyset_id),
-    )
-    .await?;
     // Clone what we need for the stream before consuming request
     let stream_fingerprints = request.fingerprints.clone();
     let stream_hashes = request.hashes.clone();
@@ -516,18 +480,10 @@ pub async fn post_offline_exchange(
         hashes,
         wallet_pk,
     } = request;
-    let response = match input_type {
-        InputType::Sat => {
-            ctrl.treasury_client
-                .sat_exchange_offline_raw(fingerprints, hashes, wallet_pk)
-                .await?
-        }
-        InputType::CrSat => {
-            ctrl.treasury_client
-                .crsat_exchange_offline_raw(fingerprints, hashes, wallet_pk)
-                .await?
-        }
-    };
+    let response = ctrl
+        .treasury_client
+        .exchange_offline_raw(fingerprints, hashes, wallet_pk)
+        .await?;
     let serialized = STANDARD
         .decode(&response.content)
         .map_err(|e| Error::InvalidInput(e.to_string()))?;
@@ -616,125 +572,15 @@ pub async fn post_commit(
     Ok(Json(response))
 }
 
-#[derive(Debug, Clone, Copy)]
-enum InputType {
-    CrSat,
-    Sat,
-}
-
-#[cfg_attr(test, mockall::automock)]
-#[async_trait]
-trait KeyClientT {
-    // returns the currency unit for the given keyset id
-    async fn currency(&self, keyset_id: cashu::Id) -> Result<cashu::CurrencyUnit>;
-}
-
-#[async_trait]
-impl KeyClientT for CoreClient {
-    async fn currency(&self, keyset_id: cashu::Id) -> Result<cashu::CurrencyUnit> {
-        let cr_response = self.keyset_info(keyset_id).await?;
-        Ok(cr_response.unit)
-    }
-}
-pub struct ForeignKeyClientWithClowder {
-    clwdr_cl: Arc<clwdr_client::ClowderRestClient>,
-    pk: bitcoin::secp256k1::PublicKey,
-}
-#[async_trait]
-impl KeyClientT for ForeignKeyClientWithClowder {
-    async fn currency(&self, keyset_id: cashu::Id) -> Result<cashu::CurrencyUnit> {
-        let keys = self.clwdr_cl.get_keyset(&self.pk, &keyset_id).await?;
-        let Some(keyset) = keys.keysets.first() else {
-            return Err(Error::Invalid(format!("keyset {keyset_id} not found")));
-        };
-        Ok(keyset.unit.clone())
-    }
-}
-
-async fn determine_input_type(
-    key_cl: &impl KeyClientT,
-    inputs: impl std::iter::Iterator<Item = cashu::Id>,
-) -> Result<InputType> {
-    let unique_kids = inputs.collect::<HashSet<_>>();
-    let requests: JoinAll<_> = unique_kids
-        .into_iter()
-        .map(|kid| key_cl.currency(kid))
-        .collect();
-    let responses: Vec<_> = requests.await.into_iter().collect::<Result<_>>()?;
-    let all_sats = responses
-        .iter()
-        .all(|unit| *unit == cashu::CurrencyUnit::Sat);
-    if all_sats {
-        return Ok(InputType::Sat);
-    }
-    let crsat = cashu::CurrencyUnit::Custom(String::from("crsat"));
-    let all_crsat = responses.iter().all(|unit| *unit == crsat);
-    if all_crsat {
-        return Ok(InputType::CrSat);
-    }
-    Err(Error::InvalidInput(String::from(
-        "mixed credit/debit inputs not allowed",
-    )))
-}
-
-async fn test_for_htlc(
-    proofs: &[cashu::Proof],
-    input_type: InputType,
-    tcl: &TreasuryClient,
-) -> Result<cashu::Amount> {
+async fn test_for_htlc(proofs: &[cashu::Proof], tcl: &TreasuryClient) -> Result<cashu::Amount> {
     let mut total = cashu::Amount::ZERO;
     for proof in proofs {
         if let Some(cashu::Witness::HTLCWitness(cashu::HTLCWitness { preimage, .. })) =
             &proof.witness
         {
-            let amount = match input_type {
-                InputType::CrSat => tcl.try_crsat_htlc(preimage.to_string()).await?,
-                InputType::Sat => tcl.try_sat_htlc(preimage.to_string()).await?,
-            };
+            let amount = tcl.try_htlc(preimage.to_string()).await?;
             total += amount;
         }
     }
     Ok(total)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bcr_common::core_tests;
-    use mockall::predicate::*;
-
-    #[tokio::test]
-    async fn determine_input_type_sat() {
-        let (_, sat_keyset) = core_tests::generate_random_ecash_keyset();
-        let amounts = [cashu::Amount::from(4u64), cashu::Amount::from(4u64)];
-        let inputs =
-            [core_tests::generate_random_ecash_proofs(&sat_keyset, &amounts[..1])[0].clone()];
-        let mut client = MockKeyClientT::new();
-        let sat_kid = sat_keyset.id;
-        client
-            .expect_currency()
-            .times(1)
-            .with(eq(sat_kid))
-            .returning(|_| Ok(cashu::CurrencyUnit::Sat));
-        let inputtype = determine_input_type(&client, inputs.iter().map(|p| p.keyset_id))
-            .await
-            .unwrap();
-        assert!(matches!(inputtype, InputType::Sat));
-    }
-
-    #[tokio::test]
-    async fn determine_input_type_crsat() {
-        let (_, keyset) = core_tests::generate_random_ecash_keyset();
-        let amounts = [cashu::Amount::from(4u64), cashu::Amount::from(8u64)];
-        let inputs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
-        let mut client = MockKeyClientT::new();
-        client
-            .expect_currency()
-            .times(1)
-            .returning(move |_| Ok(cashu::CurrencyUnit::Custom(String::from("crsat"))));
-        let inputtype = determine_input_type(&client, inputs.iter().map(|p| p.keyset_id))
-            .await
-            .unwrap();
-        assert!(matches!(inputtype, InputType::CrSat));
-    }
 }


### PR DESCRIPTION
minimum set of changes to have wildcat compile with new currency unification refactoring

treasury-service needs further refactoring:
- credit / debit modules will be renamed and refactored to e-bill / onChain, sub-modules responsible for mint/melt operations of e-ebill and onChain eCash
- foreign::sat module will be moved to simply foreign