### PR TITLE
[bcr-wdc-wallet-aggregator] remove empty wrappers

### DIFF
--- a/crates/bcr-wdc-wallet-aggregator/Cargo.toml
+++ b/crates/bcr-wdc-wallet-aggregator/Cargo.toml
@@ -29,8 +29,6 @@ tower-http = { version = "0.6.2" }
 tracing = {workspace = true }
 tracing-log = {workspace = true}
 tracing-subscriber = {workspace = true}
-utoipa = {workspace = true, features = ["axum_extras"]}
-utoipa-swagger-ui = {workspace = true, features = ["axum"]}
 uuid = {workspace = true}
 
 [dev-dependencies]

--- a/crates/bcr-wdc-wallet-aggregator/src/lib.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/lib.rs
@@ -6,16 +6,8 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use bcr_common::{
-    cashu,
-    client::clowder::Client as ClowderClient,
-    wire::{
-        clowder::{self as wire_clowder},
-        exchange as wire_exchange,
-    },
-};
+use bcr_common::client::{clowder::Client as ClowderClient, core::Client as CoreClient};
 use bcr_wdc_utils::surreal;
-use utoipa::OpenApi;
 // ----- local modules
 mod commitment;
 mod error;
@@ -92,28 +84,13 @@ impl AppController {
 }
 
 pub async fn routes(app: AppController) -> Result<Router> {
-    let swagger = utoipa_swagger_ui::SwaggerUi::new("/swagger-ui")
-        .url("/api-docs/openapi.json", ApiDoc::openapi());
-
     let router = Router::new()
         .route("/health", get(web::health))
         // Cashu Endpoints
         .route("/v1/info", get(web::get_mint_info))
         .route("/v1/wildcat", get(web::get_wildcat_info))
-        .route("/v1/keys", get(web::get_mint_keys))
-        .route("/v1/keysets", get(web::get_mint_keysets))
-        .route("/v1/keysets/{kid}", get(web::get_keyset_info))
-        .route("/v1/keys/{kid}", get(web::get_mint_keyset))
-        .route("/v1/swap", post(web::post_swap))
-        .route("/v1/checkstate", post(web::post_check_state))
-        .route("/v1/restore", post(web::post_restore))
-        .route("/v1/swap/commitment", post(web::post_commit))
+        .route(CoreClient::SWAP_EP_V1, post(web::post_swap))
         // Clowder Endpoints
-        .route(ClowderClient::LOCAL_INFO_EP_V1, get(web::get_clowder_info))
-        .route(
-            ClowderClient::LOCAL_PATH_EP_V1,
-            post(web::post_clowder_path),
-        )
         .route(
             ClowderClient::ONLINE_EXCHANGE_EP_V1,
             post(web::post_online_exchange),
@@ -122,77 +99,7 @@ pub async fn routes(app: AppController) -> Result<Router> {
             ClowderClient::OFFLINE_EXCHANGE_EP_V1,
             post(web::post_offline_exchange),
         )
-        .route(
-            ClowderClient::LOCAL_BETAS_EP_V1,
-            get(web::get_clowder_betas),
-        )
-        .route(
-            ClowderClient::FOREIGN_OFFLINE_EP_V1,
-            get(web::get_foreign_offline),
-        )
-        .route(
-            ClowderClient::FOREIGN_STATUS_EP_V1,
-            get(web::get_foreign_status),
-        )
-        .route(
-            ClowderClient::FOREIGN_SUBSTITUTE_EP_V1,
-            get(web::get_foreign_substitute),
-        )
-        .route(
-            ClowderClient::FOREIGN_KEYSETS_EP_V1,
-            get(web::get_foreign_keysets),
-        )
         .route(ClowderClient::LOCAL_COVERAGE_EP_V1, get(web::get_coverage))
-        .route(
-            ClowderClient::LOCAL_DERIVE_EBILL_PAYMENT_ADDRESS_EP_V1,
-            get(web::post_derive_ebill_payment_address),
-        )
-        .with_state(app)
-        .merge(swagger);
+        .with_state(app);
     Ok(router)
 }
-
-#[derive(utoipa::OpenApi)]
-#[openapi(
-    components(schemas(
-        // clowder service
-        wire_clowder::OfflineResponse,
-        wire_clowder::AlphaStateResponse,
-        wire_clowder::ConnectedMintResponse,
-        wire_clowder::ConnectedMintsResponse,
-        wire_clowder::PathRequest,
-        wire_clowder::ClowderNodeInfo,
-        wire_clowder::Coverage,
-        bcr_common::wire::info::WildcatInfo,
-        bcr_common::wire::info::VersionInfo,
-        // exchange service
-        wire_exchange::OnlineExchangeRequest,
-        wire_exchange::OnlineExchangeResponse,
-        wire_exchange::OfflineExchangeRequest,
-        wire_exchange::OfflineExchangeResponse,
-        // cashu types
-        cashu::KeysResponse,
-    )),
-    paths(
-        crate::web::health,
-        crate::web::get_wildcat_info,
-        crate::web::get_mint_keys,
-        crate::web::get_mint_keysets,
-        crate::web::get_mint_keyset,
-        crate::web::post_swap,
-        crate::web::post_check_state,
-        crate::web::post_restore,
-        crate::web::get_clowder_info,
-        crate::web::post_clowder_path,
-        crate::web::get_clowder_betas,
-        crate::web::get_foreign_offline,
-        crate::web::get_foreign_status,
-        crate::web::get_foreign_substitute,
-        crate::web::get_foreign_keysets,
-        crate::web::post_online_exchange,
-        crate::web::post_offline_exchange,
-        crate::web::get_coverage,
-        crate::web::post_derive_ebill_payment_address,
-    )
-)]
-struct ApiDoc;

