### PR TITLE
[bcr-wdc-treasury-service] use signed swap commitment]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "cdk-common",
  "chrono",
  "ciborium",
+ "frost-secp256k1-tr",
  "infer",
  "nostr",
  "rand 0.8.6",
@@ -1509,6 +1510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +1566,12 @@ dependencies = [
  "winnow 1.0.3",
  "yaml-rust2",
 ]
+
+[[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-oid"
@@ -1833,6 +1849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "debugless-unwrap"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1872,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1942,6 +1975,15 @@ name = "dnssec-prover"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "double-ended-peekable"
@@ -2040,6 +2082,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
+ "digest",
  "ff",
  "generic-array 0.14.7",
  "group",
@@ -2054,6 +2097,18 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -2246,6 +2301,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "frost-core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2619366c227233c0f817ae01156bd21b8cf74d2bd96cbe0889f4c2e266724e44"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "debugless-unwrap",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core 0.6.4",
+ "serde",
+ "serdect",
+ "thiserror 2.0.18",
+ "visibility",
+ "zeroize",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5eb1ea58c0250b7ce834337f7b19e0417686d14ffc7f626137dea9149762d4"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "frost-secp256k1-tr"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8a25b14bfd5d25deba5edce61ec99c3afb752a1d26630a196bba4cb1c4ca5e"
+dependencies = [
+ "document-features",
+ "frost-core",
+ "frost-rerandomized",
+ "k256",
+ "rand_core 0.6.4",
+ "sha2",
 ]
 
 [[package]]
@@ -2653,6 +2757,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version",
+ "serde",
  "spin",
  "stable_deref_trait",
 ]
@@ -3283,6 +3388,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -4149,6 +4260,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c564dbf654befd49035528299f1208a40508f6e07efb11c163444e304e4484f"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
 ]
 
 [[package]]
