### PR TITLE
[bcr-wdc-treasury-service] migrate EbillMintRequest/ EbillMintResponse

### DIFF
--- a/crates/bcr-wdc-treasury-service/src/ebill/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/ebill/service.rs
@@ -1,6 +1,8 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_common::{cashu, client::clowder::ClowderClientError, core::BillId, wire::mint as wire_mint};
+use bcr_common::{
+    cashu, client::clowder::ClowderClientError, core::BillId, wire::mint as wire_mint,
+};
 use uuid::Uuid;
 // ----- local imports
 use crate::{

--- a/crates/bcr-wdc-treasury-service/src/ebill/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/ebill/service.rs
@@ -1,6 +1,6 @@
 // ----- standard library imports
 // ----- extra library imports
-use bcr_common::{cashu, client::clowder::ClowderClientError, core::BillId};
+use bcr_common::{cashu, client::clowder::ClowderClientError, core::BillId, wire::mint as wire_mint};
 use uuid::Uuid;
 // ----- local imports
 use crate::{
@@ -82,11 +82,11 @@ impl Service {
         self.repo.mint_list(kid).await
     }
 
-    pub async fn mint(&self, request: cashu::MintRequest<Uuid>) -> Result<cashu::MintResponse> {
+    pub async fn mint(
+        &self,
+        request: wire_mint::EbillMintRequest,
+    ) -> Result<wire_mint::EbillMintResponse> {
         // basic checks
-        if request.signature.is_none() {
-            return Err(Error::InvalidInput(String::from("signature missing")));
-        }
         bcr_wdc_utils::signatures::basic_blinds_checks(&request.outputs)
             .map_err(|e| Error::InvalidInput(e.to_string()))?;
         let output_amount = request
@@ -94,8 +94,8 @@ impl Service {
             .iter()
             .fold(cashu::Amount::ZERO, |acc, blind| acc + blind.amount);
         let operation = self.repo.mint_load(request.quote).await?;
-        let signature_verification = request.verify_signature(operation.pub_key);
-        if signature_verification.is_err() {
+        let signature_is_ok = request.verify_signature(&operation.pub_key);
+        if !signature_is_ok {
             return Err(Error::InvalidInput(String::from("invalid signature")));
         }
         let same_kid = request
@@ -144,7 +144,7 @@ impl Service {
                 Err(e) => return Err(e),
             }
         };
-        Ok(cashu::MintResponse { signatures })
+        Ok(wire_mint::EbillMintResponse { signatures })
     }
 
     pub async fn request_to_pay_ebill(
@@ -610,12 +610,7 @@ mod tests {
         };
         let outputs = signatures_test::generate_blinds(kid, &amounts);
         let blinds = outputs.iter().map(|(blind, _, _)| blind.clone()).collect();
-        let mut request = cashu::MintRequest {
-            quote: uid,
-            outputs: blinds,
-            signature: None,
-        };
-        request.sign(kp.secret_key().into()).unwrap();
+        let request = wire_mint::EbillMintRequest::new(uid, blinds, &kp);
         let response = service.mint(request).await.unwrap();
         assert_eq!(response.signatures.len(), amounts.len());
     }
@@ -641,12 +636,7 @@ mod tests {
         };
         let outputs = signatures_test::generate_blinds(kid, &amounts);
         let blinds = outputs.iter().map(|(blind, _, _)| blind.clone()).collect();
-        let mut request = cashu::MintRequest {
-            quote: uid,
-            outputs: blinds,
-            signature: None,
-        };
-        request.sign(kp.secret_key().into()).unwrap();
+        let request = wire_mint::EbillMintRequest::new(uid, blinds, &kp);
         let err = service.mint(request).await.unwrap_err();
         assert!(matches!(err, Error::InvalidInput(_)));
     }

--- a/crates/bcr-wdc-treasury-service/src/ebill/service.rs
+++ b/crates/bcr-wdc-treasury-service/src/ebill/service.rs
@@ -651,7 +651,7 @@ mod tests {
 
     fn mint_retry_service(
         clowder_cl: MockClowderClient,
-    ) -> (Service, cashu::MintRequest<Uuid>, usize) {
+    ) -> (Service, wire_mint::EbillMintRequest, usize) {
         let mut mintop_repo = MockRepository::new();
         let mut core_cl = MockWildcatClient::new();
         let (kinfo, keyset) = bcr_common::core_tests::generate_random_ecash_keyset();
@@ -694,12 +694,7 @@ mod tests {
         };
         let outputs = signatures_test::generate_blinds(kid, &amounts);
         let blinds = outputs.iter().map(|(blind, _, _)| blind.clone()).collect();
-        let mut request = cashu::MintRequest {
-            quote: uid,
-            outputs: blinds,
-            signature: None,
-        };
-        request.sign(kp.secret_key().into()).unwrap();
+        let request = wire_mint::EbillMintRequest::new(uid, blinds, &kp);
         (service, request, amounts.len())
     }
 

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -13,7 +13,6 @@ use bcr_common::{
         admin::clowder::Client as ClowderClient, core::Client as CoreClient,
         ebill::Client as EbClient, treasury as cl_treasury,
     },
-    wire::mint as wire_mint,
 };
 use bcr_wdc_utils::{nut19, routine};
 // ----- local modules
@@ -27,7 +26,6 @@ pub mod persistence;
 pub mod vault;
 mod web;
 // ----- local imports
-use crate::error::{Error, Result};
 
 // ----- end imports
 

--- a/crates/bcr-wdc-treasury-service/src/lib.rs
+++ b/crates/bcr-wdc-treasury-service/src/lib.rs
@@ -13,6 +13,7 @@ use bcr_common::{
         admin::clowder::Client as ClowderClient, core::Client as CoreClient,
         ebill::Client as EbClient, treasury as cl_treasury,
     },
+    wire::mint as wire_mint,
 };
 use bcr_wdc_utils::{nut19, routine};
 // ----- local modules
@@ -26,6 +27,7 @@ pub mod persistence;
 pub mod vault;
 mod web;
 // ----- local imports
+use crate::error::{Error, Result};
 
 // ----- end imports
 

--- a/crates/bcr-wdc-treasury-service/src/persistence/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/mod.rs
@@ -70,7 +70,6 @@ mod tests {
     async fn foreign_online_store_search_htlc(db: impl foreign::OnlineRepository) {
         let hash = bitcoin::hashes::sha256::Hash::const_hash(b"online-htlc");
         let first_mint = core::generate_random_keypair().public_key();
-        let _second_mint = core::generate_random_keypair().public_key();
         let proofs = generate_test_proofs(2);
         db.store_htlc(first_mint, hash, proofs.clone())
             .await

--- a/crates/bcr-wdc-treasury-service/src/persistence/mod.rs
+++ b/crates/bcr-wdc-treasury-service/src/persistence/mod.rs
@@ -14,7 +14,6 @@ mod tests {
     use crate::{ebill, error::Error, foreign, onchain, vault};
     use bcr_common::{cashu, core, core_tests};
     use bcr_wdc_utils::signatures::test_utils as signature_tests;
-    use bitcoin::hashes::Hash;
     use std::str::FromStr;
     use uuid::Uuid;
 

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -117,8 +117,8 @@ pub async fn mint_onchain(
 pub async fn mint_ebill(
     State(ctrl): State<Arc<ebill::Service>>,
     State(cache): State<Arc<dyn nut19::Cache>>,
-    Json(request): Json<cashu::MintRequest<Uuid>>,
-) -> Result<Json<cashu::MintResponse>> {
+    Json(request): Json<wire_mint::EbillMintRequest>,
+) -> Result<Json<wire_mint::EbillMintResponse>> {
     let now = chrono::Utc::now();
     let key = nut19::ebill::mint::request_to_key(request.clone());
     if let Some(blob) = cache.load(key).await {

--- a/crates/bcr-wdc-treasury-service/src/web.rs
+++ b/crates/bcr-wdc-treasury-service/src/web.rs
@@ -10,7 +10,6 @@ use bcr_common::{
 };
 use bcr_wdc_utils::nut19;
 use bitcoin::base64::prelude::*;
-use uuid::Uuid;
 // ----- local imports
 use crate::{ebill, error::Result, foreign, onchain, vault, AppController};
 

--- a/crates/bcr-wdc-utils/src/nut19.rs
+++ b/crates/bcr-wdc-utils/src/nut19.rs
@@ -190,25 +190,22 @@ pub mod onchain {
 pub mod ebill {
     pub mod mint {
         use super::super::*;
-        use bcr_common::cashu;
+        use bcr_common::wire::mint as wire_mint;
 
-        pub fn request_to_key<U>(mut request: cashu::MintRequest<U>) -> Sha1Hash
-        where
-            U: serde::ser::Serialize + serde::de::DeserializeOwned,
-        {
+        pub fn request_to_key(mut request: wire_mint::EbillMintRequest) -> Sha1Hash {
             request.outputs.sort_by_key(|output| output.blinded_secret);
             let mut bytes = Vec::new();
             ciborium::into_writer(&request, &mut bytes).unwrap();
             Sha1Hash::hash(&bytes)
         }
 
-        pub fn blob_to_response(blob: ciborium::Value) -> cashu::MintResponse {
+        pub fn blob_to_response(blob: ciborium::Value) -> wire_mint::EbillMintResponse {
             let mut bytes = Vec::new();
             ciborium::into_writer(&blob, &mut bytes).unwrap();
             ciborium::from_reader(bytes.as_slice()).unwrap()
         }
 
-        pub fn response_to_blob(response: &cashu::MintResponse) -> ciborium::Value {
+        pub fn response_to_blob(response: &wire_mint::EbillMintResponse) -> ciborium::Value {
             let mut bytes = Vec::new();
             ciborium::into_writer(response, &mut bytes).unwrap();
             ciborium::from_reader(bytes.as_slice()).unwrap()


### PR DESCRIPTION
PR is not building as [bcr-common#168](https://github.com/BitcreditProtocol/bcr-common/pull/168) got merged before [bcr-common#167](https://github.com/BitcreditProtocol/bcr-common/pull/167) 

once #914 gets merged, this PR needs to be rebased