### PR TITLE
[bcr-wdc-core-service] update commiment repository

### DIFF
--- a/crates/bcr-wdc-core-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-core-service/src/persistence/inmemory.rs
@@ -46,6 +46,8 @@ impl persistence::KeysRepository for KeyMap {
         max_expiration_tstamp: Option<u64>,
     ) -> Result<Vec<MintKeySetInfo>> {
         let rlocked = self.keys.read().unwrap();
+        let max_exp = max_expiration_tstamp.unwrap_or(u64::MAX);
+        let min_exp = min_expiration_tstamp.unwrap_or(u64::MIN);
         let a = rlocked
             .iter()
             .filter_map(|(_, (info, _))| {
@@ -54,14 +56,11 @@ impl persistence::KeysRepository for KeyMap {
                         return None;
                     }
                 }
-                if info.final_expiry.unwrap_or_default()
-                    <= min_expiration_tstamp.unwrap_or_default()
-                {
+                let exp = info.final_expiry.unwrap_or_default();
+                if exp < min_exp {
                     return None;
                 }
-                if info.final_expiry.unwrap_or_default()
-                    >= max_expiration_tstamp.unwrap_or_default()
-                {
+                if exp > max_exp {
                     return None;
                 }
                 Some(info)
@@ -185,6 +184,7 @@ type Commitment = (
     Vec<cashu::PublicKey>,
     TStamp,
     cashu::PublicKey,
+    schnorr::Signature,
 );
 #[allow(dead_code)]
 #[derive(Clone, Default)]
@@ -196,13 +196,13 @@ pub struct CommitmentMap {
 impl persistence::CommitmentRepository for CommitmentMap {
     async fn clean_expired(&self, now: TStamp) -> Result<()> {
         let mut commitments = self.commitments.write().unwrap();
-        commitments.retain(|_, (_, _, expiration, _)| *expiration > now);
+        commitments.retain(|_, (_, _, expiration, _, _)| *expiration > now);
         Ok(())
     }
 
     async fn contains_inputs(&self, ys: &[cashu::PublicKey]) -> Result<bool> {
         let commitments = self.commitments.read().unwrap();
-        for (_, (inputs, _, _, _)) in commitments.iter() {
+        for (_, (inputs, _, _, _, _)) in commitments.iter() {
             for y in ys {
                 if inputs.contains(y) {
                     return Ok(true);
@@ -214,7 +214,7 @@ impl persistence::CommitmentRepository for CommitmentMap {
 
     async fn contains_outputs(&self, secrets: &[cashu::PublicKey]) -> Result<bool> {
         let commitments = self.commitments.read().unwrap();
-        for (_, (_, outputs, _, _)) in commitments.iter() {
+        for (_, (_, outputs, _, _, _)) in commitments.iter() {
             for secret in secrets {
                 if outputs.contains(secret) {
                     return Ok(true);
@@ -230,34 +230,29 @@ impl persistence::CommitmentRepository for CommitmentMap {
         mut outputs: Vec<cashu::PublicKey>,
         expiration: TStamp,
         wallet_key: cashu::PublicKey,
+        wallet_sig: schnorr::Signature,
         signature: schnorr::Signature,
     ) -> Result<()> {
         let mut commitments = self.commitments.write().unwrap();
         inputs.sort();
         outputs.sort();
-        commitments.insert(signature, (inputs, outputs, expiration, wallet_key));
+        commitments.insert(
+            signature,
+            (inputs, outputs, expiration, wallet_key, wallet_sig),
+        );
         Ok(())
     }
 
     async fn load(
         &self,
-        inputs: &[cashu::PublicKey],
-        outputs: &[cashu::PublicKey],
-    ) -> Result<schnorr::Signature> {
-        let mut inputs = inputs.to_vec();
-        inputs.sort();
-        let mut outputs = outputs.to_vec();
-        outputs.sort();
-        let commitments = self.commitments.read().unwrap();
-        for (signature, (committed_inputs, committed_outputs, _, _)) in commitments.iter() {
-            if *committed_inputs == inputs && *committed_outputs == outputs {
-                return Ok(*signature);
-            }
-        }
-        Err(Error::ResourceNotFound(format!(
-            "{:?} ; {:?}",
-            inputs, outputs
-        )))
+        signature: &schnorr::Signature,
+    ) -> Result<(Vec<cashu::PublicKey>, Vec<cashu::PublicKey>, TStamp)> {
+        let comms = self.commitments.read().unwrap();
+        let comm = comms
+            .get(signature)
+            .ok_or(Error::ResourceNotFound(signature.to_string()))?
+            .clone();
+        Ok((comm.0, comm.1, comm.2))
     }
 
     async fn delete(&self, commitment: schnorr::Signature) -> Result<()> {

--- a/crates/bcr-wdc-core-service/src/persistence/mod.rs
+++ b/crates/bcr-wdc-core-service/src/persistence/mod.rs
@@ -56,13 +56,13 @@ pub trait CommitmentRepository: Send + Sync {
         outputs: Vec<cashu::PublicKey>,
         expiration: TStamp,
         wallet_key: cashu::PublicKey,
+        wallet_signature: schnorr::Signature,
         commitment: schnorr::Signature,
     ) -> Result<()>;
     async fn load(
         &self,
-        inputs: &[cashu::PublicKey],
-        outputs: &[cashu::PublicKey],
-    ) -> Result<schnorr::Signature>;
+        signature: &schnorr::Signature,
+    ) -> Result<(Vec<cashu::PublicKey>, Vec<cashu::PublicKey>, TStamp)>;
     async fn contains_inputs(&self, inputs: &[cashu::PublicKey]) -> Result<bool>;
     async fn contains_outputs(&self, outputs: &[cashu::PublicKey]) -> Result<bool>;
     async fn delete(&self, commitment: schnorr::Signature) -> Result<()>;

--- a/crates/bcr-wdc-core-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-core-service/src/persistence/surreal.rs
@@ -1,8 +1,5 @@
 // ----- standard library imports
-use std::{
-    collections::{BTreeMap, HashMap},
-    str::FromStr,
-};
+use std::collections::{BTreeMap, HashMap};
 // ----- extra library imports
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -436,6 +433,7 @@ struct CommitmentDBEntry {
     outputs: Vec<cashu::PublicKey>,
     expiration: TStamp,
     wallet_key: cashu::PublicKey,
+    wallet_sig: schnorr::Signature,
 }
 
 #[derive(Debug, Clone)]
@@ -463,7 +461,7 @@ impl persistence::CommitmentRepository for DBCommitments {
             .bind(("table", Self::TABLE))
             .bind(("now", now))
             .await
-            .map_err(|e| Error::CommitmentRepository(anyhow!("SurrealDB error: {}", e)))?;
+            .map_err(|e| Error::CommitmentRepository(anyhow!(e)))?;
         Ok(())
     }
 
@@ -474,9 +472,9 @@ impl persistence::CommitmentRepository for DBCommitments {
             .bind(("table", Self::TABLE))
             .bind(("ys", ys.to_vec()))
             .await
-            .map_err(|e| Error::CommitmentRepository(anyhow!("SurrealDB error: {}", e)))?
+            .map_err(|e| Error::CommitmentRepository(anyhow!(e)))?
             .take(0)
-            .map_err(|e| Error::CommitmentRepository(anyhow!("SurrealDB error: {}", e)))?;
+            .map_err(|e| Error::CommitmentRepository(anyhow!(e)))?;
         Ok(commitment.is_some())
     }
 
@@ -487,9 +485,9 @@ impl persistence::CommitmentRepository for DBCommitments {
             .bind(("table", Self::TABLE))
             .bind(("secrets", secrets.to_vec()))
             .await
-            .map_err(|e| Error::CommitmentRepository(anyhow!("SurrealDB error: {}", e)))?
+            .map_err(|e| Error::CommitmentRepository(anyhow!(e)))?
             .take(0)
-            .map_err(|e| Error::CommitmentRepository(anyhow!("SurrealDB error: {}", e)))?;
+            .map_err(|e| Error::CommitmentRepository(anyhow!(e)))?;
         Ok(commitment.is_some())
     }
 
@@ -499,6 +497,7 @@ impl persistence::CommitmentRepository for DBCommitments {
         outputs: Vec<cashu::PublicKey>,
         expiration: TStamp,
         wallet_key: cashu::PublicKey,
+        wallet_sig: schnorr::Signature,
         signature: schnorr::Signature,
     ) -> Result<()> {
         let rid = RecordId::from_table_key(Self::TABLE, signature.to_string());
@@ -508,6 +507,7 @@ impl persistence::CommitmentRepository for DBCommitments {
             outputs,
             expiration,
             wallet_key,
+            wallet_sig,
         };
         let _: Option<CommitmentDBEntry> = self
             .db
@@ -520,41 +520,29 @@ impl persistence::CommitmentRepository for DBCommitments {
 
     async fn load(
         &self,
-        inputs: &[cashu::PublicKey],
-        outputs: &[cashu::PublicKey],
-    ) -> Result<schnorr::Signature> {
-        let commitment: Option<CommitmentDBEntry> = self
+        signature: &schnorr::Signature,
+    ) -> Result<(Vec<cashu::PublicKey>, Vec<cashu::PublicKey>, TStamp)> {
+        let rid = RecordId::from_table_key(Self::TABLE, signature.to_string());
+        let commitment_entry: CommitmentDBEntry = self
             .db
-            .query(
-                "SELECT * FROM type::table($table)
-    WHERE
-        array::is_empty(array::difference(inputs, $inputs))
-    AND
-        array::is_empty(array::difference(outputs, $outputs))
-    LIMIT 1",
-            )
-            .bind(("table", Self::TABLE))
-            .bind(("inputs", inputs.to_vec()))
-            .bind(("outputs", outputs.to_vec()))
+            .select(rid.clone())
             .await
-            .map_err(|e| Error::CommitmentRepository(anyhow!("SurrealDB error: {}", e)))?
-            .take(0)
-            .map_err(|e| Error::CommitmentRepository(anyhow!("SurrealDB error: {}", e)))?;
-        let Some(entry) = commitment else {
-            return Err(Error::ResourceNotFound(format!(
-                "commitment not found {inputs:?} ; {outputs:?}"
-            )));
-        };
-        let key = entry.id.key().to_string();
-        let commitment = schnorr::Signature::from_str(&key).expect("signature from recordId");
-        Ok(commitment)
+            .map_err(|e| Error::CommitmentRepository(anyhow!(e)))?
+            .ok_or(Error::ResourceNotFound(rid.to_string()))?;
+        Ok((
+            commitment_entry.inputs,
+            commitment_entry.outputs,
+            commitment_entry.expiration,
+        ))
     }
 
     async fn delete(&self, commitment: schnorr::Signature) -> Result<()> {
         let rid = RecordId::from_table_key(Self::TABLE, commitment.to_string());
-        let _: Option<CommitmentDBEntry> = self.db.delete(rid).await.map_err(|e| {
-            Error::CommitmentRepository(anyhow!("SurrealDB error while deleting commitment: {}", e))
-        })?;
+        let _: Option<CommitmentDBEntry> = self
+            .db
+            .delete(rid)
+            .await
+            .map_err(|e| Error::CommitmentRepository(anyhow!(e)))?;
         Ok(())
     }
 }
@@ -918,14 +906,22 @@ mod tests {
             tstamp,
             random_wallet_key(),
             signature,
+            signature,
         )
         .await
         .unwrap();
         inputs.swap(0, 1);
         let signature = random_signature();
-        db.store(inputs, outputs, tstamp, random_wallet_key(), signature)
-            .await
-            .unwrap();
+        db.store(
+            inputs,
+            outputs,
+            tstamp,
+            random_wallet_key(),
+            signature,
+            signature,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -940,6 +936,7 @@ mod tests {
             outputs.clone(),
             tstamp,
             random_wallet_key(),
+            signature,
             signature,
         )
         .await
@@ -969,6 +966,7 @@ mod tests {
             tstamp,
             random_wallet_key(),
             signature,
+            signature,
         )
         .await
         .unwrap();
@@ -997,36 +995,13 @@ mod tests {
             tstamp,
             random_wallet_key(),
             signature,
+            signature,
         )
         .await
         .unwrap();
-        // wrong inputs
-        let tester = random_cdk_pks(2);
-        let result = db.load(&tester, &outputs).await;
-        assert!(result.is_err());
-        // wrong outputs
-        let result = db.load(&inputs, &tester).await;
-        assert!(result.is_err());
-        let mut tester = random_cdk_pks(4);
-        tester.push(inputs[0]);
-        // subset of inputs
-        let result = db.load(&tester, &outputs).await;
-        assert!(result.is_err());
-        let mut tester = random_cdk_pks(2);
-        tester.push(outputs[0]);
-        // subset of outputs
-        let result = db.load(&inputs, &tester).await;
-        assert!(result.is_err());
-        // correct inputs and outputs
-        let result = db.load(&inputs, &outputs).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), signature);
-        let mut tester_in = inputs.clone();
-        tester_in.extend(random_cdk_pks(2));
-        let mut tester_out = outputs.clone();
-        tester_out.extend(random_cdk_pks(2));
-        // extra inputs and outputs
-        let result = db.load(&tester_in, &tester_out).await;
-        assert!(result.is_err());
+        let result = db.load(&signature).await.unwrap();
+        assert_eq!(result.0, inputs);
+        assert_eq!(result.1, outputs);
+        assert_eq!(result.2, tstamp)
     }
 }

--- a/crates/bcr-wdc-core-service/src/swap/service.rs
+++ b/crates/bcr-wdc-core-service/src/swap/service.rs
@@ -121,13 +121,22 @@ impl Service {
                 "blinded messages committed",
             )));
         }
-        // store commitment
-        self.commitments
-            .store(ys, bs, expiry, request.wallet_key, request.wallet_signature)
-            .await?;
+        let wallet_pk = request.wallet_key;
+        let wallet_sig = request.wallet_signature;
         // broadcast request to clowder
         let (content, commitment) = self.clowder.commit_to_swap(request).await?;
-        Ok((content, commitment))
+        // store commitment
+        let store_res = self
+            .commitments
+            .store(ys, bs, expiry, wallet_pk, wallet_sig, commitment.clone())
+            .await;
+        match store_res {
+            Ok(_) => Ok((content, commitment)),
+            Err(e) => {
+                tracing::error!("failed to store commitment: {e}");
+                Err(e)
+            }
+        }
     }
 
     pub async fn swap(


### PR DESCRIPTION
- minor bug fixes
- CommitmentRepository::load now uses the mint's commitment as key to
  search for the corresponding commitment data