--- a/crates/bcr-wdc-wallet-aggregator/src/web.rs
+++ b/crates/bcr-wdc-wallet-aggregator/src/web.rs
@@ -1,9 +1,9 @@
 // ----- standard library imports
 // ----- extra library imports
-use axum::extract::{Json, Path, State};
+use axum::extract::{Json, State};
 use bcr_common::{
     cashu::{self, MintVersion},
-    client::{clowder::Client as ClowderClient, treasury::Client as TreasuryClient},
+    client::treasury::Client as TreasuryClient,
     wire::{
         clowder::{self as wire_clowder, messages},
         exchange as wire_exchange,
@@ -20,24 +20,10 @@ use crate::{
 
 // ----- end imports
 
-#[utoipa::path(
-    get,
-    path = "/health",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
 pub async fn health() -> Result<&'static str> {
     Ok("{ \"status\": \"OK\" }")
 }
 
-#[utoipa::path(
-    get,
-    path = "/v1/info",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
 pub async fn get_mint_info(State(ctrl): State<AppController>) -> Result<Json<cashu::MintInfo>> {
     tracing::debug!("Requested /v1/info");
     let network = ctrl.clwdr_rest_client.get_info().await?.network;
@@ -79,13 +65,6 @@ build-time = {build_time}
     Ok(Json(info))
 }
 
-#[utoipa::path(
-    get,
-    path = "/v1/wildcat",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
 pub async fn get_wildcat_info(State(ctrl): State<AppController>) -> Result<Json<WildcatInfo>> {
     tracing::debug!("Requested /v1/wildcat");
 
@@ -127,104 +106,12 @@ pub async fn get_wildcat_info(State(ctrl): State<AppController>) -> Result<Json<
     Ok(Json(wildcat_info))
 }
 
-#[utoipa::path(
-    get,
-    path = "/v1/keys",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_mint_keys(State(ctrl): State<AppController>) -> Result<Json<cashu::KeysResponse>> {
-    tracing::debug!("Requested /v1/keys");
-
-    let bcr_keys = ctrl.core_client.list_keys().await.unwrap_or_default();
-    let response = cashu::KeysResponse { keysets: bcr_keys };
-    Ok(Json(response))
-}
-
-#[utoipa::path(
-    get,
-    path = "/v1/keysets",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_mint_keysets(
-    State(ctrl): State<AppController>,
-) -> Result<Json<cashu::KeysetResponse>> {
-    tracing::debug!("Requested /v1/keysets");
-
-    let bcr_infos = ctrl
-        .core_client
-        .list_keyset_info(Default::default())
-        .await
-        .unwrap_or_default();
-    let response = cashu::KeysetResponse { keysets: bcr_infos };
-    Ok(Json(response))
-}
-
-#[utoipa::path(
-    get,
-    path = "/v1/keys/{kid}",
-    params(
-        ("kid" = cashu::Id, Path, description = "The keyset id")
-    ),
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-        (status = 404, description = "Keyset not found"),
-    )
-)]
-pub async fn get_mint_keyset(
-    State(ctrl): State<AppController>,
-    Path(kid): Path<cashu::Id>,
-) -> Result<Json<cashu::KeysResponse>> {
-    tracing::debug!("Requested /v1/keys/{}", kid);
-
-    let keys = ctrl.core_client.keys(kid).await?;
-    let response = cashu::KeysResponse {
-        keysets: vec![keys],
-    };
-    Ok(Json(response))
-}
-
-#[utoipa::path(
-    get,
-    path = "/v1/keysets/{kid}",
-    params(
-        ("kid" = cashu::Id, Path, description = "The keyset id")
-    ),
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-        (status = 404, description = "Keyset not found"),
-    )
-)]
-pub async fn get_keyset_info(
-    State(ctrl): State<AppController>,
-    Path(kid): Path<cashu::Id>,
-) -> Result<Json<cashu::KeySetInfo>> {
-    tracing::debug!("Requested /v1/keysets/{}", kid);
-
-    let info = ctrl.core_client.keyset_info(kid).await?;
-    Ok(Json(info))
-}
-
-#[utoipa::path(
-    post,
-    path = "/v1/swap",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
 pub async fn post_swap(
     State(ctrl): State<AppController>,
     Json(request): Json<wire_swap::SwapRequest>,
 ) -> Result<Json<wire_swap::SwapResponse>> {
     tracing::debug!("Requested /v1/swap");
 
-    let now = chrono::Utc::now();
-    ctrl.commit_srv
-        .check_swap(now, &request.inputs, &request.outputs, &request.commitment)
-        .await?;
     let wire_swap::SwapRequest {
         inputs,
         outputs,
@@ -248,174 +135,6 @@ pub async fn post_swap(
     Ok(Json(wire_swap::SwapResponse { signatures }))
 }
 
-#[utoipa::path(
-    post,
-    path = "/v1/checkstate",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn post_check_state(
-    State(ctrl): State<AppController>,
-    Json(request): Json<cashu::CheckStateRequest>,
-) -> Result<Json<cashu::CheckStateResponse>> {
-    tracing::debug!("Requested /v1/checkstate");
-
-    let credit_states = ctrl.core_client.check_state(request.ys.clone()).await?;
-    Ok(Json(cashu::CheckStateResponse {
-        states: credit_states,
-    }))
-}
-
-#[utoipa::path(
-    post,
-    path = "/v1/restore",
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn post_restore(
-    State(ctrl): State<AppController>,
-    Json(request): Json<cashu::RestoreRequest>,
-) -> Result<Json<cashu::RestoreResponse>> {
-    tracing::debug!("Requested /v1/restore");
-
-    let cashu::RestoreRequest { outputs } = request;
-    let restore_pair = ctrl.core_client.restore(outputs).await?;
-    let (outputs, signatures) = restore_pair.into_iter().unzip();
-    let response = cashu::RestoreResponse {
-        outputs,
-        signatures,
-        promises: Default::default(),
-    };
-    Ok(Json(response))
-}
-
-#[utoipa::path(
-    get,
-    path = ClowderClient::LOCAL_INFO_EP_V1,
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_clowder_info(
-    State(ctrl): State<AppController>,
-) -> Result<Json<wire_clowder::ClowderNodeInfo>> {
-    Ok(Json(ctrl.clwdr_rest_client.get_info().await?))
-}
-
-#[utoipa::path(
-    post,
-    path = ClowderClient::LOCAL_PATH_EP_V1,
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn post_clowder_path(
-    State(ctrl): State<AppController>,
-    Json(request): Json<wire_clowder::PathRequest>,
-) -> Result<Json<wire_clowder::ConnectedMintsResponse>> {
-    Ok(Json(
-        ctrl.clwdr_rest_client
-            .post_path(request.origin_mint_url)
-            .await?,
-    ))
-}
-
-#[utoipa::path(
-    get,
-    path = ClowderClient::LOCAL_BETAS_EP_V1,
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_clowder_betas(
-    State(ctrl): State<AppController>,
-) -> Result<Json<wire_clowder::ConnectedMintsResponse>> {
-    Ok(Json(ctrl.clwdr_rest_client.get_betas().await?))
-}
-
-#[utoipa::path(
-    get,
-    path = ClowderClient::FOREIGN_OFFLINE_EP_V1,
-    params(
-        ("alpha_id" = String, Path, description = "The alpha public key")
-    ),
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_foreign_offline(
-    State(ctrl): State<AppController>,
-    Path(alpha_id): Path<bitcoin::secp256k1::PublicKey>,
-) -> Result<Json<wire_clowder::OfflineResponse>> {
-    tracing::debug!("Requested /v1/foreign/offline/{alpha_id}");
-    Ok(Json(ctrl.clwdr_rest_client.get_offline(alpha_id).await?))
-}
-
-#[utoipa::path(
-    get,
-    path = ClowderClient::FOREIGN_STATUS_EP_V1,
-    params(
-        ("alpha_id" = String, Path, description = "The alpha public key")
-    ),
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_foreign_status(
-    State(ctrl): State<AppController>,
-    Path(alpha_id): Path<bitcoin::secp256k1::PublicKey>,
-) -> Result<Json<wire_clowder::AlphaStateResponse>> {
-    tracing::debug!("Requested /v1/foreign/status/{alpha_id}");
-    Ok(Json(ctrl.clwdr_rest_client.get_status(alpha_id).await?))
-}
-
-#[utoipa::path(
-    get,
-    path = ClowderClient::FOREIGN_SUBSTITUTE_EP_V1,
-    params(
-        ("alpha_id" = String, Path, description = "The alpha public key")
-    ),
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_foreign_substitute(
-    State(ctrl): State<AppController>,
-    Path(alpha_id): Path<bitcoin::secp256k1::PublicKey>,
-) -> Result<Json<wire_clowder::ConnectedMintResponse>> {
-    tracing::debug!("Requested /v1/foreign/substitute/{alpha_id}");
-    Ok(Json(ctrl.clwdr_rest_client.get_substitute(alpha_id).await?))
-}
-
-#[utoipa::path(
-    get,
-    path = ClowderClient::FOREIGN_KEYSETS_EP_V1,
-    params(
-        ("alpha_id" = String, Path, description = "The alpha public key")
-    ),
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-pub async fn get_foreign_keysets(
-    State(ctrl): State<AppController>,
-    Path(alpha_id): Path<bitcoin::secp256k1::PublicKey>,
-) -> Result<Json<cashu::KeysResponse>> {
-    tracing::debug!("Requested /v1/foreign/keysets/{alpha_id}");
-    Ok(Json(
-        ctrl.clwdr_rest_client.get_active_keysets(&alpha_id).await?,
-    ))
-}
-
-#[utoipa::path(
-    post,
-    path = ClowderClient::ONLINE_EXCHANGE_EP_V1,
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl, request))]
 pub async fn post_online_exchange(
     State(ctrl): State<AppController>,
@@ -456,13 +175,6 @@ pub async fn post_online_exchange(
     Ok(Json(response))
 }
 
-#[utoipa::path(
-    post,
-    path = ClowderClient::OFFLINE_EXCHANGE_EP_V1,
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl, request))]
 pub async fn post_offline_exchange(
     State(ctrl): State<AppController>,
@@ -509,13 +221,6 @@ pub async fn post_offline_exchange(
     Ok(Json(response))
 }
 
-#[utoipa::path(
-    get,
-    path = ClowderClient::LOCAL_COVERAGE_EP_V1,
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
 pub async fn get_coverage(
     State(ctrl): State<AppController>,
@@ -530,70 +235,6 @@ pub async fn get_coverage(
         ebill_collateral: collateral.ebill,
         eiou_collateral: collateral.eiou,
     }))
