### PR TITLE
[bcr-wdc-treasury-service] stop storing MintUrl

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
@@ -10,6 +10,7 @@ use bcr_common::{
         keys as wire_keys,
     },
 };
+use bitcoin::secp256k1;
 // ----- local imports
 use crate::{
     error::{Error, Result},
@@ -80,24 +81,16 @@ impl proof::ClowderClient for ClowderCl {
 
 #[async_trait]
 impl foreign::ClowderClient for ClowderCl {
-    async fn get_myself_pk(&self) -> Result<bitcoin::PublicKey> {
-        let my_id = self.clwdr.get_info().await?.node_id;
-        let pk = bitcoin::PublicKey::from(*my_id);
-
-        Ok(pk)
+    async fn get_myself_pk(&self) -> Result<secp256k1::PublicKey> {
+        let my_cashu_pk = self.clwdr.get_info().await?.node_id;
+        let my_id = secp256k1::PublicKey::from_slice(&my_cashu_pk.to_bytes())
+            .expect("secp256k1::PublicKey == cashu::PublicKey");
+        Ok(my_id)
     }
 
-    async fn get_mint_url_from_pk(&self, pk: &cashu::PublicKey) -> Result<cashu::MintUrl> {
-        let response = self.clwdr.get_alphas().await?;
-
-        let mint = response
-            .mints
-            .iter()
-            .find(|mint| cashu::PublicKey::from(mint.node_id) == *pk);
-        if let Some(mint) = mint {
-            return Ok(mint.mint.clone());
-        }
-        Err(Error::InvalidInput(format!("{pk} not in the alpha set")))
+    async fn get_mint_url_from_pk(&self, pk: &secp256k1::PublicKey) -> Result<reqwest::Url> {
+        let response = self.clwdr.get_mint_url(pk).await?;
+        Ok(response.mint_url)
     }
 
     async fn sign_p2pk_proofs(&self, proofs: &[cashu::Proof]) -> Result<Vec<cashu::Proof>> {

--- a/crates/bcr-wdc-treasury-service/src/foreign/crsat.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/crsat.rs
@@ -41,14 +41,14 @@ impl Service {
         hashes: Vec<Sha256Hash>,
         wpk: cashu::PublicKey,
     ) -> Result<Vec<cashu::Proof>> {
-        let (foreign_mint_url, foreign_mint_pk) = self
+        let (_, foreign_mint_id) = self
             .clowder
             .can_accept_offline_exchange(inputs.clone())
             .await?;
         let foreign_fps = fingerprints_vec_to_map(inputs.clone(), hashes.clone());
         let mut retv: Vec<cashu::Proof> = Vec::new();
         for (kid, fps_hashes) in foreign_fps {
-            let k_info = self.clowder.get_keyset_info(&foreign_mint_pk, &kid).await?;
+            let k_info = self.clowder.get_keyset_info(&foreign_mint_id, &kid).await?;
             let Some(foreign_unix_expiration) = k_info.final_expiry else {
                 return Err(Error::InvalidInput(String::from(
                     "Foreign keyset has no expiration",
@@ -86,7 +86,7 @@ impl Service {
             retv.extend(proofs);
         }
         self.offline_repo
-            .store_fps((foreign_mint_pk, foreign_mint_url), inputs, hashes)
+            .store_fps(foreign_mint_id, inputs, hashes)
             .await?;
         Ok(retv)
     }
@@ -104,7 +104,7 @@ impl Service {
         let mut path_it = path.iter().rev();
         let wallet_pk = path_it.next().unwrap();
         let myself = self.clowder.get_myself_pk().await?;
-        let myself = cashu::PublicKey::from(myself.inner);
+        let myself = cashu::PublicKey::from(myself);
         if &myself != path_it.next().unwrap() {
             return Err(Error::InvalidInput(String::from(
                 "Exchange path must end with [myself pk, wallet pk]",
@@ -112,7 +112,9 @@ impl Service {
         };
         let foreign_pk = path_it.next().unwrap();
         let foreign_mint = self.clowder.get_mint_url_from_pk(foreign_pk).await?;
-        let foreign_client = self.mint_factory.make_client(foreign_mint.clone()).await?;
+        let foreign_cashu_url = cashu::MintUrl::from_str(foreign_mint.as_str())
+            .expect("cashu::MintUrl == reqwest::Url");
+        let foreign_client = self.mint_factory.make_client(foreign_cashu_url).await?;
         let (htlc_hash, foreign_locktime) = proof::check_htlc_foreign_proofs(
             *foreign_pk,
             &proofs,
@@ -125,7 +127,7 @@ impl Service {
             .fold(cashu::Amount::ZERO, |total, p| total + p.amount);
         let kid = proofs[0].keyset_id;
         self.online_repo
-            .store_htlc((*foreign_pk.deref(), foreign_mint), htlc_hash, proofs)
+            .store_htlc(*foreign_pk.deref(), htlc_hash, proofs)
             .await?;
         let foreign_keyset = foreign_client.get_mint_keyset(kid).await?;
         let Some(foreign_unix_expiration) = foreign_keyset.final_expiry else {
@@ -191,7 +193,8 @@ async fn try_online_htlc(
     let foreign_proofs = repo.search_htlc(&hash).await?;
     let foreign_proofs = proofs_vec_to_map(foreign_proofs);
 
-    for ((mint_pk, mint_url), mut f_proofs) in foreign_proofs {
+    for (mint_id, mut f_proofs) in foreign_proofs {
+        let mint_url = clowder.get_mint_url_from_pk(&mint_id).await?;
         let mut f_fingerprints = Vec::with_capacity(f_proofs.len());
         for proof in &mut f_proofs {
             proof.add_preimage(preimage.to_string());
@@ -216,7 +219,9 @@ async fn try_online_htlc(
                 .len(),
             "All foreign proofs must have the same keyset_id"
         );
-        let foreign_client = factory.make_client(mint_url.clone()).await?;
+        let cashu_url =
+            cashu::MintUrl::from_str(mint_url.as_str()).expect("cashu::MintUrl == reqwest::Url");
+        let foreign_client = factory.make_client(cashu_url).await?;
         let keys = foreign_client
             .get_mint_keyset(f_proofs[0].keyset_id)
             .await?;
@@ -227,7 +232,7 @@ async fn try_online_htlc(
             let proof = unblind_ecash_signature(&keys, pre.clone(), sig)?;
             proofs.push(proof);
         }
-        repo.store((mint_pk, mint_url), proofs).await?;
+        repo.store(mint_id, proofs).await?;
         repo.remove_htlcs(&f_fingerprints).await?;
         gran_total += total;
     }
@@ -241,9 +246,10 @@ async fn try_offline_htlc_swap(
     settler: &dyn OfflineSettleHandler,
 ) -> Result<cashu::Amount> {
     let hash = Sha256Hash::hash(preimage.as_bytes());
-    let Some(((mint_pk, mint_url), fp)) = repo.search_fp(&hash).await? else {
+    let Some((mint_id, fp)) = repo.search_fp(&hash).await? else {
         return Ok(cashu::Amount::ZERO);
     };
+    let mint_url = clowder.get_mint_url_from_pk(&mint_id).await?;
     let secret = cashu::secret::Secret::from_str(preimage)?;
     let amount = cashu::Amount::from(fp.amount);
     let proof = cashu::Proof {
@@ -259,16 +265,15 @@ async fn try_offline_htlc_swap(
             "preimage does not match fingerprint",
         )));
     }
-    let keys = clowder.get_keyset(&mint_pk, &proof.keyset_id).await?;
+    let keys = clowder.get_keyset(&mint_id, &proof.keyset_id).await?;
     let key = keys
         .keys
         .get(&proof.amount)
         .ok_or(Error::Internal(String::from("key amount not found")))?;
     proof.verify_dleq(*key)?;
     repo.remove_fps(&[fp.y]).await?;
-    repo.store_proofs((mint_pk, mint_url.clone()), vec![proof])
-        .await?;
-    settler.monitor((mint_pk, mint_url))?;
+    repo.store_proofs(mint_id, vec![proof]).await?;
+    settler.monitor((mint_id, mint_url))?;
     Ok(amount)
 }
 
@@ -342,7 +347,8 @@ mod tests {
         let foreign_kp = core_tests::generate_random_keypair();
         let myself_kp = core_tests::generate_random_keypair();
         let wallet_kp = core_tests::generate_random_keypair();
-        let foreign_url = cashu::MintUrl::from_str("https://foreign-mint.example").unwrap();
+        let foreign_url = reqwest::Url::parse("https://foreign-mint.example").unwrap();
+        let cashu_foreign_url = cashu::MintUrl::from_str(foreign_url.as_str()).unwrap();
         let (_, mut foreign_keyset) = core_tests::generate_random_ecash_keyset();
         let expiration = chrono::Utc::now() + chrono::TimeDelta::days(7);
         foreign_keyset.final_expiry = Some(expiration.timestamp() as u64);
@@ -368,7 +374,7 @@ mod tests {
             cashu::PublicKey::from(wallet_kp.public_key()),
         ];
         let myself_pk = myself_kp.public_key();
-        let foreign_pk = cashu::PublicKey::from(foreign_kp.public_key());
+        let foreign_pk = foreign_kp.public_key();
         clowder
             .expect_get_myself_pk()
             .times(1)
@@ -382,7 +388,7 @@ mod tests {
         let cloned_keyset = cashu::KeySet::from(foreign_keyset);
         factory
             .expect_make_client()
-            .with(eq(foreign_url.clone()))
+            .with(eq(cashu_foreign_url.clone()))
             .times(1)
             .returning(move |_| {
                 let mut foreign_client = crate::foreign::test_utils::MockMintConnector::new();
@@ -413,9 +419,10 @@ mod tests {
                     .returning(move |_| Ok(cloned_keyset.clone()));
                 Ok(Box::new(foreign_client))
             });
+        let cashu_foreign_pk = cashu::PublicKey::from(foreign_pk);
         clowder
             .expect_check_htlc_proofs()
-            .with(eq(foreign_pk), eq(inputs.clone()))
+            .with(eq(cashu_foreign_pk), eq(inputs.clone()))
             .times(1)
             .returning(|_, _| Ok(()));
 
@@ -524,11 +531,7 @@ mod tests {
         });
         offlinerepo
             .expect_store_fps()
-            .with(
-                eq((foreign_pk, foreign_url.clone())),
-                eq(inputs.clone()),
-                eq(hashes.clone()),
-            )
+            .with(eq(foreign_pk), eq(inputs.clone()), eq(hashes.clone()))
             .times(1)
             .returning(|_, _, _| Ok(()));
 
@@ -556,7 +559,8 @@ mod tests {
         let keys = MockKeysClient::new();
         let mut clowder = crate::foreign::tests::MockClowderClient::new();
         let mut factory = crate::foreign::MockMintClientFactory::new();
-        let foreign_url = cashu::MintUrl::from_str("https://foreign-mint.example").unwrap();
+        let foreign_url = reqwest::Url::parse("https://foreign-mint.example").unwrap();
+        let cashu_foreign_url = cashu::MintUrl::from_str(foreign_url.as_str()).unwrap();
         let foreign_kp = core_tests::generate_random_keypair();
         let wallet_kp = core_tests::generate_random_keypair();
         let myself_kp = core_tests::generate_random_keypair();
@@ -570,16 +574,18 @@ mod tests {
         );
         let preimage = foreign_proof.secret.to_string();
         let hash = Sha256Hash::hash(foreign_proof.secret.as_bytes());
-        let search_response = vec![(
-            (foreign_kp.public_key(), foreign_url.clone()),
-            foreign_proof.clone(),
-        )];
+        let search_response = vec![(foreign_kp.public_key(), foreign_proof.clone())];
         let myself_sk = cashu::SecretKey::from(myself_kp.secret_key());
         onlinerepo
             .expect_search_htlc()
             .with(eq(hash))
             .times(1)
             .returning(move |_| Ok(search_response.clone()));
+        clowder
+            .expect_get_mint_url_from_pk()
+            .with(eq(foreign_kp.public_key()))
+            .times(1)
+            .returning(move |_| Ok(foreign_url.clone()));
         clowder
             .expect_sign_p2pk_proofs()
             .times(1)
@@ -594,7 +600,7 @@ mod tests {
         let cloned_keyset = foreign_keyset.clone();
         factory
             .expect_make_client()
-            .with(eq(foreign_url.clone()))
+            .with(eq(cashu_foreign_url.clone()))
             .times(1)
             .returning(move |_| {
                 let cloned_keyset = cloned_keyset.clone();
@@ -662,7 +668,7 @@ mod tests {
         let preimage = foreign_proof.secret.to_string();
         let hash = Sha256Hash::hash(foreign_proof.secret.as_bytes());
         let search_response = (
-            (foreign_kp.public_key(), foreign_url.clone()),
+            foreign_kp.public_key(),
             bcr_common::wire::keys::ProofFingerprint::try_from(foreign_proof.clone()).unwrap(),
         );
         onlinerepo
@@ -678,6 +684,12 @@ mod tests {
         let foreign_kid = foreign_keyset.id;
         let foreign_pk = foreign_kp.public_key();
         let cloned_keyset = cashu::KeySet::from(foreign_keyset);
+        let cloned_url = foreign_url.clone();
+        clowder
+            .expect_get_mint_url_from_pk()
+            .with(eq(foreign_pk))
+            .times(1)
+            .returning(move |_| Ok(cloned_url.clone()));
         clowder
             .expect_get_keyset()
             .with(eq(foreign_pk), eq(foreign_kid))
@@ -691,7 +703,7 @@ mod tests {
             .returning(|_| Ok(()));
         offlinerepo
             .expect_store_proofs()
-            .with(eq((foreign_pk, foreign_url.clone())), always())
+            .with(eq(foreign_pk), always())
             .times(1)
             .returning(|_, _| Ok(()));
         settler

--- a/crates/bcr-wdc-treasury-service/src/foreign/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/mod.rs
@@ -104,24 +104,20 @@ pub mod test_utils {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait OnlineRepository: Send + Sync {
-    async fn store(
-        &self,
-        mint: (secp256k1::PublicKey, cashu::MintUrl),
-        proofs: Vec<cashu::Proof>,
-    ) -> Result<()>;
+    async fn store(&self, mint_id: secp256k1::PublicKey, proofs: Vec<cashu::Proof>) -> Result<()>;
     #[allow(dead_code)]
-    async fn list(&self) -> Result<Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>>;
+    async fn list(&self) -> Result<Vec<(secp256k1::PublicKey, cashu::Proof)>>;
 
     async fn store_htlc(
         &self,
-        mint: (secp256k1::PublicKey, cashu::MintUrl),
+        mint_id: secp256k1::PublicKey,
         hash: Sha256Hash,
         proofs: Vec<cashu::Proof>,
     ) -> Result<()>;
     async fn search_htlc(
         &self,
         hash: &Sha256Hash,
-    ) -> Result<Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>>;
+    ) -> Result<Vec<(secp256k1::PublicKey, cashu::Proof)>>;
     async fn remove_htlcs(&self, ys: &[cashu::PublicKey]) -> Result<()>;
 }
 
@@ -130,38 +126,30 @@ pub trait OnlineRepository: Send + Sync {
 pub trait OfflineRepository: Send + Sync {
     async fn store_fps(
         &self,
-        alpha: (secp256k1::PublicKey, reqwest::Url),
+        mint_id: secp256k1::PublicKey,
         fps: Vec<wire_keys::ProofFingerprint>,
         hash: Vec<Sha256Hash>,
     ) -> Result<()>;
     async fn search_fp(
         &self,
         hash: &Sha256Hash,
-    ) -> Result<
-        Option<(
-            (secp256k1::PublicKey, reqwest::Url),
-            wire_keys::ProofFingerprint,
-        )>,
-    >;
+    ) -> Result<Option<(secp256k1::PublicKey, wire_keys::ProofFingerprint)>>;
     async fn remove_fps(&self, ys: &[cashu::PublicKey]) -> Result<()>;
     async fn store_proofs(
         &self,
-        alpha: (secp256k1::PublicKey, reqwest::Url),
+        mint_id: secp256k1::PublicKey,
         proof: Vec<cashu::Proof>,
     ) -> Result<()>;
     #[allow(dead_code)]
-    async fn load_proofs(
-        &self,
-        alpha: &(secp256k1::PublicKey, reqwest::Url),
-    ) -> Result<Vec<cashu::Proof>>;
+    async fn load_proofs(&self, mint_id: secp256k1::PublicKey) -> Result<Vec<cashu::Proof>>;
     #[allow(dead_code)]
     async fn remove_proofs(&self, ys: &[cashu::PublicKey]) -> Result<()>;
 }
 
 #[async_trait]
 pub trait ClowderClient: proof::ClowderClient {
-    async fn get_mint_url_from_pk(&self, pk: &cashu::PublicKey) -> Result<cashu::MintUrl>;
-    async fn get_myself_pk(&self) -> Result<bitcoin::PublicKey>;
+    async fn get_mint_url_from_pk(&self, pk: &secp256k1::PublicKey) -> Result<reqwest::Url>;
+    async fn get_myself_pk(&self) -> Result<secp256k1::PublicKey>;
     async fn sign_p2pk_proofs(&self, proofs: &[cashu::Proof]) -> Result<Vec<cashu::Proof>>;
     // yes if result is Ok
     async fn can_accept_offline_exchange(
@@ -195,10 +183,9 @@ pub trait OfflineSettleHandler: Send + Sync {
 }
 
 fn proofs_vec_to_map(
-    input: Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>,
-) -> HashMap<(secp256k1::PublicKey, cashu::MintUrl), Vec<cashu::Proof>> {
-    let mut map: HashMap<(secp256k1::PublicKey, cashu::MintUrl), Vec<cashu::Proof>> =
-        HashMap::new();
+    input: Vec<(secp256k1::PublicKey, cashu::Proof)>,
+) -> HashMap<secp256k1::PublicKey, Vec<cashu::Proof>> {
+    let mut map: HashMap<secp256k1::PublicKey, Vec<cashu::Proof>> = HashMap::new();
     for (mint, proof) in input {
         map.entry(mint).or_default().push(proof);
     }
@@ -238,8 +225,8 @@ mod tests {
         }
         #[async_trait]
         impl super::ClowderClient for ClowderClient {
-            async fn get_mint_url_from_pk(&self, pk: &cashu::PublicKey) -> Result<cashu::MintUrl>;
-            async fn get_myself_pk(&self) -> Result<bitcoin::PublicKey>;
+            async fn get_mint_url_from_pk(&self, pk: &secp256k1::PublicKey) -> Result<reqwest::Url>;
+            async fn get_myself_pk(&self) -> Result<secp256k1::PublicKey>;
             async fn sign_p2pk_proofs(&self, proofs: &[cashu::Proof]) -> Result<Vec<cashu::Proof>>;
             async fn can_accept_offline_exchange(
                 &self,

--- a/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
@@ -140,7 +140,7 @@ async fn monitor(
             warn!("make_client failed {}, retry later", mint.1);
             continue;
         };
-        let Ok(proofs) = offline_repo.load_proofs(&mint).await else {
+        let Ok(proofs) = offline_repo.load_proofs(mint.0).await else {
             warn!("load_proofs failed {}, retry later", mint.1);
             continue;
         };
@@ -190,7 +190,7 @@ async fn monitor(
                 news.push(proof);
             }
             let online_mint = (mint.0, mint_url.clone());
-            if online_repo.store(online_mint, news).await.is_err() {
+            if online_repo.store(online_mint.0, news).await.is_err() {
                 error!("store new proofs failed {}, {total} lost", mint.1);
             };
             if offline_repo.remove_proofs(&ys).await.is_err() {

--- a/crates/bcr-wdc-treasury-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/inmemory.rs
@@ -20,46 +20,40 @@ use crate::{
 #[allow(dead_code)]
 #[derive(Clone, Default, Debug)]
 pub struct OnlineRepository {
-    proofs: Arc<Mutex<Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>>>,
-    htlc: Arc<
-        Mutex<HashMap<Sha256Hash, Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>>>,
-    >,
+    proofs: Arc<Mutex<Vec<(secp256k1::PublicKey, cashu::Proof)>>>,
+    htlc: Arc<Mutex<HashMap<Sha256Hash, Vec<(secp256k1::PublicKey, cashu::Proof)>>>>,
 }
 
 #[async_trait]
 impl foreign::OnlineRepository for OnlineRepository {
-    async fn store(
-        &self,
-        mint: (secp256k1::PublicKey, cashu::MintUrl),
-        proofs: Vec<cashu::Proof>,
-    ) -> Result<()> {
+    async fn store(&self, mint_id: secp256k1::PublicKey, proofs: Vec<cashu::Proof>) -> Result<()> {
         let mut locked = self.proofs.lock().unwrap();
         for proof in proofs {
-            locked.push((mint.clone(), proof));
+            locked.push((mint_id, proof));
         }
         Ok(())
     }
-    async fn list(&self) -> Result<Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>> {
+    async fn list(&self) -> Result<Vec<(secp256k1::PublicKey, cashu::Proof)>> {
         Ok(self.proofs.lock().unwrap().clone())
     }
 
     async fn store_htlc(
         &self,
-        mint: (secp256k1::PublicKey, cashu::MintUrl),
+        mint_id: secp256k1::PublicKey,
         hash: Sha256Hash,
         proofs: Vec<cashu::Proof>,
     ) -> Result<()> {
         let mut locked = self.htlc.lock().unwrap();
         let entry = locked.entry(hash).or_default();
         for proof in proofs {
-            entry.push((mint.clone(), proof));
+            entry.push((mint_id, proof));
         }
         Ok(())
     }
     async fn search_htlc(
         &self,
         hash: &Sha256Hash,
-    ) -> Result<Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>> {
+    ) -> Result<Vec<(secp256k1::PublicKey, cashu::Proof)>> {
         let locked = self.htlc.lock().unwrap();
         Ok(locked.get(hash).cloned().unwrap_or_default())
     }
@@ -75,22 +69,21 @@ impl foreign::OnlineRepository for OnlineRepository {
 #[allow(dead_code)]
 #[derive(Clone, Default, Debug)]
 pub struct OfflineRepository {
-    fingerprints:
-        Arc<Mutex<HashMap<Sha256Hash, ((secp256k1::PublicKey, reqwest::Url), ProofFingerprint)>>>,
-    proofs: Arc<Mutex<HashMap<(secp256k1::PublicKey, reqwest::Url), Vec<cashu::Proof>>>>,
+    fingerprints: Arc<Mutex<HashMap<Sha256Hash, (secp256k1::PublicKey, ProofFingerprint)>>>,
+    proofs: Arc<Mutex<HashMap<secp256k1::PublicKey, Vec<cashu::Proof>>>>,
 }
 
 #[async_trait]
 impl foreign::OfflineRepository for OfflineRepository {
     async fn store_fps(
         &self,
-        alpha: (secp256k1::PublicKey, reqwest::Url),
+        mint_id: secp256k1::PublicKey,
         fps: Vec<ProofFingerprint>,
         hash: Vec<Sha256Hash>,
     ) -> Result<()> {
         let mut locked = self.fingerprints.lock().unwrap();
         for (h, fp) in hash.into_iter().zip(fps) {
-            locked.insert(h, (alpha.clone(), fp));
+            locked.insert(h, (mint_id, fp));
         }
         Ok(())
     }
@@ -98,7 +91,7 @@ impl foreign::OfflineRepository for OfflineRepository {
     async fn search_fp(
         &self,
         hash: &Sha256Hash,
-    ) -> Result<Option<((secp256k1::PublicKey, reqwest::Url), ProofFingerprint)>> {
+    ) -> Result<Option<(secp256k1::PublicKey, ProofFingerprint)>> {
         let locked = self.fingerprints.lock().unwrap();
         let val = locked.get(hash).cloned();
         Ok(val)
@@ -111,19 +104,16 @@ impl foreign::OfflineRepository for OfflineRepository {
     }
     async fn store_proofs(
         &self,
-        alpha: (secp256k1::PublicKey, reqwest::Url),
+        mint_id: secp256k1::PublicKey,
         proof: Vec<cashu::Proof>,
     ) -> Result<()> {
         let mut locked = self.proofs.lock().unwrap();
-        locked.entry(alpha).or_default().extend(proof);
+        locked.entry(mint_id).or_default().extend(proof);
         Ok(())
     }
-    async fn load_proofs(
-        &self,
-        alpha: &(secp256k1::PublicKey, reqwest::Url),
-    ) -> Result<Vec<cashu::Proof>> {
+    async fn load_proofs(&self, mint_id: secp256k1::PublicKey) -> Result<Vec<cashu::Proof>> {
         let locked = self.proofs.lock().unwrap();
-        Ok(locked.get(alpha).cloned().unwrap_or_default())
+        Ok(locked.get(&mint_id).cloned().unwrap_or_default())
     }
     async fn remove_proofs(&self, ys: &[cashu::PublicKey]) -> Result<()> {
         let mut locked = self.proofs.lock().unwrap();

--- a/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
@@ -1,5 +1,4 @@
 // ----- standard library imports
-use std::str::FromStr;
 // ----- extra library imports
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -20,6 +19,7 @@ use crate::{
 
 // ----- end imports
 
+///////////////////////////////////////////////////////////////////////////////// OnChain DB
 #[derive(Debug, Clone)]
 pub struct DBOnChain {
     db: Surreal<Any>,
@@ -172,42 +172,7 @@ impl onchain::Repository for DBOnChain {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct ForeignProofEntry {
-    id: RecordId,
-    proof: cashu::Proof,
-    mint_url: cashu::MintUrl,
-    mint_pk: secp256k1::PublicKey,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct ForeignOnlineHtlcProofEntry {
-    id: RecordId,
-    proof: cashu::Proof,
-    mint_url: cashu::MintUrl,
-    mint_pk: secp256k1::PublicKey,
-    hash: Sha256Hash,
-}
-
-#[derive(Debug, Clone)]
-pub struct DBForeignOnline {
-    db: Surreal<Any>,
-}
-
-impl DBForeignOnline {
-    const FOREIGNS_TABLE: &'static str = "online-foreigns";
-    const HTLCS_TABLE: &'static str = "online-htlcs";
-
-    pub async fn new(config: surreal::DBConnConfig) -> SurrealResult<Self> {
-        let db_connection = Surreal::<Any>::init();
-        db_connection.connect(config.connection).await?;
-        db_connection.use_ns(config.namespace).await?;
-        db_connection.use_db(config.database).await?;
-        Ok(Self { db: db_connection })
-    }
-}
-
-////////////////////////////////////////////////////////////////////// Credit DB
+///////////////////////////////////////////////////////////////////////////////// Ebill DB
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EbillMintOpDBEntry {
     id: RecordId,
@@ -343,24 +308,52 @@ impl ebill::Repository for DBEbill {
     }
 }
 
+//////////////////////////////////////////////////////////////////////////////// Foreign DB
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ForeignProofDBEntry {
+    id: RecordId,
+    proof: cashu::Proof,
+    mint_id: secp256k1::PublicKey,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ForeignOnlineHtlcProofDBEntry {
+    id: RecordId,
+    proof: cashu::Proof,
+    mint_id: secp256k1::PublicKey,
+    hash: Sha256Hash,
+}
+
+#[derive(Debug, Clone)]
+pub struct DBForeignOnline {
+    db: Surreal<Any>,
+}
+
+impl DBForeignOnline {
+    const FOREIGNS_TABLE: &'static str = "online-foreigns";
+    const HTLCS_TABLE: &'static str = "online-htlcs";
+
+    pub async fn new(config: surreal::DBConnConfig) -> SurrealResult<Self> {
+        let db_connection = Surreal::<Any>::init();
+        db_connection.connect(config.connection).await?;
+        db_connection.use_ns(config.namespace).await?;
+        db_connection.use_db(config.database).await?;
+        Ok(Self { db: db_connection })
+    }
+}
 #[async_trait]
 impl foreign::OnlineRepository for DBForeignOnline {
-    async fn store(
-        &self,
-        (mint_pk, mint_url): (secp256k1::PublicKey, cashu::MintUrl),
-        proofs: Vec<cashu::Proof>,
-    ) -> Result<()> {
-        let mut entries: Vec<ForeignProofEntry> = Vec::with_capacity(proofs.len());
+    async fn store(&self, mint_id: secp256k1::PublicKey, proofs: Vec<cashu::Proof>) -> Result<()> {
+        let mut entries: Vec<ForeignProofDBEntry> = Vec::with_capacity(proofs.len());
         for proof in proofs.into_iter() {
             let rid = RecordId::from_table_key(Self::FOREIGNS_TABLE, proof.y()?.to_string());
-            entries.push(ForeignProofEntry {
+            entries.push(ForeignProofDBEntry {
                 id: rid,
                 proof,
-                mint_pk,
-                mint_url: mint_url.clone(),
+                mint_id,
             });
         }
-        let _: Vec<ForeignProofEntry> = self
+        let _: Vec<ForeignProofDBEntry> = self
             .db
             .insert(Self::FOREIGNS_TABLE)
             .content(entries)
@@ -369,9 +362,9 @@ impl foreign::OnlineRepository for DBForeignOnline {
         Ok(())
     }
 
-    async fn list(&self) -> Result<Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>> {
+    async fn list(&self) -> Result<Vec<(secp256k1::PublicKey, cashu::Proof)>> {
         let statement = String::from("SELECT * FROM type::table($table)");
-        let entries: Vec<ForeignProofEntry> = self
+        let entries: Vec<ForeignProofDBEntry> = self
             .db
             .query(statement)
             .bind(("table", Self::FOREIGNS_TABLE))
@@ -381,36 +374,30 @@ impl foreign::OnlineRepository for DBForeignOnline {
             .map_err(|e| Error::DB(anyhow!(e)))?;
         let mut ret_val = Vec::with_capacity(entries.len());
         for entry in entries {
-            let ForeignProofEntry {
-                mint_url,
-                mint_pk,
-                proof,
-                ..
-            } = entry;
-            ret_val.push(((mint_pk, mint_url), proof));
+            let ForeignProofDBEntry { mint_id, proof, .. } = entry;
+            ret_val.push((mint_id, proof));
         }
         Ok(ret_val)
     }
 
     async fn store_htlc(
         &self,
-        (mint_pk, mint_url): (secp256k1::PublicKey, cashu::MintUrl),
+        mint_id: secp256k1::PublicKey,
         hash: Sha256Hash,
         proofs: Vec<cashu::Proof>,
     ) -> Result<()> {
-        let mut entries: Vec<ForeignOnlineHtlcProofEntry> = Vec::with_capacity(proofs.len());
+        let mut entries: Vec<ForeignOnlineHtlcProofDBEntry> = Vec::with_capacity(proofs.len());
         for proof in proofs {
             let id = RecordId::from_table_key(Self::HTLCS_TABLE, proof.y()?.to_string());
-            let entry = ForeignOnlineHtlcProofEntry {
+            let entry = ForeignOnlineHtlcProofDBEntry {
                 hash,
                 id,
                 proof,
-                mint_pk,
-                mint_url: mint_url.clone(),
+                mint_id,
             };
             entries.push(entry);
         }
-        let _: Vec<ForeignOnlineHtlcProofEntry> = self
+        let _: Vec<ForeignOnlineHtlcProofDBEntry> = self
             .db
             .insert(Self::HTLCS_TABLE)
             .content(entries)
@@ -422,8 +409,8 @@ impl foreign::OnlineRepository for DBForeignOnline {
     async fn search_htlc(
         &self,
         hash: &Sha256Hash,
-    ) -> Result<Vec<((secp256k1::PublicKey, cashu::MintUrl), cashu::Proof)>> {
-        let htlcs: Vec<ForeignOnlineHtlcProofEntry> = self
+    ) -> Result<Vec<(secp256k1::PublicKey, cashu::Proof)>> {
+        let htlcs: Vec<ForeignOnlineHtlcProofDBEntry> = self
             .db
             .query("SELECT * FROM type::table($table) WHERE hash = $hash")
             .bind(("table", Self::HTLCS_TABLE))
@@ -434,14 +421,7 @@ impl foreign::OnlineRepository for DBForeignOnline {
             .map_err(|e| Error::DB(anyhow!(e)))?;
         let ret_val = htlcs
             .into_iter()
-            .map(
-                |ForeignOnlineHtlcProofEntry {
-                     proof,
-                     mint_url,
-                     mint_pk,
-                     ..
-                 }| ((mint_pk, mint_url), proof),
-            )
+            .map(|ForeignOnlineHtlcProofDBEntry { proof, mint_id, .. }| (mint_id, proof))
             .collect();
         Ok(ret_val)
     }
@@ -449,7 +429,7 @@ impl foreign::OnlineRepository for DBForeignOnline {
     async fn remove_htlcs(&self, ys: &[cashu::PublicKey]) -> Result<()> {
         for y in ys {
             let rid = RecordId::from_table_key(Self::HTLCS_TABLE, y.to_string());
-            let _: Option<ForeignOnlineHtlcProofEntry> = self
+            let _: Option<ForeignOnlineHtlcProofDBEntry> = self
                 .db
                 .delete(rid)
                 .await
@@ -478,7 +458,7 @@ impl DBForeignOffline {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct ForeignFingerprintEntry {
+struct ForeignFingerprintDBEntry {
     id: RecordId,
     amount: u64,
     keyset_id: cashu::Id,
@@ -486,21 +466,20 @@ struct ForeignFingerprintEntry {
     c: cashu::PublicKey,
     witness: Option<cashu::Witness>,
     dleq: Option<cashu::ProofDleq>,
-    mint_pk: secp256k1::PublicKey,
-    mint_url: reqwest::Url,
+    mint_id: secp256k1::PublicKey,
 }
 
 #[async_trait]
 impl foreign::OfflineRepository for DBForeignOffline {
     async fn store_fps(
         &self,
-        (mint_pk, mint_url): (secp256k1::PublicKey, reqwest::Url),
+        mint_id: secp256k1::PublicKey,
         fps: Vec<wire_keys::ProofFingerprint>,
         hash: Vec<Sha256Hash>,
     ) -> Result<()> {
         for (hash, fp) in hash.into_iter().zip(fps) {
             let rid = RecordId::from_table_key(Self::FPS_TABLE, hash.to_string());
-            let entry = ForeignFingerprintEntry {
+            let entry = ForeignFingerprintDBEntry {
                 id: rid.clone(),
                 amount: fp.amount,
                 keyset_id: fp.keyset_id,
@@ -508,10 +487,9 @@ impl foreign::OfflineRepository for DBForeignOffline {
                 c: fp.c,
                 witness: fp.witness,
                 dleq: fp.dleq,
-                mint_pk,
-                mint_url: mint_url.clone(),
+                mint_id,
             };
-            let _: Option<ForeignFingerprintEntry> = self
+            let _: Option<ForeignFingerprintDBEntry> = self
                 .db
                 .insert(rid)
                 .content(entry)
@@ -524,14 +502,9 @@ impl foreign::OfflineRepository for DBForeignOffline {
     async fn search_fp(
         &self,
         hash: &Sha256Hash,
-    ) -> Result<
-        Option<(
-            (secp256k1::PublicKey, reqwest::Url),
-            wire_keys::ProofFingerprint,
-        )>,
-    > {
+    ) -> Result<Option<(secp256k1::PublicKey, wire_keys::ProofFingerprint)>> {
         let rid = RecordId::from_table_key(Self::FPS_TABLE, hash.to_string());
-        let entry: Option<ForeignFingerprintEntry> = self
+        let entry: Option<ForeignFingerprintDBEntry> = self
             .db
             .select(rid)
             .await
@@ -547,11 +520,11 @@ impl foreign::OfflineRepository for DBForeignOffline {
             witness: entry.witness,
             dleq: entry.dleq,
         };
-        Ok(Some(((entry.mint_pk, entry.mint_url), fp)))
+        Ok(Some((entry.mint_id, fp)))
     }
 
     async fn remove_fps(&self, ys: &[cashu::PublicKey]) -> Result<()> {
-        let _: Vec<ForeignFingerprintEntry> = self
+        let _: Vec<ForeignFingerprintDBEntry> = self
             .db
             .query("DELETE FROM type::table($table) WHERE array::any($ys, y)")
             .bind(("table", Self::FPS_TABLE))
@@ -564,23 +537,20 @@ impl foreign::OfflineRepository for DBForeignOffline {
     }
     async fn store_proofs(
         &self,
-        (mint_pk, mint_url): (secp256k1::PublicKey, reqwest::Url),
+        mint_id: secp256k1::PublicKey,
         proofs: Vec<cashu::Proof>,
     ) -> Result<()> {
-        let mint_url = cashu::MintUrl::from_str(mint_url.as_ref())
-            .map_err(|e| Error::InvalidInput(e.to_string()))?;
-        let mut entries: Vec<ForeignProofEntry> = Vec::with_capacity(proofs.len());
+        let mut entries: Vec<ForeignProofDBEntry> = Vec::with_capacity(proofs.len());
         for proof in proofs.into_iter() {
             let rid = RecordId::from_table_key(Self::PROOFS_TABLE, proof.y()?.to_string());
-            let entry = ForeignProofEntry {
+            let entry = ForeignProofDBEntry {
                 id: rid,
                 proof,
-                mint_pk,
-                mint_url: mint_url.clone(),
+                mint_id,
             };
             entries.push(entry);
         }
-        let _: Vec<ForeignProofEntry> = self
+        let _: Vec<ForeignProofDBEntry> = self
             .db
             .insert(Self::PROOFS_TABLE)
             .content(entries)
@@ -589,18 +559,12 @@ impl foreign::OfflineRepository for DBForeignOffline {
         Ok(())
     }
 
-    async fn load_proofs(
-        &self,
-        (mint_pk, mint_url): &(secp256k1::PublicKey, reqwest::Url),
-    ) -> Result<Vec<cashu::Proof>> {
-        let mint_url = cashu::MintUrl::from_str(mint_url.as_ref())
-            .map_err(|e| Error::InvalidInput(e.to_string()))?;
-        let entries: Vec<ForeignProofEntry> = self
+    async fn load_proofs(&self, mint_id: secp256k1::PublicKey) -> Result<Vec<cashu::Proof>> {
+        let entries: Vec<ForeignProofDBEntry> = self
             .db
-            .query("SELECT * FROM type::table($table) WHERE mint_url = $mint_url AND mint_pk = $mint_pk")
+            .query("SELECT * FROM type::table($table) WHERE mint_id = $mint_id")
             .bind(("table", Self::PROOFS_TABLE))
-            .bind(("mint_url", mint_url))
-            .bind(("mint_pk", *mint_pk))
+            .bind(("mint_id", mint_id))
             .await
             .map_err(|e| Error::DB(anyhow!(e)))?
             .take(0)
@@ -613,7 +577,7 @@ impl foreign::OfflineRepository for DBForeignOffline {
     }
 
     async fn remove_proofs(&self, ys: &[cashu::PublicKey]) -> Result<()> {
-        let _: Vec<ForeignProofEntry> = self
+        let _: Vec<ForeignProofDBEntry> = self
             .db
             .query("DELETE FROM type::table($table) WHERE array::any($ys, proof.y)")
             .bind(("table", Self::PROOFS_TABLE))
@@ -726,8 +690,7 @@ mod tests {
     async fn offline_search_fps() {
         let db = init_foreignoffline_mem_db().await;
 
-        let alpha_pk = core_tests::generate_random_keypair().public_key();
-        let alpha = (alpha_pk, reqwest::Url::parse("http://example.com").unwrap());
+        let alpha_id = core_tests::generate_random_keypair().public_key();
         let y = cashu::PublicKey::from(core_tests::generate_random_keypair().public_key());
         let c = cashu::PublicKey::from(core_tests::generate_random_keypair().public_key());
         let fps = vec![
@@ -752,13 +715,13 @@ mod tests {
             Sha256Hash::from_slice(&[0u8; 32]).unwrap(),
             Sha256Hash::from_slice(&[1u8; 32]).unwrap(),
         ];
-        db.store_fps(alpha.clone(), fps, hash.clone())
+        db.store_fps(alpha_id.clone(), fps, hash.clone())
             .await
             .unwrap();
         let result = db.search_fp(&hash[0]).await.unwrap();
         assert!(result.is_some());
         let (mint, fp) = result.unwrap();
-        assert_eq!(mint.0, alpha.0);
+        assert_eq!(mint, alpha_id);
         assert_eq!(fp.y, y);
     }
 


### PR DESCRIPTION
and use secp256k1::PublicKey instead of cashu::PublicKey


### for reviewers

main changes are in bcr-wdc-treasury-service/src/foreign/mod.rs
where I stop storing the mint URL as it can be easily retrieved using clowder API
and I try using secp256k1::PublicKey rather than cashu::PublicKey as much as possible in the attempt to reduce the footprint of cashu in our codebase

All the other changes are to accommodate such key changes