@@ -5338,6 +5462,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -6592,6 +6726,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7208,6 +7353,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/bcr-wdc-core-service/src/swap/mod.rs
+++ b/crates/bcr-wdc-core-service/src/swap/mod.rs
@@ -142,7 +142,7 @@ impl ClowderClient for ClowderCl {
         &self,
         request: wire_swap::SwapCommitmentRequest,
     ) -> Result<(String, schnorr::Signature)> {
-        let content = signature::serialize_borsh_msg_b64(&request)
+        let (content, _) = signature::serialize_borsh_msg_b64(&request)
             .map_err(|e| Error::Internal(format!("failed to serialize commitment: {e}")))?;
         let request = wire_clowder::SwapCommitmentRequest {
             inputs: request.inputs,

--- a/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/clients.rs
@@ -4,9 +4,12 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use bcr_common::{
     cashu,
-    client::clowder::ClowderNatsClient,
+    client::clowder::{ClowderNatsClient, SignatoryNatsClient},
     client::{admin::clowder::Client as ClowderClient, core::Client as CoreClient},
-    wire::{attestation as wire_attestation, clowder as wire_clowder, keys as wire_keys},
+    wire::{
+        attestation as wire_attestation, clowder as wire_clowder, keys as wire_keys,
+        swap as wire_swap,
+    },
 };
 // ----- local imports
 use crate::{
@@ -45,6 +48,7 @@ impl foreign::KeysClient for CoreCl {
 pub struct ClowderCl {
     pub rest: Arc<ClowderClient>,
     pub stream: Arc<ClowderNatsClient>,
+    pub signatory: Box<SignatoryNatsClient>,
 }
 
 #[async_trait]
@@ -189,67 +193,95 @@ impl foreign::ClowderClient for ClowderCl {
             .await?;
         Ok(())
     }
+
+    async fn sign_swap_commitment_request(
+        &self,
+        payload: wire_swap::SwapCommitmentRequest,
+    ) -> Result<(String, secp256k1::schnorr::Signature)> {
+        let (b64, message) = bcr_common::core::signature::serialize_borsh_msg_b64(&payload)?;
+        let signature = self.signatory.sign_schnorr_hash(message.as_ref()).await?;
+        Ok((b64, signature))
+    }
 }
 
 pub struct MintClient {
-    cl: bcr_common::client::mint::Client,
-    clwdr: Arc<ClowderClient>,
     my_pk: secp256k1::PublicKey,
+    foreign_cl: bcr_common::client::mint::Client,
+    foreign_clwdr: Arc<ClowderClient>,
     foreign_pk: secp256k1::PublicKey,
 }
 
 #[async_trait]
 impl ForeignClient for MintClient {
-    async fn swap(
+    async fn prepare_swap_commitment_request(
         &self,
         inputs: Vec<cashu::Proof>,
         outputs: Vec<cashu::BlindedMessage>,
         now: TStamp,
-    ) -> Result<Vec<cashu::BlindSignature>> {
+    ) -> Result<wire_swap::SwapCommitmentRequest> {
         let fps = inputs
             .iter()
             .cloned()
             .map(wire_keys::ProofFingerprint::try_from)
             .collect::<std::result::Result<Vec<_>, _>>()?;
         let expiry = now + chrono::Duration::minutes(1);
-        // Acquire an attestation from the local Clowder node (assumed Beta of
-        // the foreign Alpha) so it can be bound into the commitment.
         let attestation = self
-            .clwdr
+            .foreign_clwdr
             .post_attest_issuance(&wire_attestation::IssuanceAttestationRequest {
                 alpha_id: self.foreign_pk,
                 inputs: fps.clone(),
             })
             .await?;
-        let (_, commitment) = self
-            .cl
-            .commit_swap(
-                fps,
-                outputs.clone(),
-                expiry.timestamp() as u64,
-                self.my_pk,
-                self.foreign_pk,
-                attestation,
-            )
+        let request = bcr_common::client::mint::Client::prepare_swap_commitment_request(
+            fps,
+            outputs,
+            expiry.timestamp() as u64,
+            self.my_pk,
+            attestation,
+        );
+        Ok(request)
+    }
+
+    async fn commit_swap_with_signature(
+        &self,
+        payload: String,
+        signature: secp256k1::schnorr::Signature,
+    ) -> Result<(String, secp256k1::schnorr::Signature)> {
+        let (content, signature) = self
+            .foreign_cl
+            .commit_swap_with_signature(payload, signature, self.my_pk)
             .await?;
-        let signatures = self.cl.swap(inputs, outputs, commitment).await?;
+        Ok((content, signature))
+    }
+
+    async fn swap(
+        &self,
+        inputs: Vec<cashu::Proof>,
+        outputs: Vec<cashu::BlindedMessage>,
+        commitment: secp256k1::schnorr::Signature,
+    ) -> Result<Vec<cashu::BlindSignature>> {
+        let signatures = self.foreign_cl.swap(inputs, outputs, commitment).await?;
         Ok(signatures)
     }
 
     async fn check_state(&self, ys: Vec<cashu::PublicKey>) -> Result<Vec<cashu::ProofState>> {
-        let states = self.cl.check_state(ys).await?;
+        let states = self.foreign_cl.check_state(ys).await?;
         Ok(states)
     }
 
     async fn get_keyset(&self, kid: cashu::Id) -> Result<cashu::KeySet> {
-        let keys = self.cl.keys(kid).await?;
+        let keys = self.foreign_cl.keys(kid).await?;
         Ok(keys)
     }
 
     async fn list_keyset_infos(&self) -> Result<HashMap<cashu::Id, cashu::KeySetInfo>> {
-        let kinfos = self.cl.list_keyset_info(Default::default()).await?;
+        let kinfos = self.foreign_cl.list_keyset_info(Default::default()).await?;
         let map = HashMap::from_iter(kinfos.into_iter().map(|kinfo| (kinfo.id, kinfo)));
         Ok(map)
+    }
+
+    fn get_foreign_pk(&self) -> secp256k1::PublicKey {
+        self.foreign_pk
     }
 }
 
@@ -264,10 +296,10 @@ impl foreign::MintClientFactory for MintClientFactory {
         mint_url: reqwest::Url,
         mint_pk: secp256k1::PublicKey,
     ) -> Result<Box<dyn ForeignClient>> {
-        let cl = bcr_common::client::mint::Client::new(mint_url);
+        let foreign_cl = bcr_common::client::mint::Client::new(mint_url);
         Ok(Box::new(MintClient {
-            cl,
-            clwdr: self.clwdr.clone(),
+            foreign_cl,
+            foreign_clwdr: self.clwdr.clone(),
             my_pk: self.my_pk,
             foreign_pk: mint_pk,
         }))

--- a/crates/bcr-wdc-treasury-service/src/foreign/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/mod.rs
@@ -1,9 +1,13 @@
 // ----- standard library imports
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 // ----- extra library imports
 use async_trait::async_trait;
-use bcr_common::{cashu, wire::keys as wire_keys};
-pub use bitcoin::hashes::sha256::Hash as Sha256Hash;
+use bcr_common::{
+    cashu,
+    wire::{keys as wire_keys, swap as wire_swap},
+};
+pub use bitcoin::{hashes::sha256::Hash as Sha256Hash, secp256k1};
+use tracing::warn;
 // ----- local modules
 pub mod clients;
 mod proof;
@@ -110,21 +114,40 @@ pub trait ClowderClient: Send + Sync {
         wallet_pk: cashu::PublicKey,
         outputs: Vec<cashu::Proof>,
     ) -> Result<()>;
+    async fn sign_swap_commitment_request(
+        &self,
+        payload: wire_swap::SwapCommitmentRequest,
+    ) -> Result<(String, secp256k1::schnorr::Signature)>;
 }
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait ForeignClient: Send + Sync {
-    async fn swap(
+    async fn prepare_swap_commitment_request(
         &self,
         inputs: Vec<cashu::Proof>,
         outputs: Vec<cashu::BlindedMessage>,
         now: TStamp,
+    ) -> Result<wire_swap::SwapCommitmentRequest>;
+
+    async fn commit_swap_with_signature(
+        &self,
+        payload: String,
+        signature: secp256k1::schnorr::Signature,
+    ) -> Result<(String, secp256k1::schnorr::Signature)>;
+
+    async fn swap(
+        &self,
+        inputs: Vec<cashu::Proof>,
+        outputs: Vec<cashu::BlindedMessage>,
+        commitment: secp256k1::schnorr::Signature,
     ) -> Result<Vec<cashu::BlindSignature>>;
 
     async fn check_state(&self, ys: Vec<cashu::PublicKey>) -> Result<Vec<cashu::ProofState>>;
     async fn get_keyset(&self, kid: cashu::Id) -> Result<cashu::KeySet>;
     async fn list_keyset_infos(&self) -> Result<HashMap<cashu::Id, cashu::KeySetInfo>>;
+
+    fn get_foreign_pk(&self) -> secp256k1::PublicKey;
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -157,4 +180,71 @@ fn fingerprints_vec_to_map(
         map.entry(fp.keyset_id).or_default().push((fp, hash));
     }
     map
+}
+
+async fn signed_swap_with_foreign(
+    foreign_proofs: Vec<cashu::Proof>,
+    clowder: &dyn ClowderClient,
+    foreign_cl: &dyn ForeignClient,
+    now: TStamp,
+) -> Result<Vec<cashu::Proof>> {
+    let foreign_kids: HashSet<cashu::Id> = foreign_proofs.iter().map(|p| p.keyset_id).collect();
+    let foreign_id = foreign_cl.get_foreign_pk();
+    let mut foreign_kinfos = HashMap::new();
+    for foreign_kid in foreign_kids {
+        let kinfo = clowder.get_keyset_info(&foreign_id, &foreign_kid).await?;
+        foreign_kinfos.insert(foreign_kid, kinfo);
+    }
+    // prepare the swap plan
+    let swap_plan =
+        bcr_common::core::swap::wallet::prepare_signed_swap(&foreign_proofs, &foreign_kinfos)?;
+    let mut foreign_keysets_map: HashMap<cashu::Id, cashu::KeySet> = HashMap::new();
+    let mut premint_secrets: Vec<cashu::PreMintSecrets> = Vec::with_capacity(swap_plan.len());
+    for (kid, amount) in swap_plan {
+        let keyset = clowder.get_keyset(&foreign_id, &kid).await?;
+        let premint = cashu::PreMintSecrets::random(
+            kid,
+            amount,
+            &cashu::amount::SplitTarget::None,
+            &bcr_wdc_utils::keys::to_fee_and_amounts(&keyset),
+        )?;
+        premint_secrets.push(premint);
+        foreign_keysets_map.insert(kid, keyset);
+    }
+    let blinds: Vec<cashu::BlindedMessage> = premint_secrets
+        .iter()
+        .flat_map(|p| p.blinded_messages())
+        .collect();
+    let premints: Vec<cashu::PreMint> = premint_secrets
+        .into_iter()
+        .flat_map(|p| p.secrets)
+        .collect();
+    // ready to swap using the signed commitment protocol
+    let request = foreign_cl
+        .prepare_swap_commitment_request(foreign_proofs.clone(), blinds.clone(), now)
+        .await?;
+    // sign the request with our clowder signatory service
+    let (payload, signature) = clowder.sign_swap_commitment_request(request).await?;
+    let (_foreign_payload, foreign_commitment) = foreign_cl
+        .commit_swap_with_signature(payload, signature)
+        .await?;
+    let signatures = foreign_cl
+        .swap(foreign_proofs, blinds, foreign_commitment)
+        .await?;
+    // unblind the signatures to get new proofs
+    let mut new_proofs = Vec::with_capacity(signatures.len());
+    for (signature, premint) in signatures.into_iter().zip(premints) {
+        let keyset = foreign_keysets_map
+            .get(&signature.keyset_id)
+            .expect("keyset_id must be here");
+        let amount = premint.amount;
+        let Ok(new_p) =
+            bcr_common::core::signature::unblind_ecash_signature(keyset, premint, signature)
+        else {
+            warn!("unblind_ecash_signature failed, lost {amount}");
+            continue;
+        };
+        new_proofs.push(new_p);
+    }
+    Ok(new_proofs)
 }

--- a/crates/bcr-wdc-treasury-service/src/foreign/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/service.rs
@@ -1,7 +1,11 @@
 // ----- standard library imports
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 // ----- extra library imports
-use bcr_common::{cashu, core, wire::keys as wire_keys};
+use bcr_common::{
+    cashu::{self, ProofsMethods},
+    core,
+    wire::keys as wire_keys,
+};
 use bitcoin::{
     hashes::{sha256::Hash as Sha256Hash, Hash},
     hex::FromHex,
@@ -10,10 +14,9 @@ use bitcoin::{
 // ----- local imports
 use crate::{
     error::{Error, Result},
-    foreign::proof,
     foreign::{
-        fingerprints_vec_to_map, to_mint_proofs_map, ClowderClient, KeysClient, MintClientFactory,
-        OfflineRepository, OnlineRepository,
+        fingerprints_vec_to_map, proof, signed_swap_with_foreign, to_mint_proofs_map,
+        ClowderClient, KeysClient, MintClientFactory, OfflineRepository, OnlineRepository,
     },
     TStamp,
 };
@@ -207,41 +210,16 @@ async fn try_online_htlc(
     for (mint_id, mut f_proofs) in foreign_proofs {
         let mint_url = clowder.get_mint_url_from_pk(&mint_id).await?;
         let foreign_client = factory.make_client(mint_url, mint_id).await?;
-        let kinfos = foreign_client.list_keyset_infos().await?;
-        let swap_plan = core::swap::wallet::prepare_swap(&f_proofs, &kinfos)?;
-        let mut outputs = Vec::with_capacity(f_proofs.len());
-        let mut secrets = Vec::with_capacity(f_proofs.len());
-        let mut keysets = HashMap::new();
-        for (kid, amount) in swap_plan {
-            let keyset = foreign_client.get_keyset(kid).await?;
-            let premint = cashu::PreMintSecrets::random(
-                kid,
-                amount,
-                &cashu::amount::SplitTarget::None,
-                &bcr_wdc_utils::keys::to_fee_and_amounts(&keyset),
-            )?;
-            outputs.extend(premint.blinded_messages());
-            secrets.extend(premint.secrets);
-            keysets.insert(keyset.id, keyset);
-        }
         let mut f_fingerprints = Vec::with_capacity(f_proofs.len());
         for proof in &mut f_proofs {
             proof.add_preimage(preimage.to_string());
             f_fingerprints.push(proof.y()?);
         }
         f_proofs = clowder.sign_p2pk_proofs(&f_proofs).await?;
-        let signatures = foreign_client.swap(f_proofs, outputs, now).await?;
-        let mut proofs = Vec::with_capacity(signatures.len());
-        let mut total = cashu::Amount::ZERO;
-        for (signature, secret) in signatures.into_iter().zip(secrets.iter()) {
-            let keyset = keysets.get(&signature.keyset_id).unwrap();
-            let proof =
-                core::signature::unblind_ecash_signature(keyset, secret.clone(), signature)?;
-            total += proof.amount;
-            proofs.push(proof);
-        }
-
-        repo.store(mint_id, proofs).await?;
+        let new_proofs =
+            signed_swap_with_foreign(f_proofs, clowder, foreign_client.as_ref(), now).await?;
+        let total = new_proofs.total_amount().unwrap_or_default();
+        repo.store(mint_id, new_proofs).await?;
         repo.remove_htlcs(&f_fingerprints).await?;
         gran_total += total;
     }
@@ -288,7 +266,14 @@ async fn try_offline_htlc_swap(
 mod tests {
 
     use super::*;
-    use bcr_common::{core, core_tests};
+    use bcr_common::{
+        core, core_tests,
+        wire::{
+            attestation::{self as wire_attestation, IssuanceAttestation},
+            swap as wire_swap,
+        },
+    };
+    use bcr_wdc_utils::signatures::test_utils as signature_tests;
     use bitcoin::hex::prelude::*;
     use mockall::predicate::*;
 
@@ -602,41 +587,73 @@ mod tests {
                     .for_each(|p| p.sign_p2pk(myself_sk.clone()).unwrap());
                 Ok(proofs)
             });
-        let foreign_kid = foreign_keyset.id;
-        let cloned_keyset = foreign_keyset.clone();
+        ///// expectations for signed swap with foreign
+        let mut foreign_client_mock = crate::foreign::MockForeignClient::new();
+        foreign_client_mock
+            .expect_get_foreign_pk()
+            .times(1)
+            .returning(move || foreign_kp.public_key());
+        clowder
+            .expect_get_keyset_info()
+            .with(eq(foreign_kp.public_key()), eq(foreign_keyset.id))
+            .times(1)
+            .returning(move |_, _| Ok(cashu::KeySetInfo::from(foreign_kinfo.clone())));
+        let cloned_keyset = bcr_common::core::keys::to_keyset(&foreign_keyset, None);
+        clowder
+            .expect_get_keyset()
+            .with(eq(foreign_kp.public_key()), eq(foreign_keyset.id))
+            .times(1)
+            .returning(move |_, _| Ok(cloned_keyset.clone()));
+        foreign_client_mock
+            .expect_prepare_swap_commitment_request()
+            .times(1)
+            .returning(move |inp, outp, now| {
+                let fps = inp
+                    .iter()
+                    .map(|p| wire_keys::ProofFingerprint::try_from(p.clone()).unwrap())
+                    .collect::<Vec<_>>();
+                let attested = wire_attestation::AttestedFingerprints {
+                    inputs: fps.clone(),
+                    attestation: IssuanceAttestation {
+                        beta_id: core::generate_random_keypair().public_key(),
+                        fp_digest: Default::default(),
+                        coords_mac: Default::default(),
+                        signature: signature_tests::random_schnorr_signature(),
+                    },
+                };
+                Ok(wire_swap::SwapCommitmentRequest {
+                    inputs: attested,
+                    outputs: outp,
+                    expiry: now.timestamp() as u64,
+                    wallet_key: core::generate_random_keypair().public_key(),
+                })
+            });
+        clowder
+            .expect_sign_swap_commitment_request()
+            .times(1)
+            .returning(|_| Ok((String::new(), signature_tests::random_schnorr_signature())));
+        foreign_client_mock
+            .expect_commit_swap_with_signature()
+            .times(1)
+            .returning(|_, _| Ok((String::new(), signature_tests::random_schnorr_signature())));
+        foreign_client_mock
+            .expect_swap()
+            .times(1)
+            .returning(move |inputs, outputs, _| {
+                let mut signatures = Vec::with_capacity(inputs.len());
+                for blind in outputs {
+                    let signature =
+                        bcr_common::core::signature::sign_ecash(&foreign_keyset, &blind).unwrap();
+                    signatures.push(signature);
+                }
+                Ok(signatures)
+            });
+
         factory
             .expect_make_client()
             .with(eq(foreign_url.clone()), always())
             .times(1)
-            .returning(move |_, _| {
-                let cloned_keyset = cloned_keyset.clone();
-                let mut foreign_client = crate::foreign::MockForeignClient::new();
-                let keyset = bcr_wdc_utils::keys::to_keyset(&cloned_keyset, None);
-                let cloned_info = cashu::KeySetInfo::from(foreign_kinfo.clone());
-                foreign_client
-                    .expect_list_keyset_infos()
-                    .times(1)
-                    .returning(move || Ok(HashMap::from([(cloned_info.id, cloned_info.clone())])));
-                foreign_client
-                    .expect_get_keyset()
-                    .with(eq(foreign_kid))
-                    .times(1)
-                    .returning(move |_| Ok(keyset.clone()));
-                foreign_client
-                    .expect_swap()
-                    .times(1)
-                    .returning(move |inputs, outputs, _| {
-                        let mut signatures = Vec::with_capacity(inputs.len());
-                        for blind in outputs {
-                            let signature =
-                                bcr_common::core::signature::sign_ecash(&cloned_keyset, &blind)
-                                    .unwrap();
-                            signatures.push(signature);
-                        }
-                        Ok(signatures)
-                    });
-                Ok(Box::new(foreign_client))
-            });
+            .return_once(move |_, _| Ok(Box::new(foreign_client_mock)));
         onlinerepo.expect_store().times(1).returning(|_, _| Ok(()));
         let foreign_y = foreign_proof.y().unwrap();
         onlinerepo

--- a/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
+++ b/crates/bcr-wdc-treasury-service/src/foreign/settle.rs
@@ -1,8 +1,5 @@
 // ----- standard library imports
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::sync::Arc;
 // ----- extra library imports
 use anyhow::Result as AnyResult;
 use async_trait::async_trait;
@@ -10,7 +7,9 @@ use bcr_common::cashu::{self, ProofsMethods};
 use bcr_wdc_utils::{routine::Routine, TStamp};
 use tracing::{debug, error, info, warn};
 // ----- local imports
-use crate::foreign::{ClowderClient, MintClientFactory, OfflineRepository, OnlineRepository};
+use crate::foreign::{
+    signed_swap_with_foreign, ClowderClient, MintClientFactory, OfflineRepository, OnlineRepository,
+};
 
 // ----- end imports
 
@@ -21,17 +20,6 @@ pub struct Handler {
     pub mint_factory: Arc<dyn MintClientFactory>,
 }
 
-macro_rules! try_or_warn {
-    ($expr:expr) => {
-        match $expr {
-            Ok(result) => result,
-            Err(e) => {
-                warn!("{} failed: {}, retry later", stringify!($expr), e);
-                continue;
-            }
-        }
-    };
-}
 macro_rules! async_try_or_warn {
     ($expr:expr) => {
         match $expr.await {
@@ -56,62 +44,21 @@ impl Routine for Handler {
                 debug!("{} still offline", mint_url);
                 continue;
             }
-            let client =
-                async_try_or_warn!(self.mint_factory.make_client(mint_url.clone(), mint_id));
+            // foreign mint is back online, proceed to settle
+            // load the proofs from the repository
             let foreign_proofs = async_try_or_warn!(self.offline.load_proofs(mint_id));
-            let foreign_total = try_or_warn!(foreign_proofs.total_amount());
             let foreign_ys: Vec<cashu::PublicKey> = foreign_proofs
                 .iter()
                 .map(|p| p.y().expect("Proof::y(): impossible!!"))
                 .collect();
-            let foreign_kids: HashSet<cashu::Id> =
-                foreign_proofs.iter().map(|p| p.keyset_id).collect();
-            let mut foreign_kinfos = HashMap::new();
-            for foreign_kid in foreign_kids {
-                let kinfo =
-                    async_try_or_warn!(self.clowder.get_keyset_info(&mint_id, &foreign_kid));
-                foreign_kinfos.insert(foreign_kid, kinfo);
-            }
-            let swap_plan = try_or_warn!(bcr_common::core::swap::wallet::prepare_swap(
-                &foreign_proofs,
-                &foreign_kinfos,
+            let foreign_client =
+                async_try_or_warn!(self.mint_factory.make_client(mint_url.clone(), mint_id));
+            let new_proofs = async_try_or_warn!(signed_swap_with_foreign(
+                foreign_proofs,
+                self.clowder.as_ref(),
+                foreign_client.as_ref(),
+                now
             ));
-            let mut foreign_keysets_map: HashMap<cashu::Id, cashu::KeySet> = HashMap::new();
-            let mut premint_secrets: Vec<cashu::PreMintSecrets> =
-                Vec::with_capacity(swap_plan.len());
-            for (kid, amount) in swap_plan {
-                let keyset = async_try_or_warn!(self.clowder.get_keyset(&mint_id, &kid));
-                let Ok(premint) = cashu::PreMintSecrets::random(
-                    kid,
-                    amount,
-                    &cashu::amount::SplitTarget::None,
-                    &bcr_wdc_utils::keys::to_fee_and_amounts(&keyset),
-                ) else {
-                    warn!("PreMintSecrets::random failed {mint_url}, retry later");
-                    continue;
-                };
-                premint_secrets.push(premint);
-                foreign_keysets_map.insert(kid, keyset);
-            }
-            let blinds: Vec<cashu::BlindedMessage> = premint_secrets
-                .iter()
-                .flat_map(|p| p.blinded_messages())
-                .collect();
-            let premints: Vec<cashu::PreMint> = premint_secrets
-                .into_iter()
-                .flat_map(|p| p.secrets)
-                .collect();
-            let signatures = async_try_or_warn!(client.swap(foreign_proofs, blinds, now));
-            let mut new_proofs = Vec::with_capacity(signatures.len());
-            for (signature, premint) in signatures.into_iter().zip(premints) {
-                let keyset = foreign_keysets_map
-                    .get(&signature.keyset_id)
-                    .expect("keyset_id must be here");
-                let new_p = try_or_warn!(bcr_common::core::signature::unblind_ecash_signature(
-                    keyset, premint, signature
-                ));
-                new_proofs.push(new_p);
-            }
             loop {
                 match self.online.store(mint_id, new_proofs.clone()).await {
                     Ok(_) => break,
@@ -124,7 +71,8 @@ impl Routine for Handler {
             if self.offline.remove_proofs(&foreign_ys).await.is_err() {
                 warn!("remove_proofs failed {mint_url}");
             }
-            info!("Settled {foreign_total} from mint {mint_url}");
+            let total = new_proofs.total_amount().unwrap_or_default();
+            info!("Settled {total} from mint {mint_url}");
         }
         Ok(None)
     }

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use bcr_common::{
     cashu,
-    client::clowder::ClowderNatsClient,
+    client::clowder::{ClowderNatsClient, SignatoryNatsClient},
     client::{
         admin::clowder::Client as ClowderClient, core::Client as CoreClient,
         ebill::Client as EbClient, treasury as cl_treasury, Url as ClientUrl,
@@ -96,10 +96,13 @@ pub async fn init_app(cfg: AppConfig) -> (AppController, Vec<routine::RoutineHan
     let core_client = Arc::new(CoreClient::new(core_url));
     let ebill_client = EbClient::new(ebill_url);
     let clowder_client = Arc::new(ClowderClient::new(clowder_rest_url));
-    let nats_cl = ClowderNatsClient::new(clowder_nats_url)
+    let nats_cl = ClowderNatsClient::new(clowder_nats_url.clone())
         .await
         .expect("Failed to create clowder nats client");
     let clowder_nats_client = Arc::new(nats_cl);
+    let signer_cl = SignatoryNatsClient::new(clowder_nats_url, None)
+        .await
+        .expect("Failed to create signatory nats client");
 
     let info = clowder_client
         .get_info()
@@ -173,6 +176,7 @@ pub async fn init_app(cfg: AppConfig) -> (AppController, Vec<routine::RoutineHan
     let clowder = Arc::new(foreign::clients::ClowderCl {
         rest: clowder_client.clone(),
         stream: clowder_nats_client.clone(),
+        signatory: Box::new(signer_cl),
     });
     let factory = Arc::new(foreign::clients::MintClientFactory {
         my_pk,

--- a/crates/bcr-wdc-treasury-service/src/onchain/clients.rs
+++ b/crates/bcr-wdc-treasury-service/src/onchain/clients.rs
@@ -180,7 +180,7 @@ impl ClowderClient for ClowderCl {
             wallet_key: msg.wallet_key,
         };
         let response = self.nats.mint_quote_onchain(request).await?;
-        let content = signature::serialize_borsh_msg_b64(msg)?;
+        let (content, _) = signature::serialize_borsh_msg_b64(msg)?;
         Ok((content, response.commitment))
     }
 
@@ -200,7 +200,7 @@ impl ClowderClient for ClowderCl {
             wallet_key: msg.wallet_key,
         };
         let response = self.nats.melt_quote_onchain(request).await?;
-        let content = signature::serialize_borsh_msg_b64(msg)?;
+        let (content, _) = signature::serialize_borsh_msg_b64(msg)?;
         Ok((content, response.commitment))
     }
 


### PR DESCRIPTION

in foreign service, when doing any swap in the intermint exchange we
want to use signed commitment swap so we don't pay any extra fees