### PR TITLE
[bcr-wdc-treasury-service] remove optional nats URL

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/credit/client.rs
+++ b/crates/bcr-wdc-treasury-service/src/credit/client.rs
@@ -24,6 +24,7 @@ use crate::{
 
 // ----- end imports
 
+#[allow(dead_code)]
 pub struct DummyClwdr {}
 #[async_trait]
 impl credit::ClowderClient for DummyClwdr {
@@ -132,16 +133,13 @@ impl credit::ClowderClient for ClwdrCl {
     }
 }
 pub fn new_clowder_client(
-    nats_cl: Option<Arc<ClowderNatsClient>>,
+    nats_cl: Arc<ClowderNatsClient>,
     rest_cl: Arc<ClowderRestClient>,
 ) -> Box<dyn credit::ClowderClient> {
-    let cl: Box<dyn credit::ClowderClient> = match nats_cl {
-        None => Box::new(DummyClwdr {}),
-        Some(nats_cl) => Box::new(ClwdrCl {
-            nats: nats_cl,
-            rest: rest_cl,
-        }),
-    };
+    let cl: Box<dyn credit::ClowderClient> = Box::new(ClwdrCl {
+        nats: nats_cl,
+        rest: rest_cl,
+    });
     cl
 }
 

--- a/crates/bcr-wdc-treasury-service/src/debit/clowder.rs
+++ b/crates/bcr-wdc-treasury-service/src/debit/clowder.rs
@@ -19,7 +19,7 @@ use crate::{
 
 pub struct ClowderCl {
     pub rest: Arc<ClowderRestClient>,
-    pub nats: Option<Arc<ClowderNatsClient>>,
+    pub nats: Arc<ClowderNatsClient>,
     pub signatory: Arc<SignatoryNatsClient>,
     pub min_confirmations: u32,
 }
@@ -42,10 +42,8 @@ impl ClowderClient for ClowderCl {
         req: clowder_messages::RequestToPayEbillRequest,
         resp: clowder_messages::RequestToPayEbillResponse,
     ) -> Result<()> {
-        let Some(nats) = &self.nats else {
-            return Ok(());
-        };
-        nats.request_to_pay_bill(req, resp)
+        self.nats
+            .request_to_pay_bill(req, resp)
             .await
             .map(|_| ())
             .map_err(Error::ClowderClient)
@@ -85,9 +83,6 @@ impl ClowderClient for ClowderCl {
         kid: cashu::Id,
         signatures: Vec<cashu::BlindSignature>,
     ) -> Result<Vec<cashu::BlindSignature>> {
-        let Some(nats) = &self.nats else {
-            return Ok(signatures);
-        };
         let output_amount = signatures
             .iter()
             .fold(cashu::Amount::ZERO, |acc, sig| acc + sig.amount);
@@ -97,7 +92,7 @@ impl ClowderClient for ClowderCl {
             amount: output_amount,
         };
         let response = clowder_messages::MintOnchainResponse { signatures };
-        let response = nats.mint_onchain(request, response).await?;
+        let response = self.nats.mint_onchain(request, response).await?;
         Ok(response.signatures)
     }
 
@@ -131,16 +126,13 @@ impl ClowderClient for ClowderCl {
         address: bitcoin::Address,
         proofs: Vec<cashu::Proof>,
     ) -> Result<wire_melt::MeltTx> {
-        let Some(nats) = &self.nats else {
-            return Err(Error::ClowderUnavailable);
-        };
         let request = clowder_messages::MeltOnchainRequest {
             quote: qid,
             address: address.into_unchecked(),
             amount,
             proofs,
         };
-        let response = nats.melt_onchain(request).await?;
+        let response = self.nats.melt_onchain(request).await?;
         Ok(response.txid)
     }
 }

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -43,7 +43,7 @@ pub struct AppConfig {
     core_url: ClientUrl,
     ebill_url: ClientUrl,
     clowder_rest_url: reqwest::Url,
-    clowder_nats_url: Option<reqwest::Url>,
+    clowder_nats_url: reqwest::Url,
     signer_url: reqwest::Url,
 }
 
@@ -77,7 +77,7 @@ pub struct AppController {
     crsat: Arc<foreign::crsat::Service>,
     sat: Arc<ProdSatService>,
     signer: Arc<SignatoryNatsClient>,
-    clwdr_nats: Option<Arc<ClowderNatsClient>>,
+    clwdr_nats: Arc<ClowderNatsClient>,
     clwdr_rest: Arc<ClowderRestClient>,
     dev: Arc<devmode::Service>,
 }
@@ -116,15 +116,10 @@ pub async fn init_app(
     let core_client = Arc::new(CoreClient::new(core_url));
     let ebill_client = EbClient::new(ebill_url);
     let clowder_rest_client = Arc::new(ClowderRestClient::new(clowder_rest_url));
-    let clowder_nats_client = if let Some(url) = clowder_nats_url {
-        Some(Arc::new(
-            ClowderNatsClient::new(url)
-                .await
-                .expect("Failed to create clowder nats client"),
-        ))
-    } else {
-        None
-    };
+    let nats_cl = ClowderNatsClient::new(clowder_nats_url)
+        .await
+        .expect("Failed to create clowder nats client");
+    let clowder_nats_client = Arc::new(nats_cl);
     let signer_client = Arc::new(
         SignatoryNatsClient::new(signer_url, None)
             .await


### PR DESCRIPTION
clowder is no longer an optional service that can be run or not