-}
-
-#[utoipa::path(
-    post,
-    path = ClowderClient::LOCAL_DERIVE_EBILL_PAYMENT_ADDRESS_EP_V1,
-    responses (
-        (status = 200, description = "Successful response", content_type = "application/json"),
-    )
-)]
-#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl))]
-pub async fn post_derive_ebill_payment_address(
-    State(ctrl): State<AppController>,
-    Json(request): Json<wire_clowder::DeriveEbillPaymentAddressRequest>,
-) -> Result<Json<wire_clowder::DeriveEbillPaymentAddressResponse>> {
-    tracing::debug!("Requested /v1/local/derive_ebill_payment_address");
-    let resp = ctrl
-        .clwdr_rest_client
-        .derive_ebill_payment_address(
-            request.bill_id,
-            request.block_id,
-            request.previous_block_hash,
-        )
-        .await?;
-    Ok(Json(resp))
-}
-
-#[tracing::instrument(level = tracing::Level::DEBUG, skip(ctrl, request))]
-pub async fn post_commit(
-    State(ctrl): State<AppController>,
-    Json(request): Json<wire_swap::SwapCommitmentRequest>,
-) -> Result<Json<wire_swap::SwapCommitmentResponse>> {
-    let now = chrono::Utc::now();
-    let (ys, secrets, expiry) = ctrl.commit_srv.commit(now, &request).await?;
-
-    // stream commitment to Clowder and get signed response
-    let clowder_req = messages::SwapCommitmentRequest {
-        content: request.content.clone(),
-        wallet_key: request.wallet_key,
-        wallet_signature: request.wallet_signature,
-    };
-    let clowder_resp = ctrl
-        .clwdr_stream_client
-        .swap_commitment(clowder_req)
-        .await?;
-
-    // store commitment with the Clowder-signed signature
-    ctrl.commit_srv
-        .store_commitment(
-            ys,
-            secrets,
-            request.wallet_key,
-            clowder_resp.commitment,
-            expiry,
-        )
-        .await?;
-
-    let serialized = borsh::to_vec(&request)?;
-    let content = STANDARD.encode(&serialized);
-
-    let response = wire_swap::SwapCommitmentResponse {
-        content,
-        commitment: clowder_resp.commitment,
-    };
-    Ok(Json(response))
 }
 
 async fn test_for_htlc(proofs: &[cashu::Proof], tcl: &TreasuryClient) -> Result<cashu::Amount> {


### PR DESCRIPTION
some of the API that the wallet aggregator used to provide no longer make sense.
There is no need to aggregate such functions any more, we can simply redirect such APIs directly to the internal services