### PR TITLE
[bcr-wdc-core-service] add settlement window

### DIFF
--- a/crates/bcr-wdc-core-service/src/error.rs
+++ b/crates/bcr-wdc-core-service/src/error.rs
@@ -65,6 +65,8 @@ pub enum Error {
 
     #[error("internal {0}")]
     Internal(String),
+    #[error("service temporarily unavailable, retry later")]
+    ServiceUnavailable,
 }
 
 impl axum::response::IntoResponse for Error {
@@ -104,6 +106,7 @@ impl axum::response::IntoResponse for Error {
             Error::InactiveKeyset(_) => (StatusCode::BAD_REQUEST, String::from("Inactive keyset")),
 
             Error::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            Error::ServiceUnavailable => (StatusCode::SERVICE_UNAVAILABLE, self.to_string()),
         };
 
         response.into_response()

--- a/crates/bcr-wdc-core-service/src/lib.rs
+++ b/crates/bcr-wdc-core-service/src/lib.rs
@@ -38,6 +38,7 @@ pub struct AppConfig {
     max_expiry_sec: u64,
     minimum_keyset_fees_ppk: u64,
     cache_expiry_sec: u64,
+    settle_window_sec: u64,
 }
 
 #[derive(Clone, FromRef)]
@@ -62,6 +63,7 @@ impl AppController {
             max_expiry_sec,
             minimum_keyset_fees_ppk,
             cache_expiry_sec,
+            settle_window_sec,
         } = cfg;
 
         let keys_repo = persistence::surreal::DBKeys::new(keys)
@@ -110,6 +112,8 @@ impl AppController {
         let treasury_for_swap = swap::TreasuryCl {
             cl: Box::new(treasury_cl),
         };
+        let settle_window_tout =
+            chrono::Utc::now() + chrono::Duration::seconds(settle_window_sec as i64);
         let swap_service = swap::service::Service {
             proofs: Box::new(proofs_repo),
             commitments: Box::new(commitments_repo),
@@ -118,6 +122,7 @@ impl AppController {
             treasury: Box::new(treasury_for_swap),
             max_expiry,
             alpha_id,
+            settle_window_deadline: settle_window_tout,
         };
         let cache_expiry = chrono::Duration::seconds(cache_expiry_sec as i64);
         let cache = Arc::new(nut19::InMemoryMap::new(cache_expiry));
@@ -198,6 +203,7 @@ pub mod test_utils {
             treasury: Box::new(swap::test_utils::DummyTreasuryClient),
             max_expiry: chrono::Duration::seconds(3600),
             alpha_id: mint_kp().public_key(),
+            settle_window_deadline: TStamp::default(),
         };
         AppController {
             keys: Arc::new(keysrv),

--- a/crates/bcr-wdc-core-service/src/persistence/inmemory.rs
+++ b/crates/bcr-wdc-core-service/src/persistence/inmemory.rs
@@ -182,7 +182,7 @@ type Commitment = (
     TStamp,
     cashu::PublicKey,
     [u8; 32],
-    bool,
+    persistence::SignatureOwner,
 );
 #[allow(dead_code)]
 #[derive(Clone, Default)]
@@ -246,7 +246,7 @@ impl persistence::CommitmentRepository for CommitmentMap {
         wallet_key: cashu::PublicKey,
         signature: schnorr::Signature,
         fp_digest: [u8; 32],
-        signed: bool,
+        signed: persistence::SignatureOwner,
     ) -> Result<()> {
         inputs.sort();
         outputs.sort();
@@ -271,8 +271,8 @@ impl persistence::CommitmentRepository for CommitmentMap {
             .ok_or(Error::ResourceNotFound(signature.to_string()))?
             .clone();
         Ok(persistence::StoredCommitment {
-            inputs: comm.0,
-            outputs: comm.1,
+            inputs: comm.0.clone(),
+            outputs: comm.1.clone(),
             expiration: comm.2,
             fp_digest: comm.4,
             signed: comm.5,

--- a/crates/bcr-wdc-core-service/src/persistence/mod.rs
+++ b/crates/bcr-wdc-core-service/src/persistence/mod.rs
@@ -47,12 +47,19 @@ pub trait ProofRepository: Send + Sync {
     async fn contains(&self, y: cashu::PublicKey) -> Result<Option<cashu::ProofState>>;
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum SignatureOwner {
+    Unsigned,
+    Alpha,
+    Beta,
+}
+
 pub struct StoredCommitment {
     pub inputs: Vec<cashu::PublicKey>,
     pub outputs: Vec<cashu::PublicKey>,
     pub expiration: TStamp,
     pub fp_digest: [u8; 32],
-    pub signed: bool,
+    pub signed: SignatureOwner,
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -66,7 +73,7 @@ pub trait CommitmentRepository: Send + Sync {
         wallet_key: cashu::PublicKey,
         commitment: schnorr::Signature,
         fp_digest: [u8; 32],
-        signed: bool,
+        signed: SignatureOwner,
     ) -> Result<()>;
     async fn load(&self, signature: &schnorr::Signature) -> Result<StoredCommitment>;
     async fn contains_inputs(&self, inputs: &[cashu::PublicKey]) -> Result<bool>;
@@ -483,7 +490,7 @@ mod tests {
             random_wallet_key(),
             signature,
             [0u8; 32],
-            false,
+            SignatureOwner::Unsigned,
         )
         .await
         .unwrap();
@@ -499,7 +506,7 @@ mod tests {
                 random_wallet_key(),
                 signature,
                 [0u8; 32],
-                false,
+                SignatureOwner::Unsigned,
             )
             .await;
         assert!(res.is_err());
@@ -513,7 +520,7 @@ mod tests {
                 random_wallet_key(),
                 signature,
                 [0u8; 32],
-                false,
+                SignatureOwner::Unsigned,
             )
             .await;
         assert!(res.is_err());
@@ -539,7 +546,7 @@ mod tests {
             random_wallet_key(),
             signature,
             [0u8; 32],
-            false,
+            SignatureOwner::Unsigned,
         )
         .await
         .unwrap();
@@ -575,7 +582,7 @@ mod tests {
             random_wallet_key(),
             signature,
             [0u8; 32],
-            false,
+            SignatureOwner::Unsigned,
         )
         .await
         .unwrap();
@@ -611,7 +618,7 @@ mod tests {
             random_wallet_key(),
             signature,
             [0u8; 32],
-            false,
+            SignatureOwner::Unsigned,
         )
         .await
         .unwrap();

--- a/crates/bcr-wdc-core-service/src/persistence/surreal.rs
+++ b/crates/bcr-wdc-core-service/src/persistence/surreal.rs
@@ -422,6 +422,31 @@ impl persistence::ProofRepository for DBProofs {
 
 ////////////////////////////////////////////////////////////////////// Commitments DB
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum SignatureOwner {
+    Unsigned,
+    Alpha,
+    Beta,
+}
+impl std::convert::From<persistence::SignatureOwner> for SignatureOwner {
+    fn from(owner: persistence::SignatureOwner) -> Self {
+        match owner {
+            persistence::SignatureOwner::Unsigned => SignatureOwner::Unsigned,
+            persistence::SignatureOwner::Alpha => SignatureOwner::Alpha,
+            persistence::SignatureOwner::Beta => SignatureOwner::Beta,
+        }
+    }
+}
+impl std::convert::From<SignatureOwner> for persistence::SignatureOwner {
+    fn from(owner: SignatureOwner) -> Self {
+        match owner {
+            SignatureOwner::Unsigned => persistence::SignatureOwner::Unsigned,
+            SignatureOwner::Alpha => persistence::SignatureOwner::Alpha,
+            SignatureOwner::Beta => persistence::SignatureOwner::Beta,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct CommitmentDBEntry {
     id: RecordId,
     inputs: Vec<cashu::PublicKey>,
@@ -429,7 +454,7 @@ struct CommitmentDBEntry {
     expiration: TStamp,
     wallet_key: cashu::PublicKey,
     fp_digest: [u8; 32],
-    signed: bool,
+    signed: SignatureOwner,
 }
 
 #[derive(Debug, Clone)]
@@ -495,7 +520,7 @@ impl persistence::CommitmentRepository for DBCommitments {
         wallet_key: cashu::PublicKey,
         signature: schnorr::Signature,
         fp_digest: [u8; 32],
-        signed: bool,
+        signed: persistence::SignatureOwner,
     ) -> Result<()> {
         let rid = RecordId::from_table_key(Self::TABLE, signature.to_string());
         let newentry = CommitmentDBEntry {
@@ -505,7 +530,7 @@ impl persistence::CommitmentRepository for DBCommitments {
             expiration,
             wallet_key,
             fp_digest,
-            signed,
+            signed: signed.into(),
         };
         let mut query = self
             .db
@@ -561,7 +586,7 @@ impl persistence::CommitmentRepository for DBCommitments {
             outputs: commitment_entry.outputs,
             expiration: commitment_entry.expiration,
             fp_digest: commitment_entry.fp_digest,
-            signed: commitment_entry.signed,
+            signed: commitment_entry.signed.into(),
         })
     }
 

--- a/crates/bcr-wdc-core-service/src/swap/mod.rs
+++ b/crates/bcr-wdc-core-service/src/swap/mod.rs
@@ -14,6 +14,7 @@ use bitcoin::secp256k1::{schnorr, PublicKey};
 use crate::{
     error::{Error, Result},
     keys,
+    persistence::SignatureOwner,
 };
 // ----- local modules
 pub mod service;
@@ -103,6 +104,14 @@ impl KeysService for KeysSignService {
 pub enum PublicKeyOwner {
     Alpha,
     Beta,
+}
+impl std::convert::From<PublicKeyOwner> for SignatureOwner {
+    fn from(value: PublicKeyOwner) -> Self {
+        match value {
+            PublicKeyOwner::Alpha => SignatureOwner::Alpha,
+            PublicKeyOwner::Beta => SignatureOwner::Beta,
+        }
+    }
 }
 
 #[cfg_attr(test, mockall::automock)]

--- a/crates/bcr-wdc-core-service/src/swap/service.rs
+++ b/crates/bcr-wdc-core-service/src/swap/service.rs
@@ -14,7 +14,10 @@ use secp256k1::schnorr;
 // ----- local imports
 use crate::{
     error::{Error, Result},
-    persistence::{CommitmentRepository, ProofRepository, ReservedYsRepository, StoredCommitment},
+    persistence::{
+        CommitmentRepository, ProofRepository, ReservedYsRepository, SignatureOwner,
+        StoredCommitment,
+    },
     swap::{ClowderClient, KeysService, TreasuryService},
     TStamp,
 };
@@ -29,6 +32,7 @@ pub struct Service {
     pub treasury: Box<dyn TreasuryService>,
     pub max_expiry: chrono::Duration,
     pub alpha_id: PublicKey,
+    pub settle_window_deadline: TStamp,
 }
 
 impl Service {
@@ -92,8 +96,13 @@ impl Service {
             &signature,
             &content.wallet_key.x_only_public_key().0,
         )?;
-        let _owner = self.clowder.verify_pk(&content.wallet_key).await?;
-        self._commit_to_swap(sign_service, content, now, true).await
+        let owner = self.clowder.verify_pk(&content.wallet_key).await?;
+        let signature_owner = SignatureOwner::from(owner);
+        if now < self.settle_window_deadline && !matches!(signature_owner, SignatureOwner::Beta) {
+            return Err(Error::ServiceUnavailable);
+        }
+        self._commit_to_swap(sign_service, content, now, signature_owner)
+            .await
     }
 
     pub async fn commit_to_swap(
@@ -102,7 +111,11 @@ impl Service {
         request: wire_swap::SwapCommitmentRequest,
         now: TStamp,
     ) -> Result<(String, schnorr::Signature)> {
-        self._commit_to_swap(sign_service, request, now, false)
+        // check settle window
+        if now < self.settle_window_deadline {
+            return Err(Error::ServiceUnavailable);
+        }
+        self._commit_to_swap(sign_service, request, now, SignatureOwner::Unsigned)
             .await
     }
 
@@ -111,7 +124,7 @@ impl Service {
         sign_service: &dyn KeysService,
         request: wire_swap::SwapCommitmentRequest,
         now: TStamp,
-        signed: bool,
+        signed: SignatureOwner,
     ) -> Result<(String, schnorr::Signature)> {
         // check expiry
         let expiry = chrono::DateTime::from_timestamp(request.expiry as i64, 0)
@@ -208,6 +221,10 @@ impl Service {
             signed,
             ..
         } = self.commitments.load(&commitment).await?;
+        // check settle window
+        if now < self.settle_window_deadline && !matches!(signed, SignatureOwner::Beta) {
+            return Err(Error::ServiceUnavailable);
+        }
         // check expiration
         if expiration < now {
             return Err(Error::InvalidInput(String::from("commitment has expired")));
@@ -234,8 +251,8 @@ impl Service {
             sign_service.verify_proofs(&inputs),
         )?;
         let fee_policy = match signed {
-            true => swap::mint::FeePolicy::Ignore,
-            false => swap::mint::FeePolicy::Apply,
+            SignatureOwner::Alpha | SignatureOwner::Beta => swap::mint::FeePolicy::Ignore,
+            SignatureOwner::Unsigned => swap::mint::FeePolicy::Apply,
         };
         swap::mint::verify_swap(&inputs, &outputs, &kinfos, fee_policy)?;
         // generate signatures
@@ -405,6 +422,7 @@ mod tests {
             treasury: Box::new(DummyTreasuryClient),
             max_expiry: chrono::Duration::seconds(3600),
             alpha_id,
+            settle_window_deadline: TStamp::default(),
         };
         let request = wire_swap::SwapCommitmentRequest {
             inputs: bcr_common::wire::attestation::AttestedFingerprints {
@@ -457,6 +475,7 @@ mod tests {
             treasury: Box::new(DummyTreasuryClient),
             max_expiry: chrono::Duration::seconds(3600),
             alpha_id: alpha_kp.public_key(),
+            settle_window_deadline: TStamp::default(),
         };
         let request = wire_swap::SwapCommitmentRequest {
             inputs: bcr_common::wire::attestation::AttestedFingerprints {
@@ -499,7 +518,7 @@ mod tests {
                 outputs: vec![],
                 expiration: expiry,
                 fp_digest,
-                signed: false,
+                signed: SignatureOwner::Unsigned,
             })
         });
         let cloned = cashu::KeySetInfo::from(kinfo);
@@ -554,6 +573,7 @@ mod tests {
             treasury: Box::new(mocktreasu),
             max_expiry: chrono::Duration::seconds(3600),
             alpha_id,
+            settle_window_deadline: TStamp::default(),
         };
         let signatures = service
             .swap(
@@ -588,7 +608,7 @@ mod tests {
                 outputs: vec![],
                 expiration: expiry,
                 fp_digest: [1u8; 32],
-                signed: false,
+                signed: SignatureOwner::Unsigned,
             })
         });
         let alpha_id = core::generate_random_keypair().public_key();
@@ -600,6 +620,7 @@ mod tests {
             treasury: Box::new(mocktreasu),
             max_expiry: chrono::Duration::seconds(3600),
             alpha_id,
+            settle_window_deadline: TStamp::default(),
         };
         let err = service
             .swap(


### PR DESCRIPTION
at the start of the service we assume we are coming from an offline state and we wait for the settlement window before accepting commitments for swap operation by anonymous users