### PR TITLE
[bcr-wdc-treasury-service] foreign offline settler

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/foreign/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/mod.rs
@@ -59,6 +59,7 @@ pub trait OfflineRepository: Send + Sync {
     async fn load_proofs(&self, mint_id: secp256k1::PublicKey) -> Result<Vec<cashu::Proof>>;
     #[allow(dead_code)]
     async fn remove_proofs(&self, ys: &[cashu::PublicKey]) -> Result<()>;
+    async fn list_foreign_pks(&self) -> Result<Vec<secp256k1::PublicKey>>;
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -128,13 +129,6 @@ pub trait MintClientFactory: Send + Sync {
         mint_url: reqwest::Url,
         mint_pk: secp256k1::PublicKey,
     ) -> Result<Box<dyn ForeignClient>>;
-}
-
-#[cfg_attr(test, mockall::automock)]
-#[async_trait]
-pub trait OfflineSettleHandler: Send + Sync {
-    fn monitor(&self, mint: (secp256k1::PublicKey, reqwest::Url)) -> Result<()>;
-    async fn stop(&self) -> Result<()>;
 }
 
 fn proofs_vec_to_map(

--- a/crates/bcr-wdc-treasury-service/src/foreign/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/service.rs
@@ -12,7 +12,7 @@ use crate::{
     foreign::proof,
     foreign::{
         fingerprints_vec_to_map, proofs_vec_to_map, ClowderClient, KeysClient, MintClientFactory,
-        OfflineRepository, OfflineSettleHandler, OnlineRepository,
+        OfflineRepository, OnlineRepository,
     },
     TStamp,
 };
@@ -25,7 +25,6 @@ pub struct Service {
     pub keys: Arc<dyn KeysClient>,
     pub clowder: Arc<dyn ClowderClient>,
     pub mint_factory: Arc<dyn MintClientFactory>,
-    pub settler: Box<dyn OfflineSettleHandler>,
 }
 
 impl Service {
@@ -174,18 +173,10 @@ impl Service {
         if online_amount > cashu::Amount::ZERO {
             return Ok(online_amount);
         }
-        let offline_amount = try_offline_htlc_swap(
-            preimage,
-            self.offline_repo.as_ref(),
-            self.clowder.as_ref(),
-            self.settler.as_ref(),
-        )
-        .await?;
+        let offline_amount =
+            try_offline_htlc_swap(preimage, self.offline_repo.as_ref(), self.clowder.as_ref())
+                .await?;
         Ok(offline_amount)
-    }
-
-    pub async fn stop(&self) -> Result<()> {
-        self.settler.stop().await
     }
 }
 
@@ -248,13 +239,11 @@ async fn try_offline_htlc_swap(
     preimage: &str,
     repo: &dyn OfflineRepository,
     clowder: &dyn ClowderClient,
-    settler: &dyn OfflineSettleHandler,
 ) -> Result<cashu::Amount> {
     let hash = Sha256Hash::hash(preimage.as_bytes());
     let Some((mint_id, fp)) = repo.search_fp(&hash).await? else {
         return Ok(cashu::Amount::ZERO);
     };
-    let mint_url = clowder.get_mint_url_from_pk(&mint_id).await?;
     let secret = cashu::secret::Secret::from_str(preimage)?;
     let amount = cashu::Amount::from(fp.amount);
     let proof = cashu::Proof {
@@ -278,7 +267,6 @@ async fn try_offline_htlc_swap(
     proof.verify_dleq(*key)?;
     repo.remove_fps(&[fp.y]).await?;
     repo.store_proofs(mint_id, vec![proof]).await?;
-    settler.monitor((mint_id, mint_url))?;
     Ok(amount)
 }
 
@@ -328,7 +316,6 @@ mod tests {
 
     #[tokio::test]
     async fn online_exchange_works() {
-        let settler = crate::foreign::MockOfflineSettleHandler::new();
         let mut onlinerepo = crate::foreign::MockOnlineRepository::new();
         let offlinerepo = crate::foreign::MockOfflineRepository::new();
         let mut keys = crate::foreign::MockKeysClient::new();
@@ -444,7 +431,6 @@ mod tests {
             keys: Arc::new(keys),
             clowder: Arc::new(clowder),
             mint_factory: Arc::new(factory),
-            settler: Box::new(settler),
         };
         let proofs = srvc.online_exchange(inputs, exchange_path).await.unwrap();
         assert_eq!(2, proofs.len());
@@ -452,7 +438,6 @@ mod tests {
 
     #[tokio::test]
     async fn offline_exchange_works() {
-        let settler = crate::foreign::MockOfflineSettleHandler::new();
         let onlinerepo = crate::foreign::MockOnlineRepository::new();
         let mut offlinerepo = crate::foreign::MockOfflineRepository::new();
         let mut keys = crate::foreign::MockKeysClient::new();
@@ -533,7 +518,6 @@ mod tests {
             keys: Arc::new(keys),
             clowder: Arc::new(clowder),
             mint_factory: Arc::new(factory),
-            settler: Box::new(settler),
         };
         let proofs = srvc
             .offline_exchange(inputs, hashes, wallet_pk)
@@ -544,7 +528,6 @@ mod tests {
 
     #[tokio::test]
     async fn try_swap_htlc_online() {
-        let settler = crate::foreign::MockOfflineSettleHandler::new();
         let mut onlinerepo = crate::foreign::MockOnlineRepository::new();
         let offlinerepo = crate::foreign::MockOfflineRepository::new();
         let keys = crate::foreign::MockKeysClient::new();
@@ -630,7 +613,6 @@ mod tests {
             keys: Arc::new(keys),
             clowder: Arc::new(clowder),
             mint_factory: Arc::new(factory),
-            settler: Box::new(settler),
         };
         let amount = srvc
             .try_swap_htlc(&preimage, chrono::Utc::now())
@@ -641,13 +623,11 @@ mod tests {
 
     #[tokio::test]
     async fn try_swap_htlc_offline() {
-        let mut settler = crate::foreign::MockOfflineSettleHandler::new();
         let mut onlinerepo = crate::foreign::MockOnlineRepository::new();
         let mut offlinerepo = crate::foreign::MockOfflineRepository::new();
         let keys = crate::foreign::MockKeysClient::new();
         let mut clowder = crate::foreign::MockClowderClient::new();
         let factory = crate::foreign::MockMintClientFactory::new();
-        let foreign_url = reqwest::Url::parse("https://foreign-mint.example").unwrap();
         let foreign_kp = core::generate_random_keypair();
         let wallet_kp = core::generate_random_keypair();
         let myself_kp = core::generate_random_keypair();
@@ -678,12 +658,6 @@ mod tests {
         let foreign_kid = foreign_keyset.id;
         let foreign_pk = foreign_kp.public_key();
         let cloned_keyset = cashu::KeySet::from(foreign_keyset);
-        let cloned_url = foreign_url.clone();
-        clowder
-            .expect_get_mint_url_from_pk()
-            .with(eq(foreign_pk))
-            .times(1)
-            .returning(move |_| Ok(cloned_url.clone()));
         clowder
             .expect_get_keyset()
             .with(eq(foreign_pk), eq(foreign_kid))
@@ -700,18 +674,12 @@ mod tests {
             .with(eq(foreign_pk), always())
             .times(1)
             .returning(|_, _| Ok(()));
-        settler
-            .expect_monitor()
-            .times(1)
-            .with(eq((foreign_pk, foreign_url)))
-            .returning(|_| Ok(()));
         let srvc = Service {
             online_repo: Arc::new(onlinerepo),
             offline_repo: Arc::new(offlinerepo),
             keys: Arc::new(keys),
             clowder: Arc::new(clowder),
             mint_factory: Arc::new(factory),
-            settler: Box::new(settler),
         };
         let amount = srvc
             .try_swap_htlc(&preimage, chrono::Utc::now())

--- a/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
@@ -1,195 +1,86 @@
 // ----- standard library imports
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::Arc;
 // ----- extra library imports
+use anyhow::Result as AnyResult;
 use async_trait::async_trait;
 use bcr_common::cashu;
-use tokio::time::Duration;
-use tokio_util::sync::CancellationToken;
+use bcr_wdc_utils::routine::{Routine, TStamp};
 use tracing::{debug, error, info, warn};
 // ----- local imports
-use crate::{
-    error::{Error, Result},
-    foreign::{
-        ClowderClient, MintClientFactory, OfflineRepository, OfflineSettleHandler, OnlineRepository,
-    },
-};
+use crate::foreign::{ClowderClient, MintClientFactory, OfflineRepository, OnlineRepository};
 
 // ----- end imports
 
 pub struct Handler {
-    online: Weak<dyn OnlineRepository>,
-    offline: Weak<dyn OfflineRepository>,
-    clowder: Weak<dyn ClowderClient>,
-    mint_factory: Weak<dyn MintClientFactory>,
-    cancel: CancellationToken,
-    interval: tokio::time::Duration,
-    monitored: Mutex<Vec<secp256k1::PublicKey>>,
-    handles: Mutex<Vec<tokio::task::JoinHandle<()>>>,
+    pub online: Arc<dyn OnlineRepository>,
+    pub offline: Arc<dyn OfflineRepository>,
+    pub clowder: Arc<dyn ClowderClient>,
+    pub mint_factory: Arc<dyn MintClientFactory>,
 }
 
-impl Handler {
-    pub fn new(
-        online: &Arc<dyn OnlineRepository>,
-        offline: &Arc<dyn OfflineRepository>,
-        clowder: &Arc<dyn ClowderClient>,
-        mint_factory: &Arc<dyn MintClientFactory>,
-        interval: std::time::Duration,
-    ) -> Self {
-        Self {
-            online: Arc::downgrade(online),
-            offline: Arc::downgrade(offline),
-            clowder: Arc::downgrade(clowder),
-            mint_factory: Arc::downgrade(mint_factory),
-            cancel: CancellationToken::new(),
-            interval,
-            monitored: Mutex::new(Vec::new()),
-            handles: Mutex::new(Vec::new()),
+macro_rules! try_or_warn {
+    ($expr:expr) => {
+        match $expr.await {
+            Ok(result) => result,
+            Err(e) => {
+                warn!("{} failed: {}, retry later", stringify!($expr), e);
+                continue;
+            }
         }
-    }
+    };
 }
 
 #[async_trait]
-impl OfflineSettleHandler for Handler {
-    fn monitor(&self, mint: (secp256k1::PublicKey, reqwest::Url)) -> Result<()> {
-        {
-            let mut monitored = self.monitored.lock().unwrap();
-            if monitored.contains(&mint.0) {
-                return Ok(());
+impl Routine for Handler {
+    async fn run_task(&self, now: TStamp) -> AnyResult<Option<std::time::Duration>> {
+        let mints = self.offline.list_foreign_pks().await?;
+        for mint_id in mints {
+            debug!("Checking offline status for mint {}", mint_id);
+            let mint_url = try_or_warn!(self.clowder.get_mint_url_from_pk(&mint_id));
+            let is_offline = try_or_warn!(self.clowder.is_offline(mint_id));
+            if is_offline {
+                debug!("{} still offline", mint_url);
+                continue;
             }
-            monitored.push(mint.0);
-        }
-        let handle = tokio::spawn(monitor(
-            mint.clone(),
-            Weak::clone(&self.clowder),
-            Weak::clone(&self.online),
-            Weak::clone(&self.offline),
-            Weak::clone(&self.mint_factory),
-            self.interval,
-            self.cancel.clone(),
-        ));
-        {
-            let mut handles = self.handles.lock().unwrap();
-            handles.push(handle);
-        }
-        Ok(())
-    }
-
-    async fn stop(&self) -> Result<()> {
-        self.cancel.cancel();
-        loop {
-            let handle = self.handles.lock().unwrap().pop();
-            let Some(handle) = handle else { return Ok(()) };
-            handle.await.map_err(|e| Error::Internal(e.to_string()))?;
-        }
-    }
-}
-
-async fn monitor(
-    mint: (secp256k1::PublicKey, reqwest::Url),
-    clowder: Weak<dyn ClowderClient>,
-    online: Weak<dyn OnlineRepository>,
-    offline: Weak<dyn OfflineRepository>,
-    factory: Weak<dyn MintClientFactory>,
-    pause: Duration,
-    cancel: CancellationToken,
-) {
-    debug!("Starting offline monitor for {}", mint.1);
-    loop {
-        tokio::select! {
-                _ = cancel.cancelled() => {
-                    debug!("Monitor cancelled, abandoning {}", mint.1);
-                    break;
+            let client = try_or_warn!(self.mint_factory.make_client(mint_url.clone(), mint_id));
+            let proofs = try_or_warn!(self.offline.load_proofs(mint_id));
+            let mapped_proofs = bcr_common::core::signature::proofs_to_map(proofs);
+            for (kid, proofs) in mapped_proofs {
+                let total = proofs
+                    .iter()
+                    .fold(cashu::Amount::ZERO, |acc, p| acc + p.amount);
+                let ys: Vec<cashu::PublicKey> = proofs
+                    .iter()
+                    .map(|p| p.y().expect("Proof::y(): impossible!!"))
+                    .collect();
+                let keyset = try_or_warn!(client.get_keyset(kid));
+                debug!(
+                    "Settling proofs totaling {total} at {} with keysetID {kid}",
+                    mint_url
+                );
+                let Ok(premints) =
+                    cashu::PreMintSecrets::random(kid, total, &cashu::amount::SplitTarget::None)
+                else {
+                    warn!("PreMintSecrets::random failed {}, retry later", mint_url);
+                    continue;
+                };
+                let signatures =
+                    try_or_warn!(client.swap(proofs, premints.blinded_messages(), now));
+                let (rs, secrets) = premints
+                    .secrets
+                    .into_iter()
+                    .map(|s| (s.r, s.secret))
+                    .unzip();
+                let news = cashu::dhke::construct_proofs(signatures, rs, secrets, &keyset.keys)?;
+                if self.online.store(mint_id, news).await.is_err() {
+                    error!("store new proofs failed {}, {total} lost", mint_url);
+                };
+                if self.offline.remove_proofs(&ys).await.is_err() {
+                    warn!("remove_proofs failed {}", mint_url);
                 }
-                _ = tokio::time::sleep(pause) => {
+                info!("successfully settled {total} at {}", mint_url);
             }
         }
-        debug!("Checking offline status for {}", mint.1);
-        let Some(clowder) = clowder.upgrade() else {
-            warn!("ClowderClient upgrade failed, abandoning {}", mint.1);
-            break;
-        };
-        let Ok(is_offline) = clowder.is_offline(mint.0).await else {
-            warn!("is_offline failed, retrying later {}", mint.1);
-            continue;
-        };
-        if is_offline {
-            debug!("{} still offline", mint.1);
-            continue;
-        }
-        // process settlement
-        let Some(offline_repo) = offline.upgrade() else {
-            warn!("OfflineRepository upgrade failed, abandoning {}", mint.1);
-            break;
-        };
-        let Some(online_repo) = online.upgrade() else {
-            warn!("OnlineRepository upgrade failed, abandoning {}", mint.1);
-            break;
-        };
-        let Some(factory) = factory.upgrade() else {
-            warn!("MintClientFactory upgrade failed, abandoning {}", mint.1);
-            break;
-        };
-        let Ok(client) = factory.make_client(mint.1.clone(), mint.0).await else {
-            warn!("make_client failed {}, retry later", mint.1);
-            continue;
-        };
-        let Ok(proofs) = offline_repo.load_proofs(mint.0).await else {
-            warn!("load_proofs failed {}, retry later", mint.1);
-            continue;
-        };
-        let proofs = bcr_common::core::signature::proofs_to_map(proofs);
-        for (kid, proofs) in proofs {
-            let total = proofs
-                .iter()
-                .fold(cashu::Amount::ZERO, |acc, p| acc + p.amount);
-            let mut ys = Vec::with_capacity(proofs.len());
-            for proof in &proofs {
-                let Ok(y) = proof.y() else {
-                    warn!("Proof::y() failed {}, retry later", mint.1);
-                    continue;
-                };
-                ys.push(y);
-            }
-            let Ok(keyset) = client.get_keyset(kid).await else {
-                warn!("get_keyset failed {}, retry later", mint.1);
-                continue;
-            };
-            debug!(
-                "Settling proofs totaling {total} at {} with keysetID {kid}",
-                mint.1
-            );
-            let Ok(premints) =
-                cashu::PreMintSecrets::random(kid, total, &cashu::amount::SplitTarget::None)
-            else {
-                warn!("PreMintSecrets::random failed {}, retry later", mint.1);
-                continue;
-            };
-            let now = chrono::Utc::now();
-            let Ok(signatures) = client.swap(proofs, premints.blinded_messages(), now).await else {
-                warn!("swap failed {}, lost {}", mint.1, total);
-                continue;
-            };
-            let mut news = Vec::with_capacity(signatures.len());
-            for (signature, premint) in signatures.into_iter().zip(premints.iter()) {
-                let amount = signature.amount;
-                let Ok(proof) = bcr_common::core::signature::unblind_ecash_signature(
-                    &keyset,
-                    premint.clone(),
-                    signature,
-                ) else {
-                    error!("unblind_ecash_signature failed {}, lost {}", mint.1, amount);
-                    continue;
-                };
-                news.push(proof);
-            }
-            if online_repo.store(mint.0, news).await.is_err() {
-                error!("store new proofs failed {}, {total} lost", mint.1);
-            };
-            if offline_repo.remove_proofs(&ys).await.is_err() {
-                warn!("remove_proofs failed {}", mint.1);
-            }
-            info!("successfully settled {total} at {}", mint.1);
-        }
-        break;
+        Ok(None)
     }
 }

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -180,23 +180,12 @@ pub async fn init_app(cfg: AppConfig) -> (AppController, Vec<routine::RoutineHan
     let foreigncore = Arc::new(foreign::clients::CoreCl {
         core: core_client.clone(),
     });
-    let interval = std::time::Duration::from_secs(monitor_interval_sec as u64);
-    let settler = {
-        let online: Arc<dyn foreign::OnlineRepository> = onlinerepo.clone();
-        let offline: Arc<dyn foreign::OfflineRepository> = offlinerepo.clone();
-        let clwdr: Arc<dyn foreign::ClowderClient> = clowder.clone();
-        let fctry: Arc<dyn foreign::MintClientFactory> = factory.clone();
-        Box::new(foreign::settle::Handler::new(
-            &online, &offline, &clwdr, &fctry, interval,
-        ))
-    };
     let foreign = foreign::Service {
-        online_repo: onlinerepo,
-        offline_repo: offlinerepo,
+        online_repo: onlinerepo.clone(),
+        offline_repo: offlinerepo.clone(),
         keys: foreigncore.clone(),
         clowder: clowder.clone(),
         mint_factory: factory.clone(),
-        settler,
     };
 
     // vault
@@ -233,12 +222,23 @@ pub async fn init_app(cfg: AppConfig) -> (AppController, Vec<routine::RoutineHan
     };
 
     let monitor_interval = std::time::Duration::from_secs(monitor_interval_sec as u64);
-    let monitors = vec![routine::RoutineHandle::new(
-        onchain::MintOpMonitor {
-            srvc: app_ctrl.onchain.clone(),
-        },
-        monitor_interval,
-    )];
+    let monitors = vec![
+        routine::RoutineHandle::new(
+            onchain::MintOpMonitor {
+                srvc: app_ctrl.onchain.clone(),
+            },
+            monitor_interval,
+        ),
+        routine::RoutineHandle::new(
+            foreign::settle::Handler {
+                online: onlinerepo,
+                offline: offlinerepo,
+                clowder,
+                mint_factory: factory,
+            },
+            monitor_interval,
+        ),
+    ];
     (app_ctrl, monitors)
 }
 

--- a/crates/bcr-wdc-treasury-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/inmemory.rs
@@ -122,6 +122,10 @@ impl foreign::OfflineRepository for OfflineRepository {
         }
         Ok(())
     }
+    async fn list_foreign_pks(&self) -> Result<Vec<secp256k1::PublicKey>> {
+        let locked = self.proofs.lock().unwrap();
+        Ok(locked.keys().cloned().collect())
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/surreal.rs
@@ -475,7 +475,8 @@ impl ebill::Repository for DBEbill {
 struct ForeignProofDBEntry {
     id: RecordId,
     proof: cashu::Proof,
-    mint_id: secp256k1::PublicKey,
+    // storing as String, otherwise array::group() merges them into one entry
+    mint_id: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -512,7 +513,7 @@ impl foreign::OnlineRepository for DBForeignOnline {
             entries.push(ForeignProofDBEntry {
                 id: rid,
                 proof,
-                mint_id,
+                mint_id: mint_id.to_string(),
             });
         }
         let _: Vec<ForeignProofDBEntry> = self
@@ -537,6 +538,7 @@ impl foreign::OnlineRepository for DBForeignOnline {
         let mut ret_val = Vec::with_capacity(entries.len());
         for entry in entries {
             let ForeignProofDBEntry { mint_id, proof, .. } = entry;
+            let mint_id = secp256k1::PublicKey::from_str(&mint_id).expect("mint_id <--> String");
             ret_val.push((mint_id, proof));
         }
         Ok(ret_val)
@@ -601,6 +603,18 @@ impl foreign::OnlineRepository for DBForeignOnline {
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ForeignFingerprintDBEntry {
+    id: RecordId,
+    amount: u64,
+    keyset_id: cashu::Id,
+    y: cashu::PublicKey,
+    c: cashu::PublicKey,
+    witness: Option<cashu::Witness>,
+    dleq: Option<cashu::ProofDleq>,
+    mint_id: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct DBForeignOffline {
     db: Surreal<Any>,
@@ -617,18 +631,6 @@ impl DBForeignOffline {
         db_connection.use_db(config.database).await?;
         Ok(Self { db: db_connection })
     }
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct ForeignFingerprintDBEntry {
-    id: RecordId,
-    amount: u64,
-    keyset_id: cashu::Id,
-    y: cashu::PublicKey,
-    c: cashu::PublicKey,
-    witness: Option<cashu::Witness>,
-    dleq: Option<cashu::ProofDleq>,
-    mint_id: secp256k1::PublicKey,
 }
 
 #[async_trait]
@@ -649,7 +651,7 @@ impl foreign::OfflineRepository for DBForeignOffline {
                 c: fp.c,
                 witness: fp.witness,
                 dleq: fp.dleq,
-                mint_id,
+                mint_id: mint_id.to_string(),
             };
             let _: Option<ForeignFingerprintDBEntry> = self
                 .db
@@ -682,7 +684,8 @@ impl foreign::OfflineRepository for DBForeignOffline {
             witness: entry.witness,
             dleq: entry.dleq,
         };
-        Ok(Some((entry.mint_id, fp)))
+        let mint_id = secp256k1::PublicKey::from_str(&entry.mint_id).expect("mint_id <--> String");
+        Ok(Some((mint_id, fp)))
     }
 
     async fn remove_fps(&self, ys: &[cashu::PublicKey]) -> Result<()> {
@@ -708,7 +711,7 @@ impl foreign::OfflineRepository for DBForeignOffline {
             let entry = ForeignProofDBEntry {
                 id: rid,
                 proof,
-                mint_id,
+                mint_id: mint_id.to_string(),
             };
             entries.push(entry);
         }
@@ -726,7 +729,7 @@ impl foreign::OfflineRepository for DBForeignOffline {
             .db
             .query("SELECT * FROM type::table($table) WHERE mint_id = $mint_id")
             .bind(("table", Self::PROOFS_TABLE))
-            .bind(("mint_id", mint_id))
+            .bind(("mint_id", mint_id.to_string()))
             .await
             .map_err(|e| Error::DB(anyhow!(e)))?
             .take(0)
@@ -749,6 +752,27 @@ impl foreign::OfflineRepository for DBForeignOffline {
             .take(0)
             .map_err(|e| Error::DB(anyhow!(e)))?;
         Ok(())
+    }
+    async fn list_foreign_pks(&self) -> Result<Vec<secp256k1::PublicKey>> {
+        #[derive(Debug, Default, Clone, serde::Deserialize)]
+        struct MintIdEntries {
+            mint_id: Vec<String>,
+        }
+        let entries: Option<MintIdEntries> = self
+            .db
+            .query("SELECT array::group(mint_id) AS mint_id FROM type::table($table) GROUP ALL")
+            .bind(("table", Self::PROOFS_TABLE))
+            .await
+            .map_err(|e| Error::DB(anyhow!(e)))?
+            .take(0)
+            .map_err(|e| Error::DB(anyhow!(e)))?;
+        let mint_ids: Vec<secp256k1::PublicKey> = entries
+            .unwrap_or_default()
+            .mint_id
+            .into_iter()
+            .map(|m| secp256k1::PublicKey::from_str(&m).expect("mint_id <--> String"))
+            .collect();
+        Ok(mint_ids)
     }
 }
 
@@ -962,6 +986,42 @@ mod tests {
         let (mint, fp) = result.unwrap();
         assert_eq!(mint, alpha_id);
         assert_eq!(fp.y, y);
+    }
+
+    #[tokio::test]
+    async fn offline_list_foreign() {
+        let db = init_foreignoffline_mem_db().await;
+        let amounts = vec![cashu::Amount::from(8u64), cashu::Amount::from(16u64)];
+        let (_, keyset) = core_tests::generate_random_ecash_keyset();
+        let alpha1 = core::generate_random_keypair().public_key();
+        let proofs: Vec<cashu::Proof> = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+        db.store_proofs(alpha1.clone(), proofs.clone())
+            .await
+            .unwrap();
+        let alpha2 = core::generate_random_keypair().public_key();
+        let proofs: Vec<cashu::Proof> = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+        db.store_proofs(alpha2.clone(), proofs).await.unwrap();
+        let result = db.list_foreign_pks().await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&alpha1));
+        assert!(result.contains(&alpha2));
+    }
+
+    #[tokio::test]
+    async fn offline_load_proofs() {
+        let db = init_foreignoffline_mem_db().await;
+        let amounts = vec![cashu::Amount::from(8u64), cashu::Amount::from(16u64)];
+        let (_, keyset) = core_tests::generate_random_ecash_keyset();
+        let alpha = core::generate_random_keypair().public_key();
+        let proofs: Vec<cashu::Proof> = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+        db.store_proofs(alpha.clone(), proofs.clone())
+            .await
+            .unwrap();
+        let result = db.load_proofs(alpha.clone()).await.unwrap();
+        assert_eq!(result.len(), proofs.len());
+        for proof in proofs {
+            assert!(result.contains(&proof));
+        }
     }
 
     async fn init_credit_mem_db() -> DBEbill {


### PR DESCRIPTION
refactor the foreign offline settler to fit into the bcr_wdc_utils::routine framework